### PR TITLE
[FLINK-18178][build] fix Eclipse import not using flinkShadowJar dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,9 +10,15 @@
 # Debugger
 .attach_*
 
+# Eclipse
+.project
+.settings
+.classpath
+bin/
+
 # Gradle build process files
-**/.gradle/**/*
-**/build/**/*
+/.gradle/
+build/
 **/.gradletasknamecache
 
 # IntelliJ

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ subprojects {
     }
     apply plugin: 'com.github.johnrengelman.shadow'
     apply plugin: 'checkstyle'
+    apply plugin: 'eclipse'
 
     // artifact properties
     group = 'org.apache.flink'
@@ -111,6 +112,12 @@ subprojects {
         test.runtimeClasspath += configurations.flinkShadowJar
 
         javadoc.classpath += configurations.flinkShadowJar
+    }
+
+    eclipse {
+        classpath {
+            plusConfigurations += [configurations.flinkShadowJar]
+        }
     }
 
     if (plugins.findPlugin('application')) {


### PR DESCRIPTION
This PR makes the training repo work out of the box in Eclipse:

- add several Eclipse build files to `.gitignore`
- add an Eclipse gradle configuration that teaches the import to work with our `flinkShadowJar`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apache/flink-training/10)
<!-- Reviewable:end -->
