### PR TITLE
[FLINK-17279][travis] enable build scans

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jdk:
   - openjdk11
 
 script:
-  - ./gradlew build --stacktrace
+  - ./gradlew build --scan --stacktrace
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,24 @@
+plugins {
+    id "com.gradle.enterprise" version "3.2.1"
+}
+
 rootProject.name = 'flink-training'
 include 'common'
 include 'ride-cleansing'
 include 'rides-and-fares'
 include 'hourly-tips'
 include 'long-ride-alerts'
+
+// CI=true, TRAVIS=true, CONTINUOUS_INTEGRATION=true set automatically during Travis execution
+// see https://docs.travis-ci.com/user/environment-variables#default-environment-variables
+def isCIBuild = ['CI', 'TRAVIS', 'CONTINUOUS_INTEGRATION'].every { System.getenv(it) == 'true' }
+if (isCIBuild) {
+    gradleEnterprise {
+        buildScan {
+            // Build Scan enabled and TOS accepted for Travis build. This does not apply to builds on
+            // non-Travis machines. Developers need to separately enable and accept TOS to use build scans.
+            termsOfServiceUrl = 'https://gradle.com/terms-of-service'
+            termsOfServiceAgree = 'yes'
+        }
+    }
+}


### PR DESCRIPTION
This builds on #4 and enables Gradle build scans [1] for quick analysis into what happened if a CI build failed. It uploads a report with detailed info to [1].

See this for an example: https://gradle.com/s/g3tdhu47lntoc

I integrated this similarly to how the Apache Beam folks did it in https://github.com/apache/beam/blob/master/build.gradle#L44

[1] https://scans.gradle.com/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apache/flink-training/5)
<!-- Reviewable:end -->
