### PR TITLE
[FLINK-18630] Redo the LongRideAlerts solutions to cover a corner case

### DIFF
--- a/long-ride-alerts/DISCUSSION.md
+++ b/long-ride-alerts/DISCUSSION.md
@@ -21,7 +21,23 @@ under the License.
 
 (Discussion of [Lab: `ProcessFunction` and Timers (Long Ride Alerts)](./))
 
+It would be interesting to test that the solution does not leak state.
 
+A good way to write unit tests for a `KeyedProcessFunction` that check for state retention, etc., is to
+use the test harnesses described in the
+[documentation on testing](https://ci.apache.org/projects/flink/flink-docs-stable/dev/stream/testing.html#unit-testing-stateful-or-timely-udfs--custom-operators). 
+
+In fact, the reference solutions will leak state in the case where a START event is missing. They also
+leak in the case where the alert is generated, but then the END event does eventually arrive (after `onTimer()`
+has cleared the matching START event).
+
+This could be addressed either by using [state TTL](https://ci.apache.org/projects/flink/flink-docs-stable/dev/stream/state/state.html#state-time-to-live-ttl),
+or by using another timer that eventually
+clears any remaining state. There is a tradeoff here, however: once that state has been removed,
+then if the matching events are't actually missing, but are instead very, very late, they will cause erroneous alerts.
+
+This tradeoff between keeping state indefinitely versus occasionally getting things wrong when events are
+exceptionally late is a challenge that is inherent to stateful stream processing.
 
 -----
 

--- a/long-ride-alerts/DISCUSSION.md
+++ b/long-ride-alerts/DISCUSSION.md
@@ -23,7 +23,7 @@ under the License.
 
 It would be interesting to test that the solution does not leak state.
 
-A good way to write unit tests for a `KeyedProcessFunction` that check for state retention, etc., is to
+A good way to write unit tests for a `KeyedProcessFunction` to check for state retention, etc., is to
 use the test harnesses described in the
 [documentation on testing](https://ci.apache.org/projects/flink/flink-docs-stable/dev/stream/testing.html#unit-testing-stateful-or-timely-udfs--custom-operators). 
 
@@ -34,7 +34,7 @@ has cleared the matching START event).
 This could be addressed either by using [state TTL](https://ci.apache.org/projects/flink/flink-docs-stable/dev/stream/state/state.html#state-time-to-live-ttl),
 or by using another timer that eventually
 clears any remaining state. There is a tradeoff here, however: once that state has been removed,
-then if the matching events are't actually missing, but are instead very, very late, they will cause erroneous alerts.
+then if the matching events are not actually missing, but are instead very, very late, they will cause erroneous alerts.
 
 This tradeoff between keeping state indefinitely versus occasionally getting things wrong when events are
 exceptionally late is a challenge that is inherent to stateful stream processing.

--- a/long-ride-alerts/README.md
+++ b/long-ride-alerts/README.md
@@ -75,10 +75,10 @@ collect START events to the output only if a matching END event hasn't yet arriv
 There are many possible solutions for this exercise, but in general it is enough to keep one
 `TaxiRide` in state (one `TaxiRide` for each key, or `rideId`). The approach used in the reference solution is to
 store whichever event arrives first (the START or the END), and if it's a START event,
-create a timer for two hours later. If and when the other event (for the same rideId) arrives,
+create a timer for two hours later. If and when the other event (for the same `rideId`) arrives,
 carefully clean things up.
 
-It's possible to arrange this so that if `onTimer()` is called, you are guaranteed that
+It is possible to arrange this so that if `onTimer()` is called, you are guaranteed that
 an alert (i.e., the ride kept in state) should be emitted. Writing the code this way conveniently
 puts all of the complex business logic together in one place (in the `processElement()` method).
 </details>

--- a/long-ride-alerts/README.md
+++ b/long-ride-alerts/README.md
@@ -62,13 +62,11 @@ The resulting stream should be printed to standard out.
 <details>
 <summary><strong>Overall approach</strong></summary>
 
-This exercise revolves around using a `ProcessFunction` to manage some keyed state and event time timers, and doing so in a way that works even when the END event for a given `rideId` arrives before the START (which will happen). The challenge is figuring out what state to keep, and when to set and clear that state.
-</details>
-
-<details>
-<summary><strong>Timers and State</strong></summary>
-
-You will want to use event time timers that fire two hours after the incoming events, and in the `onTimer()` method, collect START events to the output only if a matching END event hasn't yet arrived. As for what state to keep, it is enough to remember the "last" event for each `rideId`, where "last" is based on event time and ride type (START vs END &mdash; yes, there are rides where the START and END have the same timestamp), rather than the order in which the events are processed. The `TaxiRide` class implements `Comparable`; feel free to take advantage of that, and be sure to eventually clear any state you create.
+This exercise revolves around using a `ProcessFunction` to manage some keyed state and event time timers, 
+and doing so in a way that works even when the END event for a given `rideId` arrives before the START (which can happen). 
+The challenge is figuring out what state to keep, and when to set and clear that state.
+You will want to use event time timers that fire two hours after an incoming START event, and in the `onTimer()` method, 
+collect START events to the output only if a matching END event hasn't yet arrived.
 </details>
 
 ## Documentation

--- a/long-ride-alerts/README.md
+++ b/long-ride-alerts/README.md
@@ -69,6 +69,20 @@ You will want to use event time timers that fire two hours after an incoming STA
 collect START events to the output only if a matching END event hasn't yet arrived.
 </details>
 
+<details>
+<summary><strong>State and timers</strong></summary>
+
+There are many possible solutions for this exercise, but in general it is enough to keep one
+`TaxiRide` in state (one `TaxiRide` for each key, or `rideId`). The approach used in the reference solution is to
+store whichever event arrives first (the START or the END), and if it's a START event,
+create a timer for two hours later. If and when the other event (for the same rideId) arrives,
+carefully clean things up.
+
+It's possible to arrange this so that if `onTimer()` is called, you are guaranteed that
+an alert (i.e., the ride kept in state) should be emitted. Writing the code this way conveniently
+puts all of the complex business logic together in one place (in the `processElement()` method).
+</details>
+
 ## Documentation
 
 - [ProcessFunction](https://ci.apache.org/projects/flink/flink-docs-stable/dev/stream/operators/process_function.html)

--- a/long-ride-alerts/src/test/java/org/apache/flink/training/exercises/longrides/LongRidesTest.java
+++ b/long-ride-alerts/src/test/java/org/apache/flink/training/exercises/longrides/LongRidesTest.java
@@ -88,6 +88,16 @@ public class LongRidesTest extends TaxiRideTestBase<TaxiRide> {
 		assertEquals(Collections.singletonList(rideStarted), results(source));
 	}
 
+	@Test
+	public void startIsDelayedMoreThanTwoHours() throws Exception {
+		TaxiRide rideStarted = startRide(1, BEGINNING);
+		TaxiRide rideEndedAfter1Hour = endRide(rideStarted, BEGINNING.plusSeconds(60 * 60));
+		Long mark2HoursAfterEnd = BEGINNING.plusSeconds(180 * 60).toEpochMilli();
+
+		TestRideSource source = new TestRideSource(rideEndedAfter1Hour, mark2HoursAfterEnd, rideStarted);
+		assert(results(source).isEmpty());
+	}
+
 	private TaxiRide testRide(long rideId, Boolean isStart, Instant startTime, Instant endTime) {
 		return new TaxiRide(rideId, isStart, startTime, endTime, -73.9947F, 40.750626F, -73.9947F, 40.750626F, (short) 1, 0, 0);
 	}


### PR DESCRIPTION
Fixing an issue in the reference solutions for this exercise. I've added a test to cover this corner case, which is when the END event for a ride arrives more than two hours before the matching START event. Thanks to @zbyszkop for pointing out the problem, and proposing a solution.

I also added some content to the DISCUSSION page (which was empty).