### PR TITLE
[FLINK-22868] Update to use Flink 1.13.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,12 +31,12 @@ subprojects {
 
     // artifact properties
     group = 'org.apache.flink'
-    version = '1.12-SNAPSHOT'
+    version = '1.13-SNAPSHOT'
     description = """Flink Training Exercises"""
 
     ext {
         javaVersion = '1.8'
-        flinkVersion = '1.12.0'
+        flinkVersion = '1.13.1'
         scalaBinaryVersion = '2.12'
         slf4jVersion = '1.7.15'
         log4jVersion = '1.2.17'


### PR DESCRIPTION
Updating from 1.12.0 to 1.13.1.

This is destined to go into both master and a new release-1.13 branch.