### PR TITLE
[FLINK-18499] Update for Flink 1.11: don’t use deprecated forms of keyBy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,12 +31,12 @@ subprojects {
 
     // artifact properties
     group = 'org.apache.flink'
-    version = '1.10-SNAPSHOT'
+    version = '1.11-SNAPSHOT'
     description = """Flink Training Exercises"""
 
     ext {
         javaVersion = '1.8'
-        flinkVersion = '1.10.0'
+        flinkVersion = '1.11.0'
         scalaBinaryVersion = '2.12'
         slf4jVersion = '1.7.15'
         log4jVersion = '1.2.17'

--- a/common/src/main/java/org/apache/flink/training/examples/ridecount/RideCountExample.java
+++ b/common/src/main/java/org/apache/flink/training/examples/ridecount/RideCountExample.java
@@ -19,7 +19,6 @@
 package org.apache.flink.training.examples.ridecount;
 
 import org.apache.flink.api.common.functions.MapFunction;
-import org.apache.flink.api.java.tuple.Tuple;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -73,7 +72,7 @@ public class RideCountExample {
 		});
 
 		// partition the stream by the driverId
-		KeyedStream<Tuple2<Long, Long>, Tuple> keyedByDriverId = tuples.keyBy(0);
+		KeyedStream<Tuple2<Long, Long>, Long> keyedByDriverId = tuples.keyBy(t -> t.f0);
 
 		// count the rides for each driver
 		DataStream<Tuple2<Long, Long>> rideCounts = keyedByDriverId.sum(1);

--- a/hourly-tips/DISCUSSION.md
+++ b/hourly-tips/DISCUSSION.md
@@ -118,7 +118,7 @@ But, what if we were to do this, instead?
 
 ```java
 DataStream<Tuple3<Long, Long, Float>> hourlyMax = hourlyTips
-	.keyBy(0)
+	.keyBy(t -> t.f0)
 	.maxBy(2);
 ```
 

--- a/hourly-tips/src/solution/java/org/apache/flink/training/solutions/hourlytips/HourlyTipsSolution.java
+++ b/hourly-tips/src/solution/java/org/apache/flink/training/solutions/hourlytips/HourlyTipsSolution.java
@@ -82,7 +82,7 @@ public class HourlyTipsSolution extends ExerciseBase {
 //		and different from, the solution above (using a windowAll)?
 
 // 		DataStream<Tuple3<Long, Long, Float>> hourlyMax = hourlyTips
-// 			.keyBy(0)
+// 			.keyBy(t -> t.f0)
 // 			.maxBy(2);
 
 		printOrTest(hourlyMax);

--- a/long-ride-alerts/src/main/java/org/apache/flink/training/exercises/longrides/LongRidesExercise.java
+++ b/long-ride-alerts/src/main/java/org/apache/flink/training/exercises/longrides/LongRidesExercise.java
@@ -67,7 +67,7 @@ public class LongRidesExercise extends ExerciseBase {
 		DataStream<TaxiRide> rides = env.addSource(rideSourceOrTest(new TaxiRideSource(input, maxEventDelay, servingSpeedFactor)));
 
 		DataStream<TaxiRide> longRides = rides
-				.keyBy(ride -> ride.rideId)
+				.keyBy((TaxiRide ride) -> ride.rideId)
 				.process(new MatchFunction());
 
 		printOrTest(longRides);

--- a/long-ride-alerts/src/solution/java/org/apache/flink/training/solutions/longrides/LongRidesSolution.java
+++ b/long-ride-alerts/src/solution/java/org/apache/flink/training/solutions/longrides/LongRidesSolution.java
@@ -68,7 +68,7 @@ public class LongRidesSolution extends ExerciseBase {
 		DataStream<TaxiRide> rides = env.addSource(rideSourceOrTest(new TaxiRideSource(input, maxEventDelay, servingSpeedFactor)));
 
 		DataStream<TaxiRide> longRides = rides
-				.keyBy(r -> r.rideId)
+				.keyBy((TaxiRide ride) -> ride.rideId)
 				.process(new MatchFunction());
 
 		printOrTest(longRides);

--- a/rides-and-fares/src/main/java/org/apache/flink/training/exercises/ridesandfares/RidesAndFaresExercise.java
+++ b/rides-and-fares/src/main/java/org/apache/flink/training/exercises/ridesandfares/RidesAndFaresExercise.java
@@ -68,11 +68,11 @@ public class RidesAndFaresExercise extends ExerciseBase {
 		DataStream<TaxiRide> rides = env
 				.addSource(rideSourceOrTest(new TaxiRideSource(ridesFile, delay, servingSpeedFactor)))
 				.filter((TaxiRide ride) -> ride.isStart)
-				.keyBy("rideId");
+				.keyBy((TaxiRide ride) -> ride.rideId);
 
 		DataStream<TaxiFare> fares = env
 				.addSource(fareSourceOrTest(new TaxiFareSource(faresFile, delay, servingSpeedFactor)))
-				.keyBy("rideId");
+				.keyBy((TaxiFare fare) -> fare.rideId);
 
 		DataStream<Tuple2<TaxiRide, TaxiFare>> enrichedRides = rides
 				.connect(fares)

--- a/rides-and-fares/src/main/scala/org/apache/flink/training/exercises/ridesandfares/scala/RidesAndFaresExercise.scala
+++ b/rides-and-fares/src/main/scala/org/apache/flink/training/exercises/ridesandfares/scala/RidesAndFaresExercise.scala
@@ -55,11 +55,11 @@ object RidesAndFaresExercise {
     val rides = env
       .addSource(rideSourceOrTest(new TaxiRideSource(ridesFile, delay, servingSpeedFactor)))
       .filter { ride => ride.isStart }
-      .keyBy("rideId")
+      .keyBy { ride => ride.rideId }
 
     val fares = env
       .addSource(fareSourceOrTest(new TaxiFareSource(faresFile, delay, servingSpeedFactor)))
-      .keyBy("rideId")
+      .keyBy { fare => fare.rideId }
 
     val processed = rides
       .connect(fares)

--- a/rides-and-fares/src/solution/java/org/apache/flink/training/solutions/ridesandfares/RidesAndFaresSolution.java
+++ b/rides-and-fares/src/solution/java/org/apache/flink/training/solutions/ridesandfares/RidesAndFaresSolution.java
@@ -81,11 +81,11 @@ public class RidesAndFaresSolution extends ExerciseBase {
 		DataStream<TaxiRide> rides = env
 				.addSource(rideSourceOrTest(new TaxiRideSource(ridesFile, delay, servingSpeedFactor)))
 				.filter((TaxiRide ride) -> ride.isStart)
-				.keyBy(ride -> ride.rideId);
+				.keyBy((TaxiRide ride) -> ride.rideId);
 
 		DataStream<TaxiFare> fares = env
 				.addSource(fareSourceOrTest(new TaxiFareSource(faresFile, delay, servingSpeedFactor)))
-				.keyBy(fare -> fare.rideId);
+				.keyBy((TaxiFare fare) -> fare.rideId);
 
 		// Set a UID on the stateful flatmap operator so we can read its state using the State Processor API.
 		DataStream<Tuple2<TaxiRide, TaxiFare>> enrichedRides = rides

--- a/rides-and-fares/src/solution/scala/org/apache/flink/training/solutions/ridesandfares/scala/RidesAndFaresSolution.scala
+++ b/rides-and-fares/src/solution/scala/org/apache/flink/training/solutions/ridesandfares/scala/RidesAndFaresSolution.scala
@@ -56,11 +56,11 @@ object RidesAndFaresSolution {
     val rides = env
       .addSource(rideSourceOrTest(new TaxiRideSource(ridesFile, delay, servingSpeedFactor)))
       .filter { ride => ride.isStart }
-      .keyBy("rideId")
+      .keyBy { ride => ride.rideId }
 
     val fares = env
       .addSource(fareSourceOrTest(new TaxiFareSource(faresFile, delay, servingSpeedFactor)))
-      .keyBy("rideId")
+      .keyBy { fare => fare.rideId }
 
     val processed = rides
       .connect(fares)


### PR DESCRIPTION
Clean-up the keyBys for Flink 1.11.