### PR TITLE
[ververica] Update to Flink 1.13.1

### DIFF
--- a/LABS-OVERVIEW.md
+++ b/LABS-OVERVIEW.md
@@ -27,3 +27,4 @@ under the License.
 1. [`ProcessFunction` and Timers (Long Ride Alerts)](long-ride-alerts)
    - [Exercise](long-ride-alerts/README.md)
    - [Discussion](long-ride-alerts/DISCUSSION.md)
+1. [Tuning & Troubleshooting Labs](troubleshooting)

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ This `flink-training` project contains exercises, tests, and reference solutions
 > If you want to work on a version other than the current Flink release, make sure to check out the appropriate branch.
 
 ```bash
-git clone https://github.com/apache/flink-training.git
-cd flink-training
+git clone https://github.com/ververica/flink-training.git ververica-flink-training
+cd ververica-flink-training
 ./gradlew test shadowJar
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -36,12 +36,12 @@ subprojects {
 
     // artifact properties
     group = 'org.apache.flink'
-    version = '1.12-SNAPSHOT'
+    version = '1.13-SNAPSHOT'
     description = """Flink Training Exercises"""
 
     ext {
         javaVersion = '1.8'
-        flinkVersion = '1.12.2'
+        flinkVersion = '1.13.1'
         scalaBinaryVersion = '2.12'
         jacksonVersion = '2.11.2'
         slf4jVersion = '1.7.15'

--- a/build.gradle
+++ b/build.gradle
@@ -140,6 +140,9 @@ subprojects {
 
     shadowJar {
         configurations = [project.configurations.flinkShadowJar]
+        if (project.parent != rootProject) {
+            archiveBaseName.set("${project.parent.name}-${project.name}")
+        }
     }
 
     assemble.dependsOn(shadowJar)

--- a/build.gradle
+++ b/build.gradle
@@ -20,9 +20,14 @@ plugins {
 }
 
 subprojects {
+    if (project == project(":troubleshooting") || project == project(":troubleshooting:state-migration")) {
+        // this is just an additional grouping layer, not a project!
+        return
+    }
+
     apply plugin: 'java'
     // apply plugin: 'scala' // optional; uncomment if needed
-    if (project != project(":common")) {
+    if (project != project(":common") && project != project(":troubleshooting:common") && project != project(":troubleshooting:state-migration:common")) {
         apply plugin: 'application'
     }
     apply plugin: 'com.github.johnrengelman.shadow'
@@ -87,7 +92,7 @@ subprojects {
         implementation "log4j:log4j:${log4jVersion}"
         implementation "org.slf4j:slf4j-log4j12:${slf4jVersion}"
 
-        if (project != project(":common")) {
+        if (project != project(":common") && !project.path.startsWith(":troubleshooting")) {
             implementation project(path: ':common')
             // transitive dependencies for flinkShadowJar need to be defined above
             // (the alternative of using configuration: 'shadow' does not work there because that adds a dependency on

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ subprojects {
         javaVersion = '1.8'
         flinkVersion = '1.11.2'
         scalaBinaryVersion = '2.12'
+        jacksonVersion = '2.11.2'
         slf4jVersion = '1.7.15'
         log4jVersion = '1.2.17'
         junitVersion = '4.12'

--- a/build.gradle
+++ b/build.gradle
@@ -146,4 +146,9 @@ subprojects {
     }
 
     assemble.dependsOn(shadowJar)
+
+    // add FLINK_TRAINING_LOCAL to the environment variables if run via gradle
+    tasks.matching({ task -> task instanceof JavaExec }).all {
+        environment "FLINK_TRAINING_LOCAL", "1"
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -36,12 +36,12 @@ subprojects {
 
     // artifact properties
     group = 'org.apache.flink'
-    version = '1.11-SNAPSHOT'
+    version = '1.12-SNAPSHOT'
     description = """Flink Training Exercises"""
 
     ext {
         javaVersion = '1.8'
-        flinkVersion = '1.11.2'
+        flinkVersion = '1.12.0'
         scalaBinaryVersion = '2.12'
         jacksonVersion = '2.11.2'
         slf4jVersion = '1.7.15'

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ plugins {
 
 subprojects {
     apply plugin: 'java'
-    apply plugin: 'scala' // optional; uncomment if needed
+    // apply plugin: 'scala' // optional; uncomment if needed
     if (project != project(":common")) {
         apply plugin: 'application'
     }
@@ -102,7 +102,9 @@ subprojects {
     // make flinkShadowJar dependencies available:
     sourceSets {
         main.java.srcDirs += 'src/solution/java'
-        main.scala.srcDirs += 'src/solution/scala'
+        tasks.withType(ScalaCompile) {
+            main.scala.srcDirs += 'src/solution/scala'
+        }
         main.compileClasspath += configurations.flinkShadowJar
         main.runtimeClasspath += configurations.flinkShadowJar
 

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ subprojects {
 
     ext {
         javaVersion = '1.8'
-        flinkVersion = '1.11.0'
+        flinkVersion = '1.11.2'
         scalaBinaryVersion = '2.12'
         slf4jVersion = '1.7.15'
         log4jVersion = '1.2.17'

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ subprojects {
 
     ext {
         javaVersion = '1.8'
-        flinkVersion = '1.12.0'
+        flinkVersion = '1.12.2'
         scalaBinaryVersion = '2.12'
         jacksonVersion = '2.11.2'
         slf4jVersion = '1.7.15'

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -23,6 +23,53 @@ under the License.
 		"https://checkstyle.org/dtds/suppressions_1_2.dtd">
 
 <suppressions>
+	<!-- troubleshooting/common -->
+	<suppress
+		files="(.*)troubleshooting[/\\]common[/\\](.*)com[/\\]ververica[/\\]flink[/\\]training[/\\]common[/\\](Measurement|WindowedMeasurements|FakeKafkaRecord)\.java"
+		checks="MissingJavadocMethod"/>
+
+	<!-- troubleshooting/introduction -->
+	<suppress
+		files="(.*)troubleshooting[/\\]introduction[/\\](.*)com[/\\]ververica[/\\]flink[/\\]training[/\\]solutions[/\\](SimpleMeasurement)\.java"
+		checks="MissingJavadocMethod"/>
+
+	<!-- troubleshooting/external-enrichment -->
+	<suppress
+		files="(.*)troubleshooting[/\\]external-enrichment[/\\](.*)com[/\\]ververica[/\\]flink[/\\]training[/\\]provided[/\\](SimpleMeasurement)\.java"
+		checks="MissingJavadocMethod"/>
+	<suppress
+		files="(.*)troubleshooting[/\\]external-enrichment[/\\](.*)com[/\\]ververica[/\\]flink[/\\]training[/\\]provided[/\\](EnrichedMeasurement)\.java"
+		checks="MissingJavadocMethod"/>
+
+	<!-- troubleshooting/object-reuse -->
+	<suppress
+		files="(.*)troubleshooting[/\\]object-reuse[/\\](.*)com[/\\]ververica[/\\]flink[/\\]training[/\\]provided[/\\](ExtendedMeasurement)\.java"
+		checks="MissingJavadocMethod"/>
+	<suppress
+		files="(.*)troubleshooting[/\\]object-reuse[/\\](.*)com[/\\]ververica[/\\]flink[/\\]training[/\\]solutions[/\\]immutable[/\\](ExtendedMeasurement|Location|MeasurementValue|Sensor)\.java"
+		checks="MissingJavadocMethod"/>
+
+	<!-- troubleshooting/state-migration -->
+	<suppress
+		files="(.*)troubleshooting[/\\]state-migration[/\\](.*)com[/\\]ververica[/\\]flink[/\\]training[/\\]exercises[/\\](MeasurementAggregationReport)\.java"
+		checks="MissingJavadocMethod"/>
+	<suppress
+		files="(.*)troubleshooting[/\\]state-migration[/\\](.*)com[/\\]ververica[/\\]flink[/\\]training[/\\]exercises[/\\]custom[/\\](AggregatedSensorStatistics)\.java"
+		checks="MissingJavadocMethod"/>
+
+	<!-- troubleshooting/throughput -->
+	<suppress
+			files="(.*)troubleshooting[/\\]throughput[/\\](.*)com[/\\]ververica[/\\]flink[/\\]training[/\\]exercises[/\\](WindowedMeasurementsForArea)\.java"
+			checks="MissingJavadocMethod"/>
+	<suppress
+			files="(.*)troubleshooting[/\\]throughput[/\\](.*)com[/\\]ververica[/\\]flink[/\\]training[/\\]solutions[/\\](WindowedMeasurementsForArea2)\.java"
+			checks="MissingJavadocMethod"/>
+
+	<!-- Avro-generated files -->
+	<suppress
+		files="(.*)generated-(.*)-avro-java(.*)\.java"
+		checks=".*"/>
+
 	<suppress
 			files="(.*)test[/\\](.*)"
 			checks="MissingJavadocMethod"/>

--- a/hourly-tips/src/main/java/org/apache/flink/training/exercises/hourlytips/HourlyTipsExercise.java
+++ b/hourly-tips/src/main/java/org/apache/flink/training/exercises/hourlytips/HourlyTipsExercise.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.training.exercises.hourlytips;
 
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.training.exercises.common.datatypes.TaxiFare;
@@ -44,7 +43,6 @@ public class HourlyTipsExercise extends ExerciseBase {
 
 		// set up streaming execution environment
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 		env.setParallelism(ExerciseBase.parallelism);
 
 		// start the data generator

--- a/hourly-tips/src/main/scala/org/apache/flink/training/exercises/hourlytips/scala/HourlyTipsExercise.scala
+++ b/hourly-tips/src/main/scala/org/apache/flink/training/exercises/hourlytips/scala/HourlyTipsExercise.scala
@@ -18,7 +18,6 @@
 
 package org.apache.flink.training.exercises.hourlytips.scala
 
-import org.apache.flink.streaming.api.TimeCharacteristic
 import org.apache.flink.streaming.api.scala._
 import org.apache.flink.training.exercises.common.sources.TaxiFareGenerator
 import org.apache.flink.training.exercises.common.utils.ExerciseBase._
@@ -37,7 +36,6 @@ object HourlyTipsExercise {
 
     // set up streaming execution environment
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
     env.setParallelism(ExerciseBase.parallelism)
 
     // start the data generator

--- a/hourly-tips/src/solution/java/org/apache/flink/training/solutions/hourlytips/HourlyTipsSolution.java
+++ b/hourly-tips/src/solution/java/org/apache/flink/training/solutions/hourlytips/HourlyTipsSolution.java
@@ -19,7 +19,6 @@
 package org.apache.flink.training.solutions.hourlytips;
 
 import org.apache.flink.api.java.tuple.Tuple3;
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
@@ -49,7 +48,6 @@ public class HourlyTipsSolution extends ExerciseBase {
 
 		// set up streaming execution environment
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 		env.setParallelism(ExerciseBase.parallelism);
 
 		// start the data generator

--- a/hourly-tips/src/solution/scala/org/apache/flink/training/solutions/hourlytips/scala/HourlyTipsSolution.scala
+++ b/hourly-tips/src/solution/scala/org/apache/flink/training/solutions/hourlytips/scala/HourlyTipsSolution.scala
@@ -18,7 +18,6 @@
 
 package org.apache.flink.training.solutions.hourlytips.scala
 
-import org.apache.flink.streaming.api.TimeCharacteristic
 import org.apache.flink.streaming.api.scala._
 import org.apache.flink.streaming.api.scala.function.ProcessWindowFunction
 import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows
@@ -43,7 +42,6 @@ object HourlyTipsSolution {
 
     // set up streaming execution environment
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
     env.setParallelism(ExerciseBase.parallelism)
 
     // start the data generator

--- a/long-ride-alerts/src/main/java/org/apache/flink/training/exercises/longrides/LongRidesExercise.java
+++ b/long-ride-alerts/src/main/java/org/apache/flink/training/exercises/longrides/LongRidesExercise.java
@@ -19,7 +19,6 @@
 package org.apache.flink.training.exercises.longrides;
 
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.TimerService;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -48,7 +47,6 @@ public class LongRidesExercise extends ExerciseBase {
 
 		// set up streaming execution environment
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 		env.setParallelism(ExerciseBase.parallelism);
 
 		// start the data generator

--- a/long-ride-alerts/src/main/scala/org/apache/flink/training/exercises/longrides/scala/LongRidesExercise.scala
+++ b/long-ride-alerts/src/main/scala/org/apache/flink/training/exercises/longrides/scala/LongRidesExercise.scala
@@ -19,7 +19,6 @@
 package org.apache.flink.training.exercises.longrides.scala
 
 import org.apache.flink.configuration.Configuration
-import org.apache.flink.streaming.api.TimeCharacteristic
 import org.apache.flink.streaming.api.functions.KeyedProcessFunction
 import org.apache.flink.streaming.api.scala.{StreamExecutionEnvironment, _}
 import org.apache.flink.training.exercises.common.datatypes.TaxiRide
@@ -41,7 +40,6 @@ object LongRidesExercise {
 
     // set up the execution environment
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
     env.setParallelism(ExerciseBase.parallelism)
 
     val rides = env.addSource(rideSourceOrTest(new TaxiRideGenerator()))

--- a/long-ride-alerts/src/solution/java/org/apache/flink/training/solutions/longrides/LongRidesSolution.java
+++ b/long-ride-alerts/src/solution/java/org/apache/flink/training/solutions/longrides/LongRidesSolution.java
@@ -21,7 +21,6 @@ package org.apache.flink.training.solutions.longrides;
 import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
@@ -48,7 +47,6 @@ public class LongRidesSolution extends ExerciseBase {
 
 		// set up streaming execution environment
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 		env.setParallelism(ExerciseBase.parallelism);
 
 		// start the data generator

--- a/long-ride-alerts/src/solution/scala/org/apache/flink/training/solutions/longrides/scala/LongRidesSolution.scala
+++ b/long-ride-alerts/src/solution/scala/org/apache/flink/training/solutions/longrides/scala/LongRidesSolution.scala
@@ -20,7 +20,6 @@ package org.apache.flink.training.solutions.longrides.scala
 
 import scala.concurrent.duration._
 import org.apache.flink.api.common.state.{ValueState, ValueStateDescriptor}
-import org.apache.flink.streaming.api.TimeCharacteristic
 import org.apache.flink.streaming.api.functions.KeyedProcessFunction
 import org.apache.flink.streaming.api.scala.{StreamExecutionEnvironment, _}
 import org.apache.flink.training.exercises.common.datatypes.TaxiRide
@@ -43,7 +42,6 @@ object LongRidesSolution {
     // set up the execution environment
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     // operate in Event-time
-    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
     env.setParallelism(ExerciseBase.parallelism)
 
     val rides = env.addSource(rideSourceOrTest(new TaxiRideGenerator()))

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,6 +9,16 @@ include 'rides-and-fares'
 include 'hourly-tips'
 include 'long-ride-alerts'
 include 'state-processor'
+include 'troubleshooting:checkpointing'
+include 'troubleshooting:common'
+include 'troubleshooting:external-enrichment'
+include 'troubleshooting:introduction'
+include 'troubleshooting:object-reuse'
+include 'troubleshooting:state-migration:common'
+include 'troubleshooting:state-migration:exercise'
+include 'troubleshooting:state-migration:solution'
+include 'troubleshooting:state-migration:solution-custom-to-avro'
+include 'troubleshooting:throughput'
 
 // CI=true, TRAVIS=true, CONTINUOUS_INTEGRATION=true set automatically during Travis execution
 // see https://docs.travis-ci.com/user/environment-variables#default-environment-variables

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,6 +8,7 @@ include 'ride-cleansing'
 include 'rides-and-fares'
 include 'hourly-tips'
 include 'long-ride-alerts'
+include 'state-processor'
 
 // CI=true, TRAVIS=true, CONTINUOUS_INTEGRATION=true set automatically during Travis execution
 // see https://docs.travis-ci.com/user/environment-variables#default-environment-variables

--- a/state-processor/build.gradle
+++ b/state-processor/build.gradle
@@ -1,0 +1,14 @@
+group = 'com.ververica'
+mainClassName = 'com.ververica.flink.training.exercises.ReadRidesAndFaresSnapshot'
+
+// common set of dependencies
+dependencies {
+    // --------------------------------------------------------------
+    // Compile-time dependencies that should NOT be part of the
+    // shadow jar and are provided in the lib folder of Flink
+    // --------------------------------------------------------------
+    implementation "org.apache.flink:flink-state-processor-api_${scalaBinaryVersion}:${flinkVersion}"
+
+    flinkShadowJar "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
+    flinkShadowJar "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
+}

--- a/state-processor/src/main/java/com/ververica/flink/training/exercises/ReadRidesAndFaresSnapshot.java
+++ b/state-processor/src/main/java/com/ververica/flink/training/exercises/ReadRidesAndFaresSnapshot.java
@@ -7,7 +7,7 @@ import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.state.memory.MemoryStateBackend;
+import org.apache.flink.runtime.state.hashmap.HashMapStateBackend;
 import org.apache.flink.state.api.ExistingSavepoint;
 import org.apache.flink.state.api.Savepoint;
 import org.apache.flink.state.api.functions.KeyedStateReaderFunction;
@@ -34,7 +34,7 @@ public class ReadRidesAndFaresSnapshot {
 	 */
 	public static void main(String[] args) throws Exception {
 		ExecutionEnvironment bEnv = ExecutionEnvironment.getExecutionEnvironment();
-		MemoryStateBackend backend = new MemoryStateBackend();
+		HashMapStateBackend backend = new HashMapStateBackend();
 
 		ParameterTool params = ParameterTool.fromArgs(args);
 		String input = params.getRequired("input");

--- a/state-processor/src/main/java/com/ververica/flink/training/exercises/ReadRidesAndFaresSnapshot.java
+++ b/state-processor/src/main/java/com/ververica/flink/training/exercises/ReadRidesAndFaresSnapshot.java
@@ -1,0 +1,71 @@
+package com.ververica.flink.training.exercises;
+
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.java.DataSet;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.state.memory.MemoryStateBackend;
+import org.apache.flink.state.api.ExistingSavepoint;
+import org.apache.flink.state.api.Savepoint;
+import org.apache.flink.state.api.functions.KeyedStateReaderFunction;
+import org.apache.flink.training.exercises.common.datatypes.TaxiFare;
+import org.apache.flink.training.exercises.common.datatypes.TaxiRide;
+import org.apache.flink.util.Collector;
+
+/**
+ * Java implementation for an example using the State Processor API to read and display
+ * the contents of a retained checkpoint or savepoint from RidesAndFaresSolution.
+ *
+ * <p>Required parameter:
+ *
+ * <p>--input path-to-snapshot
+ *
+ * <p>e.g., --input file:///tmp/checkpoints/3bb27ec3cedb40d19ff31c4617e54715/chk-5
+ */
+public class ReadRidesAndFaresSnapshot {
+
+	/**
+	 * Main method.
+	 *
+	 * @throws Exception which occurs during job execution.
+	 */
+	public static void main(String[] args) throws Exception {
+		ExecutionEnvironment bEnv = ExecutionEnvironment.getExecutionEnvironment();
+		MemoryStateBackend backend = new MemoryStateBackend();
+
+		ParameterTool params = ParameterTool.fromArgs(args);
+		String input = params.getRequired("input");
+
+		ExistingSavepoint sp = Savepoint.load(bEnv, input, backend);
+
+		// the uid here must match the uid used in RidesAndFaresSolution
+		DataSet<Tuple2<TaxiRide, TaxiFare>> keyedState = sp.readKeyedState("enrichment", new ReadRidesAndFares());
+
+		keyedState.print();
+	}
+
+	static class ReadRidesAndFares extends KeyedStateReaderFunction<Long, Tuple2<TaxiRide, TaxiFare>> {
+		ValueState<TaxiRide> ride;
+		ValueState<TaxiFare> fare;
+
+		@Override
+		public void open(Configuration parameters) {
+
+			// these state descriptors must be compatible with those used in RidesAndFaresSolution
+			ride = getRuntimeContext().getState(new ValueStateDescriptor<>("saved ride", TaxiRide.class));
+			fare = getRuntimeContext().getState(new ValueStateDescriptor<>("saved fare", TaxiFare.class));
+		}
+
+		@Override
+		public void readKey(
+				Long key,
+				Context context,
+				Collector<Tuple2<TaxiRide, TaxiFare>> out) throws Exception {
+
+			out.collect(new Tuple2<>(ride.value(), fare.value()));
+		}
+	}
+}

--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -1,0 +1,13 @@
+# Tuning and Troubleshooting Labs
+
+1. [Introduction (Troubled Streaming Job)](introduction)
+1. Advanced
+   1. [Throughput Tuning](throughput)
+   1. [Checkpointing](checkpointing)
+   1. [Object Reuse](object-reuse)
+   1. [External Enrichment](external-enrichment)
+   1. [State Migration](state-migration)
+
+-----
+
+[**Back to Labs Overview**](../LABS-OVERVIEW.md)

--- a/troubleshooting/build.gradle
+++ b/troubleshooting/build.gradle
@@ -1,0 +1,3 @@
+subprojects {
+    group = 'com.ververica.flink.training.troubleshooting'
+}

--- a/troubleshooting/checkpointing/README.md
+++ b/troubleshooting/checkpointing/README.md
@@ -1,0 +1,15 @@
+# Lab: Advanced Tuning & Troubleshooting: Checkpointing
+
+## Exercise
+
+* Run [`CheckpointingJob`](src/main/java/com/ververica/flink/training/exercises/CheckpointingJob.java)
+  - once with `FsStateBackend` (default mode if run locally)
+  - once with `RocksDBStateBackend` (set your Flink cluster to use that; locally you can pass `--useRocksDB` to the job)
+* Observe the job's healthiness.
+* Fix the job so that checkpoints are not timing out (2 minutes)
+
+**There are 2 ways of solving this exercise. Can you find both?**
+
+-----
+
+[**Back to Tuning & Troubleshooting Labs Overview**](../README.md)

--- a/troubleshooting/checkpointing/build.gradle
+++ b/troubleshooting/checkpointing/build.gradle
@@ -1,0 +1,19 @@
+mainClassName = 'com.ververica.flink.training.exercises.TroubledStreamingJob'
+
+dependencies {
+    flinkShadowJar "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
+    flinkShadowJar "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
+
+    implementation project(path: ':troubleshooting:common')
+    // transitive dependencies for flinkShadowJar need to be defined above
+    // (the alternative of using configuration: 'shadow' does not work there because that adds a dependency on
+    // the jar file, not the sources)
+    flinkShadowJar project(path: ':troubleshooting:common', transitive: false)
+}
+
+sourceSets {
+    main.java.srcDirs += 'src/provided/java'
+    tasks.withType(ScalaCompile) {
+        main.scala.srcDirs += 'src/provided/scala'
+    }
+}

--- a/troubleshooting/checkpointing/src/main/java/com/ververica/flink/training/exercises/CheckpointingJob.java
+++ b/troubleshooting/checkpointing/src/main/java/com/ververica/flink/training/exercises/CheckpointingJob.java
@@ -1,0 +1,240 @@
+package com.ververica.flink.training.exercises;
+
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.api.common.functions.RichFlatMapFunction;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
+import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
+import org.apache.flink.streaming.api.windowing.assigners.SlidingEventTimeWindows;
+import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
+import org.apache.flink.util.Collector;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ververica.flink.training.common.FakeKafkaRecord;
+import com.ververica.flink.training.common.Measurement;
+import com.ververica.flink.training.common.SourceUtils;
+import com.ververica.flink.training.common.WindowedMeasurements;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Comparator;
+import java.util.PriorityQueue;
+import java.util.concurrent.TimeUnit;
+
+import static com.ververica.flink.training.common.EnvironmentUtils.createConfiguredEnvironment;
+import static com.ververica.flink.training.common.EnvironmentUtils.isLocal;
+
+/**
+ * Streaming job that isn't performing as expected. Checkpointing is slow.
+ */
+public class CheckpointingJob {
+
+    /**
+     * Creates and starts the troubled streaming job.
+	 *
+	 * @throws Exception if the application is misconfigured or fails during job submission
+     */
+	public static void main(String[] args) throws Exception {
+		ParameterTool parameters = ParameterTool.fromArgs(args);
+
+		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
+
+		//Time Characteristics
+		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		env.getConfig().setAutoWatermarkInterval(100);
+		env.setBufferTimeout(10);
+
+		//Checkpointing Configuration (use cluster-configs if not run locally)
+		if (isLocal(parameters)) {
+			env.enableCheckpointing(TimeUnit.SECONDS.toMillis(10));
+			env.getCheckpointConfig().setMinPauseBetweenCheckpoints(TimeUnit.SECONDS.toMillis(10));
+			env.getCheckpointConfig().setCheckpointTimeout(TimeUnit.MINUTES.toMillis(2));
+		}
+
+		DataStream<Tuple2<Measurement, Long>> sourceStream = env
+				.addSource(SourceUtils.createFailureFreeFakeKafkaSource())
+				.name("FakeKafkaSource")
+				.uid("FakeKafkaSource")
+				.assignTimestampsAndWatermarks(
+						WatermarkStrategy
+								.<FakeKafkaRecord>forBoundedOutOfOrderness(Duration.ofMillis(250))
+								.withTimestampAssigner(
+										(element, timestamp) -> element.getTimestamp())
+								.withIdleness(Duration.ofSeconds(1)))
+				.name("Watermarks")
+				.uid("Watermarks")
+				.flatMap(new MeasurementDeserializer())
+				.name("Deserialization")
+				.uid("Deserialization");
+
+		DataStream<WindowedMeasurements> aggregatedPerLocation = sourceStream
+				.keyBy(x -> x.f0.getSensorId())
+				.window(SlidingEventTimeWindows.of(Time.of(1, TimeUnit.MINUTES), Time.of(1, TimeUnit.SECONDS)))
+				.aggregate(new MeasurementWindowAggregatingFunction(),
+						new MeasurementWindowProcessFunction())
+				.name("WindowedAggregationPerLocation")
+				.uid("WindowedAggregationPerLocation");
+
+		if (isLocal(parameters)) {
+			aggregatedPerLocation.print()
+					.name("NormalOutput")
+					.uid("NormalOutput")
+					.disableChaining();
+		} else {
+			aggregatedPerLocation.addSink(new DiscardingSink<>())
+					.name("NormalOutput")
+					.uid("NormalOutput")
+					.disableChaining();
+		}
+
+		env.execute(CheckpointingJob.class.getSimpleName());
+	}
+
+	/**
+	 * Deserializes the JSON Kafka message.
+	 */
+	public static class MeasurementDeserializer extends
+			RichFlatMapFunction<FakeKafkaRecord, Tuple2<Measurement, Long>> {
+		private static final long serialVersionUID = 3L;
+
+		private Counter numInvalidRecords;
+		private transient ObjectMapper instance;
+
+		@Override
+		public void open(final Configuration parameters) throws Exception {
+			super.open(parameters);
+			numInvalidRecords = getRuntimeContext().getMetricGroup().counter("numInvalidRecords");
+			instance = createObjectMapper();
+		}
+
+		@Override
+		public void flatMap(final FakeKafkaRecord kafkaRecord, final Collector<Tuple2<Measurement, Long>> out) {
+			final Measurement node;
+			try {
+				node = deserialize(kafkaRecord.getValue());
+			} catch (IOException e) {
+				numInvalidRecords.inc();
+				return;
+			}
+			out.collect(Tuple2.of(node, kafkaRecord.getTimestamp()));
+		}
+
+		private Measurement deserialize(final byte[] bytes) throws IOException {
+			return instance.readValue(bytes, Measurement.class);
+		}
+	}
+
+	private static class MeasurementByTimeComparator implements Comparator<Tuple2<Measurement, Long>> {
+		@Override
+		public int compare(Tuple2<Measurement, Long> o1, Tuple2<Measurement, Long> o2) {
+			return Long.compare(o1.f1, o2.f1);
+		}
+	}
+
+	/**
+	 * Calculates data for retrieving the average temperature difference between two sensor readings
+	 * (in event-time order!).
+	 */
+	public static class MeasurementWindowAggregatingFunction
+			implements
+			AggregateFunction<Tuple2<Measurement, Long>, PriorityQueue<Tuple2<Measurement, Long>>, WindowedMeasurements> {
+		private static final long serialVersionUID = 1;
+
+		@Override
+		public PriorityQueue<Tuple2<Measurement, Long>> createAccumulator() {
+			// note: "Comparator.comparingLong(o -> o.f1)" cannot be used with Kryo
+			return new PriorityQueue<>(new MeasurementByTimeComparator());
+		}
+
+		@Override
+		public PriorityQueue<Tuple2<Measurement, Long>> add(
+				final Tuple2<Measurement, Long> record,
+				final PriorityQueue<Tuple2<Measurement, Long>> aggregate) {
+			aggregate.add(record);
+//			System.out.println("Elements for " + record.f0.getSensorId() + ": " + aggregate.size());
+			return aggregate;
+		}
+
+		@Override
+		public WindowedMeasurements getResult(final PriorityQueue<Tuple2<Measurement, Long>> windowedMeasurements) {
+			long eventsPerWindow = 0L;
+			double sumPerWindow = 0.0;
+
+			Measurement previous = null;
+			while (!windowedMeasurements.isEmpty()) {
+				Tuple2<Measurement, Long> measurement = windowedMeasurements.poll();
+				++eventsPerWindow;
+				if (previous != null) {
+					sumPerWindow += measurement.f0.getValue() - previous.getValue();
+				}
+				previous = measurement.f0;
+			}
+
+			WindowedMeasurements result = new WindowedMeasurements();
+			result.setEventsPerWindow(eventsPerWindow);
+			result.setSumPerWindow(sumPerWindow);
+
+			return result;
+		}
+
+		@Override
+		public PriorityQueue<Tuple2<Measurement, Long>> merge(
+				final PriorityQueue<Tuple2<Measurement, Long>> agg1,
+				final PriorityQueue<Tuple2<Measurement, Long>> agg2) {
+			agg1.addAll(agg2);
+			return agg1;
+		}
+	}
+
+	public static class MeasurementWindowProcessFunction
+			extends
+			ProcessWindowFunction<WindowedMeasurements, WindowedMeasurements, Integer, TimeWindow> {
+		private static final long serialVersionUID = 1L;
+
+		private static final int EVENT_TIME_LAG_WINDOW_SIZE = 10_000;
+
+		private transient DescriptiveStatisticsHistogram eventTimeLag;
+
+		@Override
+		public void process(
+				final Integer sensorId,
+				final Context context,
+				final Iterable<WindowedMeasurements> input,
+				final Collector<WindowedMeasurements> out) {
+
+			// Windows with pre-aggregation only forward the final result to the WindowFunction
+			WindowedMeasurements aggregate = input.iterator().next();
+
+			final TimeWindow window = context.window();
+			aggregate.setWindow(window);
+			aggregate.setLocation(sensorId.toString());
+
+			eventTimeLag.update(System.currentTimeMillis() - window.getEnd());
+			out.collect(aggregate);
+		}
+
+		@Override
+		public void open(Configuration parameters) throws Exception {
+			super.open(parameters);
+
+			eventTimeLag = getRuntimeContext().getMetricGroup().histogram("eventTimeLag",
+					new DescriptiveStatisticsHistogram(EVENT_TIME_LAG_WINDOW_SIZE));
+		}
+	}
+
+	private static ObjectMapper createObjectMapper() {
+		ObjectMapper objectMapper = new ObjectMapper();
+		objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+		return objectMapper;
+	}
+}

--- a/troubleshooting/checkpointing/src/main/java/com/ververica/flink/training/exercises/CheckpointingJob.java
+++ b/troubleshooting/checkpointing/src/main/java/com/ververica/flink/training/exercises/CheckpointingJob.java
@@ -8,7 +8,6 @@ import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
@@ -49,8 +48,7 @@ public class CheckpointingJob {
 
 		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
 
-		//Time Characteristics
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		//Timing Configuration
 		env.getConfig().setAutoWatermarkInterval(100);
 		env.setBufferTimeout(10);
 

--- a/troubleshooting/checkpointing/src/main/resources/log4j.properties
+++ b/troubleshooting/checkpointing/src/main/resources/log4j.properties
@@ -1,0 +1,23 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+log4j.rootLogger=INFO, console
+
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{HH:mm:ss,SSS} %-5p %-60c %x - %m%n

--- a/troubleshooting/checkpointing/src/solution/java/com/ververica/flink/training/solutions/CheckpointingJobSolution2.java
+++ b/troubleshooting/checkpointing/src/solution/java/com/ververica/flink/training/solutions/CheckpointingJobSolution2.java
@@ -1,0 +1,203 @@
+package com.ververica.flink.training.solutions;
+
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.functions.RichFlatMapFunction;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
+import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
+import org.apache.flink.streaming.api.windowing.assigners.SlidingEventTimeWindows;
+import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
+import org.apache.flink.util.Collector;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ververica.flink.training.common.FakeKafkaRecord;
+import com.ververica.flink.training.common.Measurement;
+import com.ververica.flink.training.common.SourceUtils;
+import com.ververica.flink.training.common.WindowedMeasurements;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.concurrent.TimeUnit;
+
+import static com.ververica.flink.training.common.EnvironmentUtils.createConfiguredEnvironment;
+import static com.ververica.flink.training.common.EnvironmentUtils.isLocal;
+
+/**
+ * Solution 2 for the streaming job with slow checkpointing
+ * (Solution 1 does not need any code fixes; do you know what can be done there?).
+ */
+public class CheckpointingJobSolution2 {
+
+    /**
+     * Creates and starts the troubled streaming job.
+	 *
+	 * @throws Exception if the application is misconfigured or fails during job submission
+     */
+	public static void main(String[] args) throws Exception {
+		ParameterTool parameters = ParameterTool.fromArgs(args);
+
+		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
+
+		//Time Characteristics
+		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		env.getConfig().setAutoWatermarkInterval(100);
+		env.setBufferTimeout(10);
+
+		//Checkpointing Configuration (use cluster-configs if not run locally)
+		if (isLocal(parameters)) {
+			env.enableCheckpointing(TimeUnit.SECONDS.toMillis(10));
+			env.getCheckpointConfig().setMinPauseBetweenCheckpoints(TimeUnit.SECONDS.toMillis(10));
+			env.getCheckpointConfig().setCheckpointTimeout(TimeUnit.MINUTES.toMillis(2));
+		}
+
+		DataStream<Tuple2<Measurement, Long>> sourceStream = env
+				.addSource(SourceUtils.createFailureFreeFakeKafkaSource())
+				.name("FakeKafkaSource")
+				.uid("FakeKafkaSource")
+				.assignTimestampsAndWatermarks(
+						WatermarkStrategy
+								.<FakeKafkaRecord>forBoundedOutOfOrderness(Duration.ofMillis(250))
+								.withTimestampAssigner(
+										(element, timestamp) -> element.getTimestamp())
+								.withIdleness(Duration.ofSeconds(1)))
+				.name("Watermarks")
+				.uid("Watermarks")
+				.flatMap(new MeasurementDeserializer())
+				.name("Deserialization")
+				.uid("Deserialization");
+
+		DataStream<WindowedMeasurements> aggregatedPerLocation = sourceStream
+				.keyBy(x -> x.f0.getSensorId())
+				.window(SlidingEventTimeWindows.of(Time.of(1, TimeUnit.MINUTES), Time.of(1, TimeUnit.SECONDS)))
+				.process(new MeasurementWindowProcessFunction())
+				.name("WindowedAggregationPerLocation")
+				.uid("WindowedAggregationPerLocation");
+
+		if (isLocal(parameters)) {
+			aggregatedPerLocation.print()
+					.name("NormalOutput")
+					.uid("NormalOutput")
+					.disableChaining();
+		} else {
+			aggregatedPerLocation.addSink(new DiscardingSink<>())
+					.name("NormalOutput")
+					.uid("NormalOutput")
+					.disableChaining();
+		}
+
+		env.execute(CheckpointingJobSolution2.class.getSimpleName());
+	}
+
+	/**
+	 * Deserializes the JSON Kafka message.
+	 */
+	public static class MeasurementDeserializer extends
+			RichFlatMapFunction<FakeKafkaRecord, Tuple2<Measurement, Long>> {
+		private static final long serialVersionUID = 3L;
+
+		private Counter numInvalidRecords;
+		private transient ObjectMapper instance;
+
+		@Override
+		public void open(final Configuration parameters) throws Exception {
+			super.open(parameters);
+			numInvalidRecords = getRuntimeContext().getMetricGroup().counter("numInvalidRecords");
+			instance = createObjectMapper();
+		}
+
+		@Override
+		public void flatMap(final FakeKafkaRecord kafkaRecord, final Collector<Tuple2<Measurement, Long>> out) {
+			final Measurement node;
+			try {
+				node = deserialize(kafkaRecord.getValue());
+			} catch (IOException e) {
+				numInvalidRecords.inc();
+				return;
+			}
+			out.collect(Tuple2.of(node, kafkaRecord.getTimestamp()));
+		}
+
+		private Measurement deserialize(final byte[] bytes) throws IOException {
+			return instance.readValue(bytes, Measurement.class);
+		}
+	}
+
+	private static class MeasurementByTimeComparator implements Comparator<Tuple2<Measurement, Long>> {
+		@Override
+		public int compare(Tuple2<Measurement, Long> o1, Tuple2<Measurement, Long> o2) {
+			return Long.compare(o1.f1, o2.f1);
+		}
+	}
+
+	/**
+	 * Calculates data for retrieving the average temperature difference between two sensor readings
+	 * (in event-time order!).
+	 */
+	public static class MeasurementWindowProcessFunction
+			extends
+			ProcessWindowFunction<Tuple2<Measurement, Long>, WindowedMeasurements, Integer, TimeWindow> {
+		private static final long serialVersionUID = 1L;
+
+		private static final int EVENT_TIME_LAG_WINDOW_SIZE = 10_000;
+
+		private transient DescriptiveStatisticsHistogram eventTimeLag;
+
+		@Override
+		public void process(
+				final Integer sensorId,
+				final Context context,
+				final Iterable<Tuple2<Measurement, Long>> input,
+				final Collector<WindowedMeasurements> out) {
+
+			ArrayList<Tuple2<Measurement, Long>> list = new ArrayList<>();
+			input.iterator().forEachRemaining(list::add);
+			list.sort(new MeasurementByTimeComparator());
+
+			long eventsPerWindow = 0L;
+			double sumPerWindow = 0.0;
+			Measurement previous = null;
+			for (Tuple2<Measurement, Long> measurement : list) {
+				++eventsPerWindow;
+				if (previous != null) {
+					sumPerWindow += measurement.f0.getValue() - previous.getValue();
+				}
+				previous = measurement.f0;
+			}
+
+			final TimeWindow window = context.window();
+			WindowedMeasurements result = new WindowedMeasurements();
+			result.setEventsPerWindow(eventsPerWindow);
+			result.setSumPerWindow(sumPerWindow);
+			result.setWindow(window);
+			result.setLocation(sensorId.toString());
+
+			eventTimeLag.update(System.currentTimeMillis() - window.getEnd());
+			out.collect(result);
+		}
+
+		@Override
+		public void open(Configuration parameters) throws Exception {
+			super.open(parameters);
+
+			eventTimeLag = getRuntimeContext().getMetricGroup().histogram("eventTimeLag",
+					new DescriptiveStatisticsHistogram(EVENT_TIME_LAG_WINDOW_SIZE));
+		}
+	}
+
+	private static ObjectMapper createObjectMapper() {
+		ObjectMapper objectMapper = new ObjectMapper();
+		objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+		return objectMapper;
+	}
+}

--- a/troubleshooting/checkpointing/src/solution/java/com/ververica/flink/training/solutions/CheckpointingJobSolution2.java
+++ b/troubleshooting/checkpointing/src/solution/java/com/ververica/flink/training/solutions/CheckpointingJobSolution2.java
@@ -7,7 +7,6 @@ import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
@@ -49,8 +48,7 @@ public class CheckpointingJobSolution2 {
 
 		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
 
-		//Time Characteristics
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		//Timing Configuration
 		env.getConfig().setAutoWatermarkInterval(100);
 		env.setBufferTimeout(10);
 

--- a/troubleshooting/common/build.gradle
+++ b/troubleshooting/common/build.gradle
@@ -2,8 +2,6 @@ plugins {
     id 'java-library'
 }
 
-group = 'com.ververica'
-
 // common set of dependencies
 dependencies {
     // --------------------------------------------------------------

--- a/troubleshooting/common/build.gradle
+++ b/troubleshooting/common/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+    id 'java-library'
+}
+
+group = 'com.ververica'
+
+// common set of dependencies
+dependencies {
+    // --------------------------------------------------------------
+    // Compile-time dependencies that should NOT be part of the
+    // shadow jar and are provided in the lib folder of Flink
+    // --------------------------------------------------------------
+    api "org.apache.flink:flink-java:${flinkVersion}"
+    api "org.apache.flink:flink-runtime-web_${scalaBinaryVersion}:${flinkVersion}"
+    api "org.apache.flink:flink-runtime_${scalaBinaryVersion}:${flinkVersion}"
+    api "org.apache.flink:flink-statebackend-rocksdb_${scalaBinaryVersion}:${flinkVersion}"
+    api "org.apache.flink:flink-streaming-java_${scalaBinaryVersion}:${flinkVersion}"
+    api "org.apache.flink:flink-streaming-scala_${scalaBinaryVersion}:${flinkVersion}"
+
+    flinkShadowJar "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
+    flinkShadowJar "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
+}

--- a/troubleshooting/common/src/main/java/com/ververica/flink/training/common/DoNotChangeThis.java
+++ b/troubleshooting/common/src/main/java/com/ververica/flink/training/common/DoNotChangeThis.java
@@ -1,0 +1,14 @@
+package com.ververica.flink.training.common;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Classes, methods or fields marked annotated with {@link DoNotChangeThis} should not be changed by training participants. They are either part of the required business logic, or usually outside of the scope of the Flink in a real-life scenario.
+ */
+@Retention(RetentionPolicy.SOURCE)
+@Target({ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.TYPE})
+public @interface DoNotChangeThis {
+}

--- a/troubleshooting/common/src/main/java/com/ververica/flink/training/common/EnvironmentUtils.java
+++ b/troubleshooting/common/src/main/java/com/ververica/flink/training/common/EnvironmentUtils.java
@@ -1,0 +1,81 @@
+package com.ververica.flink.training.common;
+
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.contrib.streaming.state.RocksDBStateBackend;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.state.filesystem.FsStateBackend;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.util.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Common functionality to set up execution environments for the troubleshooting training.
+ */
+public class EnvironmentUtils {
+	/**
+	 * Creates a streaming environment with a few pre-configured settings based on command-line
+	 * parameters.
+	 *
+	 * @throws IOException        if the local checkpoint directory for the file system state backend cannot be created
+	 * @throws URISyntaxException if <code>fsStatePath</code> is not a valid URI
+	 */
+	public static StreamExecutionEnvironment createConfiguredEnvironment(
+			final ParameterTool parameters) throws
+			IOException, URISyntaxException {
+		final boolean local = isLocal(parameters);
+
+		StreamExecutionEnvironment env;
+		if (local) {
+			env = StreamExecutionEnvironment.createLocalEnvironmentWithWebUI(new Configuration());
+
+			String statePath = parameters.get("fsStatePath");
+			Path checkpointPath;
+			if (statePath != null) {
+				FileUtils.deleteDirectory(new File(new URI(statePath)));
+				checkpointPath = Path.fromLocalFile(new File(new URI(statePath)));
+			} else {
+				checkpointPath =
+						Path.fromLocalFile(Files.createTempDirectory("checkpoints").toFile());
+			}
+
+			final StateBackend stateBackend;
+			if (parameters.has("useRocksDB")) {
+				stateBackend = new RocksDBStateBackend(checkpointPath.toUri());
+			} else {
+				stateBackend = new FsStateBackend(checkpointPath);
+			}
+			env.setStateBackend(stateBackend);
+		} else {
+			env = StreamExecutionEnvironment.getExecutionEnvironment();
+		}
+
+		final int parallelism = parameters.getInt("parallelism", -1);
+		if (parallelism > 0) {
+			env.setParallelism(parallelism);
+		}
+
+		env.getConfig().setGlobalJobParameters(parameters);
+		env.setRestartStrategy(RestartStrategies.fixedDelayRestart(
+				Integer.MAX_VALUE,
+				Time.of(15, TimeUnit.SECONDS) // delay
+		));
+		return env;
+	}
+
+	/**
+	 * Checks whether the environment should be set up in local mode (with Web UI,...).
+	 */
+	public static boolean isLocal(ParameterTool parameters) {
+		return parameters.getBoolean("local", false);
+	}
+}

--- a/troubleshooting/common/src/main/java/com/ververica/flink/training/common/FakeKafkaRecord.java
+++ b/troubleshooting/common/src/main/java/com/ververica/flink/training/common/FakeKafkaRecord.java
@@ -1,0 +1,92 @@
+package com.ververica.flink.training.common;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+@DoNotChangeThis
+@SuppressWarnings({"unused", "RedundantSuppression"})
+public class FakeKafkaRecord {
+
+	private long timestamp;
+	private byte[] key;
+	private byte[] value;
+	private int partition;
+
+	public FakeKafkaRecord() {
+	}
+
+	public FakeKafkaRecord(
+			final long timestamp,
+			final byte[] key,
+			final byte[] value,
+			final int partition) {
+		this.timestamp = timestamp;
+		this.key = key;
+		this.value = value;
+		this.partition = partition;
+	}
+
+	public long getTimestamp() {
+		return timestamp;
+	}
+
+	public void setTimestamp(final long timestamp) {
+		this.timestamp = timestamp;
+	}
+
+	public byte[] getKey() {
+		return key;
+	}
+
+	public void setKey(final byte[] key) {
+		this.key = key;
+	}
+
+	public byte[] getValue() {
+		return value;
+	}
+
+	public void setValue(final byte[] value) {
+		this.value = value;
+	}
+
+	public int getPartition() {
+		return partition;
+	}
+
+	public void setPartition(final int partition) {
+		this.partition = partition;
+	}
+
+	@Override
+	public boolean equals(final Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		final FakeKafkaRecord that = (FakeKafkaRecord) o;
+		return timestamp == that.timestamp &&
+				partition == that.partition &&
+				Arrays.equals(key, that.key) &&
+				Arrays.equals(value, that.value);
+	}
+
+	@Override
+	public int hashCode() {
+		int result = Objects.hash(timestamp, partition);
+		result = 31 * result + Arrays.hashCode(key);
+		result = 31 * result + Arrays.hashCode(value);
+		return result;
+	}
+
+	@Override
+	public String toString() {
+		return "FakeKafkaRecord{" + "timestamp=" + timestamp +
+				", key=" + Arrays.toString(key) +
+				", value=" + Arrays.toString(value) +
+				", partition=" + partition +
+				'}';
+	}
+}

--- a/troubleshooting/common/src/main/java/com/ververica/flink/training/common/FakeKafkaSource.java
+++ b/troubleshooting/common/src/main/java/com/ververica/flink/training/common/FakeKafkaSource.java
@@ -1,0 +1,144 @@
+package com.ververica.flink.training.common;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.BitSet;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * The {@link FakeKafkaSource} reads from {@code NO_OF_PARTIONS} Kafka partitions.
+ *
+ * <p>The timestamps roughly start at the epoch and are ascending per partition. The partitions themselves can be out of sync.
+ **
+ */
+@DoNotChangeThis
+public class FakeKafkaSource extends
+		RichParallelSourceFunction<FakeKafkaRecord> implements
+		CheckpointedFunction {
+	private static final long serialVersionUID = 4658785571367840693L;
+
+	private static final int NO_OF_PARTIONS = 8;
+	public static final Logger LOG = LoggerFactory.getLogger(FakeKafkaSource.class);
+
+	private final Random rand;
+
+	private transient volatile boolean cancelled;
+	private transient int indexOfThisSubtask;
+	private transient int numberOfParallelSubtasks;
+	private transient List<Integer> assignedPartitions;
+
+	private final List<byte[]> serializedMeasurements;
+	private final double poisonPillRate;
+	private final BitSet idlePartitions;
+
+	FakeKafkaSource(final int seed, final float poisonPillRate, List<Integer> idlePartitions,
+					List<byte[]> serializedMeasurements) {
+		this.poisonPillRate = poisonPillRate;
+		this.idlePartitions = new BitSet(NO_OF_PARTIONS);
+		for (int i : idlePartitions) {
+			this.idlePartitions.set(i);
+		}
+		this.serializedMeasurements = serializedMeasurements;
+
+		this.rand = new Random(seed);
+	}
+
+	@Override
+	public void open(final Configuration parameters) {
+		indexOfThisSubtask = getRuntimeContext().getIndexOfThisSubtask();
+		numberOfParallelSubtasks = getRuntimeContext().getNumberOfParallelSubtasks();
+
+		assignedPartitions = IntStream.range(0, NO_OF_PARTIONS)
+				.filter(i -> i % numberOfParallelSubtasks == indexOfThisSubtask)
+				.boxed()
+				.collect(Collectors.toList());
+
+		LOG.info("Now reading from partitions: {}", assignedPartitions);
+	}
+
+	@Override
+	public void run(
+			final SourceContext<FakeKafkaRecord> sourceContext)
+			throws Exception {
+
+		int numberOfPartitions = assignedPartitions.size();
+
+		if (!assignedPartitions.isEmpty()) {
+			while (!cancelled) {
+				int nextPartition = assignedPartitions.get(rand.nextInt(numberOfPartitions));
+
+				if (idlePartitions.get(nextPartition)) {
+					//noinspection BusyWait
+					Thread.sleep(1000); // avoid spinning wait
+					continue;
+				}
+
+				long nextTimestamp = getTimestampForPartition(nextPartition);
+
+				byte[] serializedMeasurement =
+						serializedMeasurements.get(rand.nextInt(serializedMeasurements.size()));
+
+				if (rand.nextFloat() > 1 - poisonPillRate) {
+					serializedMeasurement = Arrays.copyOf(serializedMeasurement, 10);
+				}
+
+				synchronized (sourceContext.getCheckpointLock()) {
+					sourceContext.collect(
+							new FakeKafkaRecord(
+									nextTimestamp, null, serializedMeasurement, nextPartition));
+				}
+			}
+		} else {
+			// this source doesn't have any partitions and thus never emits any records
+			// (and therefore also no watermarks), so we mark this subtask as idle to
+			// not block watermark forwarding
+			sourceContext.markAsTemporarilyIdle();
+
+			// wait until this is canceled
+			final Object waitLock = new Object();
+			while (!cancelled) {
+				try {
+					//noinspection SynchronizationOnLocalVariableOrMethodParameter
+					synchronized (waitLock) {
+						waitLock.wait();
+					}
+				} catch (InterruptedException e) {
+					if (cancelled) {
+						// restore the interrupted state, and fall through the loop
+						Thread.currentThread().interrupt();
+					}
+				}
+			}
+		}
+	}
+
+	private long getTimestampForPartition(int partition) {
+		return System.currentTimeMillis() - (partition * 50L);
+	}
+
+	@Override
+	public void cancel() {
+		cancelled = true;
+
+		// there will be an interrupt() call to the main thread anyways
+	}
+
+	@Override
+	public void snapshotState(final FunctionSnapshotContext context) {
+	}
+
+	@Override
+	public void initializeState(final FunctionInitializationContext context) {
+	}
+}

--- a/troubleshooting/common/src/main/java/com/ververica/flink/training/common/Measurement.java
+++ b/troubleshooting/common/src/main/java/com/ververica/flink/training/common/Measurement.java
@@ -1,0 +1,88 @@
+package com.ververica.flink.training.common;
+
+import java.util.Objects;
+
+@DoNotChangeThis
+@SuppressWarnings({"unused", "RedundantSuppression"})
+public class Measurement {
+
+	private int sensorId;
+	private double value;
+	private String location;
+	private String measurementInformation;
+
+	public Measurement() {
+	}
+
+	public Measurement(
+			final int sensorId,
+			final double value,
+			final String location,
+			final String measurementInformation) {
+		this.sensorId = sensorId;
+		this.value = value;
+		this.location = location;
+		this.measurementInformation = measurementInformation;
+	}
+
+	public String getMeasurementInformation() {
+		return measurementInformation;
+	}
+
+	public void setMeasurementInformation(final String measurementInformation) {
+		this.measurementInformation = measurementInformation;
+	}
+
+	public int getSensorId() {
+		return sensorId;
+	}
+
+	public void setSensorId(final int sensorId) {
+		this.sensorId = sensorId;
+	}
+
+	public double getValue() {
+		return value;
+	}
+
+	public void setValue(final double value) {
+		this.value = value;
+	}
+
+	public String getLocation() {
+		return location;
+	}
+
+	public void setLocation(final String location) {
+		this.location = location;
+	}
+
+	@Override
+	public boolean equals(final Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		final Measurement that = (Measurement) o;
+		return sensorId == that.sensorId &&
+				Double.compare(that.value, value) == 0 &&
+				Objects.equals(location, that.location) &&
+				Objects.equals(measurementInformation, that.measurementInformation);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(sensorId, value, location, measurementInformation);
+	}
+
+	@Override
+	public String toString() {
+		return "Measurement{" + "sensorId=" + sensorId +
+				", value=" + value +
+				", location='" + location + '\'' +
+				", measurementInformation='" + measurementInformation + '\'' +
+				'}';
+	}
+}

--- a/troubleshooting/common/src/main/java/com/ververica/flink/training/common/SourceUtils.java
+++ b/troubleshooting/common/src/main/java/com/ververica/flink/training/common/SourceUtils.java
@@ -1,0 +1,82 @@
+package com.ververica.flink.training.common;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+
+@DoNotChangeThis
+public class SourceUtils {
+
+	public static final Logger LOG = LoggerFactory.getLogger(SourceUtils.class);
+
+	public static final int NUM_OF_MEASUREMENTS = 100_000;
+	public static final int RANDOM_SEED = 1;
+	public static final float FAILURE_RATE = 0.0001f;
+	public static final List<Integer> IDLE_PARTITIONS = Arrays.asList(0, 4);
+
+	/**
+	 * Creates a source that resembles a real Kafka source but reads from memory.
+	 */
+	public static FakeKafkaSource createFakeKafkaSource() {
+		List<byte[]> serializedMeasurements = createSerializedMeasurements();
+		return new FakeKafkaSource(RANDOM_SEED, FAILURE_RATE, IDLE_PARTITIONS,
+				serializedMeasurements);
+	}
+
+	/**
+	 * Creates a source that resembles a failure-free Kafka source but reads from memory.
+	 */
+	public static FakeKafkaSource createFailureFreeFakeKafkaSource() {
+		List<byte[]> serializedMeasurements = createSerializedMeasurements();
+		return new FakeKafkaSource(RANDOM_SEED, 0.0f, Collections.emptyList(), serializedMeasurements);
+	}
+
+	private static List<byte[]> createSerializedMeasurements() {
+		Random rand = new Random(RANDOM_SEED);
+		ObjectMapper mapper = new ObjectMapper();
+
+		final List<String> locations = readLocationsFromFile();
+
+		List<byte[]> measurements = new ArrayList<>();
+		for (int i = 0; i < NUM_OF_MEASUREMENTS; i++) {
+			Measurement nextMeasurement = new Measurement(rand.nextInt(100),
+					rand.nextDouble() * 100, locations.get(rand.nextInt(locations.size())),
+					RandomStringUtils.randomAlphabetic(30));
+			try {
+				measurements.add(mapper.writeValueAsBytes(nextMeasurement));
+			} catch (JsonProcessingException e) {
+				LOG.error("Unable to serialize measurement.", e);
+				throw new RuntimeException(e);
+			}
+		}
+		return measurements;
+	}
+
+	private static List<String> readLocationsFromFile() {
+		List<String> locations = new ArrayList<>();
+		try (
+				InputStream is = SourceUtils.class.getResourceAsStream("/cities.csv");
+				BufferedReader br = new BufferedReader(new InputStreamReader(is))) {
+			String city;
+			while ((city = br.readLine()) != null) {
+				locations.add(city);
+			}
+		} catch (IOException e) {
+			LOG.error("Unable to read cities from file.", e);
+			throw new RuntimeException(e);
+		}
+		return locations;
+	}
+}

--- a/troubleshooting/common/src/main/java/com/ververica/flink/training/common/WindowedMeasurements.java
+++ b/troubleshooting/common/src/main/java/com/ververica/flink/training/common/WindowedMeasurements.java
@@ -1,0 +1,113 @@
+package com.ververica.flink.training.common;
+
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
+
+import java.util.Objects;
+
+@SuppressWarnings({"unused", "RedundantSuppression"})
+@DoNotChangeThis
+public class WindowedMeasurements {
+
+	private long windowStart;
+	private long windowEnd;
+	private String location;
+	private long eventsPerWindow;
+	private double sumPerWindow;
+
+	public WindowedMeasurements() {
+	}
+
+	public WindowedMeasurements(final long windowStart, final long windowEnd, final String location,
+								final long eventsPerWindow, final double sumPerWindow) {
+		this.windowStart = windowStart;
+		this.windowEnd = windowEnd;
+		this.location = location;
+		this.eventsPerWindow = eventsPerWindow;
+		this.sumPerWindow = sumPerWindow;
+	}
+
+	public long getWindowStart() {
+		return windowStart;
+	}
+
+	public void setWindowStart(final long windowStart) {
+		this.windowStart = windowStart;
+	}
+
+	public long getWindowEnd() {
+		return windowEnd;
+	}
+
+	public void setWindowEnd(final long windowEnd) {
+		this.windowEnd = windowEnd;
+	}
+
+	public void setWindow(TimeWindow window) {
+		setWindowStart(window.getStart());
+		setWindowEnd(window.getEnd());
+	}
+
+	public String getLocation() {
+		return location;
+	}
+
+	public void setLocation(final String location) {
+		this.location = location;
+	}
+
+	public long getEventsPerWindow() {
+		return eventsPerWindow;
+	}
+
+	public void setEventsPerWindow(final long eventsPerWindow) {
+		this.eventsPerWindow = eventsPerWindow;
+	}
+
+	public double getSumPerWindow() {
+		return sumPerWindow;
+	}
+
+	public void setSumPerWindow(final double sumPerWindow) {
+		this.sumPerWindow = sumPerWindow;
+	}
+
+	public void addMeasurement(Measurement measurement) {
+		addMeasurement(measurement.getValue());
+	}
+
+	public void addMeasurement(double value) {
+		sumPerWindow += value;
+		++eventsPerWindow;
+	}
+
+	@Override
+	public boolean equals(final Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		final WindowedMeasurements that = (WindowedMeasurements) o;
+		return windowStart == that.windowStart &&
+				windowEnd == that.windowEnd &&
+				eventsPerWindow == that.eventsPerWindow &&
+				Double.compare(that.sumPerWindow, sumPerWindow) == 0 &&
+				Objects.equals(location, that.location);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(windowStart, windowEnd, location, eventsPerWindow, sumPerWindow);
+	}
+
+	@Override
+	public String toString() {
+		return "WindowedMeasurements{" + "windowStart=" + windowStart +
+				", windowEnd=" + windowEnd +
+				", location='" + location + '\'' +
+				", eventsPerWindow=" + eventsPerWindow +
+				", sumPerWindow=" + sumPerWindow +
+				'}';
+	}
+}

--- a/troubleshooting/common/src/main/resources/cities.csv
+++ b/troubleshooting/common/src/main/resources/cities.csv
@@ -1,0 +1,23018 @@
+les Escaldes
+Andorra la Vella
+Umm al Qaywayn
+Ras al-Khaimah
+Khawr Fakkān
+Dubai
+Dibba Al-Fujairah
+Dibba Al-Hisn
+Sharjah
+Ar Ruways
+Al Fujayrah
+Al Ain
+Ajman
+Adh Dhayd
+Abu Dhabi
+Zaranj
+Taloqan
+Shīnḏanḏ
+Shibirghān
+Shahrak
+Sar-e Pul
+Sang-e Chārak
+Aībak
+Rustāq
+Qarqīn
+Qarāwul
+Pul-e Khumrī
+Paghmān
+Nahrīn
+Maymana
+Mehtar Lām
+Mazār-e Sharīf
+Lashkar Gāh
+Kushk
+Kunduz
+Khōst
+Khulm
+Khāsh
+Khanabad
+Karukh
+Kandahār
+Kabul
+Jalālābād
+Jabal os Saraj
+Herāt
+Ghormach
+Ghazni
+Gereshk
+Gardēz
+Fayzabad
+Farah
+Kafir Qala
+Charikar
+Barakī Barak
+Bāmyān
+Balkh
+Baghlān
+Ārt Khwājah
+Āsmār
+Asadābād
+Andkhōy
+Bāzārak
+Markaz-e Woluswalī-ye Āchīn
+Saint John’s
+The Valley
+Sarandë
+Kukës
+Korçë
+Gjirokastër
+Elbasan
+Burrel
+Vlorë
+Tirana
+Shkodër
+Patos Fshat
+Lushnjë
+Lezhë
+Laç
+Kuçovë
+Krujë
+Kavajë
+Fier-Çifçi
+Fier
+Durrës
+Berat
+Kapan
+Goris
+Hats’avan
+Artashat
+Ararat
+Yerevan
+Ejmiatsin
+Spitak
+Sevan
+Masis
+Vanadzor
+Gavarr
+Hrazdan
+Armavir
+Gyumri
+Ashtarak
+Abovyan
+Saurimo
+Lucapa
+Luau
+Uíge
+Soio
+Nzeto
+N’dalatando
+Mbanza Congo
+Malanje
+Luanda
+Caxito
+Cabinda
+Sumbe
+Namibe
+Menongue
+Luena
+Lubango
+Longonjo
+Lobito
+Cuito
+Huambo
+Catumbela
+Catabola
+Camacupa
+Caluquembe
+Caála
+Benguela
+Zárate
+Villa Ocampo
+Villa Lugano
+Villaguay
+Villa Gesell
+Tigre
+Tandil
+San Vicente
+Santo Tomé
+Santa Elena
+San Pedro
+San Luis del Palmar
+San Lorenzo
+San Javier
+San Isidro
+Saladas
+Retiro
+Resistencia
+Reconquista
+Quilmes
+Puerto Rico
+Puerto Iguazú
+Puerto Esperanza
+Puerto Eldorado
+Posadas
+Pontevedra
+Pirané
+Paso de los Libres
+Oberá
+Necochea
+Morón
+Monte Caseros
+Montecarlo
+Mercedes
+Mercedes
+Mar del Plata
+Luján
+La Plata
+La Paz
+Jardín América
+Gualeguaychú
+Gualeguay
+Goya
+Gobernador Ingeniero Valentín Virasoro
+General José de San Martín
+Garupá
+Formosa
+Fontana
+Federal
+Esquina
+El Soberbio
+Dolores
+Curuzú Cuatiá
+Corrientes
+Concordia
+Concepción del Uruguay
+Colegiales
+Chajarí
+Campana
+Buenos Aires
+Barranqueras
+Azul
+Avellaneda
+Aristóbulo del Valle
+Zapala
+Yerba Buena
+Villa Regina
+Villa Paula de Sarmiento
+Villa Nueva
+Villa María
+Villa Dolores
+Villa Constitución
+Villa Carlos Paz
+Villa Ángela
+Villa Allende
+Viedma
+Victoria
+Vera
+Venado Tuerto
+Veinticinco de Mayo
+Ushuaia
+Unquillo
+Tres Isletas
+Tres Arroyos
+Trelew
+Termas de Río Hondo
+Tartagal
+Tafí Viejo
+Sunchales
+Santo Tomé
+Santiago del Estero
+Santa Rosa
+Santa Lucía
+Santa Fe de la Vera Cruz
+San Salvador de Jujuy
+San Ramón de la Nueva Orán
+San Rafael
+San Pedro
+San Nicolás de los Arroyos
+San Miguel de Tucumán
+San Martín de los Andes
+San Martín
+San Luis
+San Justo
+San Juan
+San José de Jáchal
+San Jorge
+San Francisco
+San Fernando del Valle de Catamarca
+San Antonio Oeste
+Salta
+Rufino
+Rosario
+Río Tercero
+Río Segundo
+Río Gallegos
+Río Cuarto
+Río Ceballos
+Rawson
+Rafaela
+Quitilipi
+Punta Alta
+Puerto Madryn
+Presidencia Roque Sáenz Peña
+Pocito
+Plottier
+Pergamino
+Pérez
+Paraná
+Palpalá
+Olavarría
+Nueve de Julio
+Neuquén
+Morteros
+Monteros
+Mendoza
+Marcos Juárez
+Machagai
+Lincoln
+Libertador General San Martín
+Las Breñas
+La Rioja
+La Falda
+La Calera
+Laboulaye
+Junín
+Joaquín V. González
+Jesús María
+Granadero Baigorria
+Gobernador Gálvez
+General Roca
+General Pinedo
+General Pico
+General Enrique Mosconi
+Gálvez
+Firmat
+Famaillá
+Esquel
+Esperanza
+Embarcación
+Embalse
+El Bolsón
+Diamante
+Deán Funes
+Cutral-Có
+Cruz del Eje
+Crespo
+Cosquín
+Coronel Suárez
+Coronda
+Córdoba
+Comodoro Rivadavia
+Cipolletti
+Cinco Saltos
+Chivilcoy
+Chimbas
+Chilecito
+Charata
+Chacabuco
+Centenario
+Caucete
+Catriel
+Castelli
+Casilda
+Carcarañá
+Capitán Bermúdez
+Cañada de Gómez
+Caleta Olivia
+Bell Ville
+Bella Vista
+Bahía Blanca
+Arroyo Seco
+Arroyito
+Añatuya
+Alta Gracia
+Allen
+Alderetes
+Albardón
+Aguilares
+Villa Santa Rita
+Villa Mercedes
+San Carlos de Bariloche
+Adrogué
+Pago Pago
+Wolfsberg
+Wiener Neustadt
+Vienna
+Wels
+Weinzierl bei Krems
+Villach
+Traun
+Traiskirchen
+Ternitz
+Steyr
+Spittal an der Drau
+Schwechat
+Sankt Pölten
+Salzburg
+Saalfelden am Steinernen Meer
+Mödling
+Lustenau
+Linz
+Leonding
+Leoben
+Kufstein
+Krems an der Donau
+Klosterneuburg
+Klagenfurt am Wörthersee
+Kapfenberg
+Innsbruck
+Hallein
+Graz
+Feldkirch
+Dornbirn
+Bregenz
+Braunau am Inn
+Baden
+Amstetten
+Ansfelden
+Whyalla
+Rockingham
+Prospect
+Port Hedland
+Perth
+Murray Bridge
+Mount Isa
+Morphett Vale
+Mandurah
+Kwinana
+Kalgoorlie
+Gosnells
+Geraldton
+Gawler
+Fremantle
+Darwin
+Busselton
+Bunbury
+Armadale
+Alice Springs
+Albany
+Adelaide
+Woodridge
+Wodonga
+Werribee
+Warrnambool
+Wantirna South
+Wangaratta
+Wagga Wagga
+Traralgon
+Townsville
+Toowoomba
+Thornbury
+Thomastown
+Tarneit
+Taree
+Tamworth
+Sydney
+Surfers Paradise
+Sunnybank
+Sunbury
+Port Stephens
+Springvale
+Southport
+South Grafton
+Shepparton
+Seaford
+Saint Kilda
+Saint Albans
+Rowville
+Rockhampton
+Richmond
+Reservoir
+Queanbeyan
+Quakers Hill
+Preston
+Port Macquarie
+Point Cook
+Pakenham South
+Orange
+Nowra
+Northcote
+Noble Park
+Newcastle
+Nerang
+Narre Warren
+Narangba
+Mulgrave
+Mount Martha
+Mount Gambier
+Mount Eliza
+Mosman
+Mornington
+Morayfield
+Moe
+Mill Park
+Mildura
+Melton
+Melbourne
+Maryborough
+Marrickville
+Maroubra
+Maitland
+Mackay
+Liverpool
+Lismore
+Lilydale
+Launceston
+Lara
+Langwarrin
+Lalor
+Keysborough
+Kew
+Katoomba
+Hornsby
+Hobart
+Hawthorn South
+Hampton Park
+Griffith
+Greensborough
+Granville
+Goulburn
+Gold Coast
+Glenroy
+Glenferrie
+Gladstone
+Geelong
+Frankston East
+Frankston
+Forster
+Essendon
+Epping
+Epping
+Engadine
+Eltham
+Echuca
+Earlwood
+Dubbo
+Doncaster East
+Doncaster
+Devonport
+Deer Park
+Deception Bay
+Dandenong
+Cronulla
+Cranbourne
+Cranbourne
+Craigieburn
+Coffs Harbour
+Coburg
+Clayton
+Wollongong
+Cessnock
+Castle Hill
+Carrum Downs
+Carnegie
+Carlingford
+Caringbah
+Canberra
+Camberwell
+Caloundra
+Cairns
+Caboolture
+Burnie
+Bundaberg
+Buderim
+Brunswick
+Broken Hill
+Brisbane
+Boronia
+Blacktown
+Berwick
+Bendigo
+Baulkham Hills
+Bathurst
+Banora Point
+Bankstown
+Ballarat
+Auburn
+Ashfield
+Armidale
+Albury
+South Brisbane
+Cheltenham
+Randwick
+Dee Why
+Umina
+Palmerston
+Bracken Ridge
+North Ryde
+Hoppers Crossing
+Logan City
+Carindale
+Paramatta
+Ferntree Gully
+City of Parramatta
+Adelaide Hills
+Canning Vale
+Glenmore Park
+Glen Iris
+Balwyn North
+Carnegie
+Malvern East
+Brighton East
+Booval
+St Albans
+Endeavour Hills
+Clayton
+Taylors Lakes
+Roxburgh Park
+Wyndham Vale
+Willetton
+Thornbury
+Thornlie
+Hillside
+Bundoora
+Forest Lake
+Sunnybank Hills
+Narre Warren South
+Dandenong North
+Frankston South
+Sunshine West
+Altona Meadows
+West Pennant
+Oranjestad
+Babijn
+Angochi
+Mariehamn
+Xankandi
+Əhmədbəyli
+Shushi
+Salyan
+Saatlı
+Neftçala
+Nakhchivan
+Lankaran
+Imishli
+Fizuli
+Dzhalilabad
+Pushkino
+Beylagan
+Astara
+Şirvan
+Ağdam
+Zaqatala
+Zabrat
+Yevlakh
+Yelenendorf
+Xaçmaz
+Ujar
+Terter
+Sumqayıt
+Qaraçuxur
+Shamkhor
+Shamakhi
+Sheki
+Sabunçu
+Sabirabad
+Qusar
+Quba
+Hacıqabul
+Qazax
+Hacı Zeynalabdin
+Mingelchaur
+Maştağa
+Mardakan
+Lökbatan
+Kyurdarmir
+Khirdalan
+Yeni Suraxanı
+Geoktschai
+Hövsan
+Ganja
+Divichibazar
+Buzovna
+Biny Selo
+Barda
+Bilajari
+Baku
+Amirdzhan
+Aghsu
+Ağdaş
+Agdzhabedy
+Bakıxanov
+Zenica
+Visoko
+Velika Kladuša
+Tuzla
+Trebinje
+Travnik
+Sarajevo
+Prijedor
+Mostar
+Gradačac
+Gračanica
+Goražde
+Doboj
+Cazin
+Bugojno
+Brčko
+Bosanska Krupa
+Bijeljina
+Bihać
+Banja Luka
+Konjic
+Bridgetown
+Thākurgaon
+Teknāf
+Tungi
+Sylhet
+Dohār
+Jamālpur
+Shibganj
+Sātkhira
+Sirājganj
+Netrakona
+Narsingdi
+Sandwīp
+Shāhzādpur
+Rāmganj
+Rājshāhi
+Pirojpur
+Panchagarh
+Patiya
+Parbatipur
+Nārāyanganj
+Nālchiti
+Nāgarpur
+Nageswari
+Mymensingh
+Muktāgācha
+Mirzāpur
+Maulavi Bāzār
+Morrelgonj
+Mehendiganj
+Mathba
+Lalmanirhat
+Lākshām
+Comilla
+Rangpur
+Kushtia
+Kālīganj
+Jhingergācha
+Joypur Hāt
+Ishurdi
+Habiganj
+Gaurnadi
+Gafargaon
+Feni
+Rāipur
+Sarankhola
+Dhaka
+Chilmāri
+Chhāgalnāiya
+Lālmohan
+Khagrachhari
+Chhātak
+Bhātpāra Abhaynagar
+Bherāmāra
+Bhairab Bāzār
+Bāndarban
+Kālia
+Baniachang
+Bājitpur
+Badarganj
+Narail
+Tungipāra
+Sarishābāri
+Sakhipur
+Raojān
+Phultala
+Pālang
+Pār Naogaon
+Nabīnagar
+Lakshmīpur
+Kesabpur
+Hājīganj
+Farīdpur
+Dinājpur
+Uttar Char Fasson
+Chittagong
+Char Bhadrāsan
+Bera
+Burhānuddin
+Sātkania
+Cox’s Bāzār
+Khulna
+Bhola
+Barisāl
+Jessore
+Pābna
+Tāngāil
+Bogra
+Pīrgaaj
+Nawābganj
+Mādārīpur
+Sherpur
+Kishorganj
+Manikchari
+Bhāndāria
+Fatikchari
+Saidpur
+Azimpur
+Paltan
+Zwijndrecht
+Zwevegem
+Zottegem
+Zonhoven
+Zoersel
+Zemst
+Zele
+Zedelgem
+Zaventem
+Wuustwezel
+Willebroek
+Wevelgem
+Wetteren
+Westerlo
+Wervik
+Wavre
+Waterloo
+Waregem
+Walcourt
+Visé
+Vilvoorde
+Verviers
+Turnhout
+Tubize
+Tournai
+Torhout
+Tongeren
+Tienen
+Tielt
+Tessenderlo
+Tervuren
+Temse
+Stekene
+Stabroek
+Soumagne
+Soignies
+Sint-Truiden
+Sint-Pieters-Leeuw
+Sint-Niklaas
+Sint-Kruis
+Sint-Katelijne-Waver
+Sint-Gillis-Waas
+Sint-Genesius-Rode
+Seraing
+Schoten
+Schilde
+Saint-Nicolas
+Saint-Ghislain
+Rotselaar
+Ronse
+Roeselare
+Rixensart
+Riemst
+Ranst
+Quaregnon
+Puurs
+Putte
+Poperinge
+Pont-à-Celles
+Péruwelz
+Peer
+Overijse
+Oupeye
+Oudenaarde
+Oostkamp
+Ostend
+Nivelles
+Ninove
+Nijlen
+Neerpelt
+Namur
+Mouscron
+Mortsel
+Morlanwelz-Mariemont
+Mons
+Mol
+Middelkerke
+Merelbeke
+Menen
+Meise
+Mechelen
+Marche-en-Famenne
+Manage
+Maldegem
+Maasmechelen
+Maaseik
+Louvain-la-Neuve
+Londerzeel
+Lommel
+Lokeren
+Lochristi
+Lille
+Lier
+Liège
+Leuven
+Lessines
+Lede
+Lebbeke
+Lanaken
+La Louvière
+Kortrijk
+Kortenberg
+Kontich
+Koksijde
+Knokke-Heist
+Kasterlee
+Kapellen
+Kalmthout
+Izegem
+Ieper
+Huy
+Houthalen
+Hoogstraten
+Hoboken
+Heusden
+Herzele
+Herve
+Herstal
+Herentals
+Herent
+Helchteren
+Heist-op-den-Berg
+Hasselt
+Harelbeke
+Hamme
+Halle
+Haaltert
+Grimbergen
+Geraardsbergen
+Gent
+Genk
+Gembloux
+Geel
+Frameries
+Fleurus
+Fléron
+Flémalle-Haute
+Evergem
+Eupen
+Essen
+Eeklo
+Edegem
+Duffel
+Dour
+Dilbeek
+Diksmuide
+Diest
+Diepenbeek
+Destelbergen
+Dendermonde
+Denderleeuw
+Deinze
+Courcelles
+Colfontaine
+Chaudfontaine
+Châtelet
+Chasse Royale
+Charleroi
+Brussels
+Brugge
+Brecht
+Brasschaat
+Braine-le-Comte
+Braine-l'Alleud
+Boussu
+Bornem
+Boom
+Blankenberge
+Binche
+Bilzen
+Beveren
+Beringen
+Beersel
+Beerse
+Balen
+Ath
+Asse
+Arlon
+Antwerpen
+Ans
+Andenne
+Aarschot
+Aalter
+Aalst
+Zorgo
+Yako
+Tougan
+Titao
+Tenkodogo
+Réo
+Pô
+Ouahigouya
+Ouagadougou
+Nouna
+Manga
+Léo
+Koupéla
+Koudougou
+Kongoussi
+Kombissiri
+Kokologo
+Kaya
+Houndé
+Gourcy
+Garango
+Fada N'gourma
+Dori
+Djibo
+Diapaga
+Dédougou
+Boussé
+Boulsa
+Bobo-Dioulasso
+Banfora
+Gaoua
+Orodara
+Yambol
+Vratsa
+Vidin
+Velingrad
+Veliko Tŭrnovo
+Varna
+Targovishte
+Troyan
+Dobrich
+Svishtov
+Svilengrad
+Stara Zagora
+Dupnitsa
+Sofia
+Smolyan
+Sliven
+Silistra
+Shumen
+Sevlievo
+Sandanski
+Samokov
+Ruse
+Razgrad
+Rakovski
+Popovo
+Plovdiv
+Pleven
+Petrich
+Peshtera
+Pernik
+Pazardzhik
+Panagyurishte
+Nova Zagora
+Montana
+Lovech
+Lom
+Kyustendil
+Kardzhali
+Haskovo
+Kharmanli
+Kazanlŭk
+Karnobat
+Karlovo
+Gotse Delchev
+Gorna Oryakhovitsa
+Gabrovo
+Dimitrovgrad
+Chirpan
+Cherven Bryag
+Burgas
+Botevgrad
+Blagoevgrad
+Berkovitsa
+Aytos
+Asenovgrad
+Sitrah
+Madīnat ‘Īsá
+Jidd Ḩafş
+Madīnat Ḩamad
+Dār Kulayb
+Al Muharraq
+Manama
+Ar Rifā‘
+Makamba
+Bururi
+Bujumbura
+Muramvya
+Gitega
+Ruyigi
+Ngozi
+Kayanza
+Muyinga
+Rutana
+Tchaourou
+Tanguiéta
+Savé
+Savalou
+Sakété
+Porto-Novo
+Pobé
+Parakou
+Ouidah
+Nikki
+Natitingou
+Malanville
+Lokossa
+Kétou
+Kandi
+Dogbo
+Djougou
+Dassa-Zoumé
+Cové
+Cotonou
+Comé
+Bohicon
+Bembèrèkè
+Bassila
+Banikoara
+Aplahoué
+Allada
+Abomey-Calavi
+Abomey
+Gustavia
+Hamilton
+Tutong
+Seria
+Kuala Belait
+Bandar Seri Begawan
+Yacuiba
+Warnes
+Villazón
+Villa Yapacaní
+Villamontes
+Tupiza
+Trinidad
+Tarija
+Sucre
+Santiago del Torno
+Santa Cruz de la Sierra
+San Ignacio de Velasco
+San Borja
+Riberalta
+Punata
+Potosí
+Oruro
+Montero
+Mizque
+Llallagua
+La Paz
+Huanuni
+Guayaramerín
+Cotoca
+Cochabamba
+Cobija
+Camiri
+Kralendijk
+Vitória do Mearim
+Vitória de Santo Antão
+Viseu
+Conde
+Vigia
+Viçosa do Ceará
+Viçosa
+Viana
+Várzea Alegre
+Varjota
+Vargem Grande
+Valença do Piauí
+União dos Palmares
+União
+Tuntum
+Tucuruí
+Tucumã
+Trindade
+Trairi
+Toritama
+Tomé Açu
+Timon
+Timbiras
+Timbaúba
+Tianguá
+Teresina
+São João dos Inhamuns
+Tamandaré
+Tabira
+Surubim
+Sousa
+Soure
+Solânea
+Sobral
+Sirinhaém
+Sertânia
+Serra Talhada
+Senador Pompeu
+Satuba
+São Raimundo Nonato
+São Miguel dos Campos
+São Miguel do Guamá
+São Mateus do Maranhão
+São Luís do Quitunde
+São Luís
+São Lourenço da Mata
+São José do Egito
+São José de Ribamar
+São José de Mipibu
+São João dos Patos
+São Gonçalo do Amarante
+São Félix do Xingu
+São Domingos do Maranhão
+São Bento
+São Bento
+Santa Rita
+Santarém
+Santa Quitéria do Maranhão
+Santa Quitéria
+Santana do Ipanema
+Santa Luzia
+Santa Inês
+Santa Helena
+Santa Cruz do Capibaribe
+Santa Cruz
+Salinópolis
+Salgueiro
+Russas
+Rio Largo
+Rio Formoso
+Ribeirão
+Recife
+Quixeramobim
+Quixadá
+Presidente Dutra
+Santana
+Porto Calvo
+Portel
+Pombos
+Pombal
+Piripiri
+Piracuruca
+Pinheiro
+Pindaré Mirim
+Pilar
+Picos
+Petrolina
+Jatobá
+Pesqueira
+Pentecoste
+Penalva
+Pedro II
+Pedra Branca
+Paulo Afonso
+Paulista
+Patos
+Parnamirim
+Parnaíba
+Parintins
+Parelhas
+Paraipaba
+Paragominas
+Paracuru
+Palmares
+Pacatuba
+Pacajus
+Ouricuri
+Orós
+Oriximiná
+Olinda
+Oeiras
+Ábidos
+Nova Russas
+Nova Cruz
+Nazaré da Mata
+Natal
+Murici
+Moreno
+Morada Nova
+Monteiro
+Monte Alegre
+Mombaça
+Moju
+Mossoró
+Mocajuba
+Maués
+Matriz de Camaragibe
+Mari
+Marechal Deodoro
+Maragogi
+Maracanaú
+Marabá
+Mamanguape
+Maceió
+Macau
+Macapá
+Macaíba
+Limoeiro do Norte
+Limoeiro
+Lavras da Mangabeira
+Lajedo
+Lago da Pedra
+Lagoa do Itaenga
+Juazeiro do Norte
+José de Freitas
+João Pessoa
+João Câmara
+Jaguaruana
+Jaguaribe
+Jaboatão
+Itupiranga
+Itacoatiara
+Itaporanga
+Itapissuma
+Itapipoca
+Itapecuru Mirim
+Itapagé
+Itaituba
+Itaitinga
+Itabaiana
+Ipueiras
+Ipubi
+Ipu
+Ipojuca
+Imperatriz
+Iguatu
+Igarapé Miri
+Igarapé Açu
+Igarassu
+Icó
+Horizonte
+Guaraciaba do Norte
+Guarabira
+Guaiúba
+Gravatá
+Granja
+Grajaú
+Goiana
+Glória do Goitá
+Garanhuns
+Gameleira
+Fortaleza
+Floriano
+Floresta
+Eusébio
+Extremoz
+Estreito
+Esperantina
+Esperança
+Escada
+Dom Pedro
+Demerval Lobão
+Delmiro Gouveia
+Custódia
+Cururupu
+Currais Novos
+Cupira
+Crato
+Crateús
+Coroatá
+Condado
+Conceição do Araguaia
+Colinas
+Coelho Neto
+Codó
+Chapadinha
+Chã Grande
+Ceará Mirim
+Caxias
+Caucaia
+Catolé do Rocha
+Catende
+Castanhal
+Cascavel
+Caruaru
+Carpina
+Carolina
+Capitão Poço
+Capanema
+Canindé
+Canguaretama
+Campos Sales
+Campo Maior
+Campo Alegre
+Campina Grande
+Camocim
+Cametá
+Cajueiro
+Cajazeiras
+Caicó
+Cabrobó
+Cabo
+Cabedelo
+Buriti Bravo
+Buíque
+Breves
+Brejo Santo
+Brejo da Madre de Deus
+Bragança
+Bom Conselho
+Boa Viagem
+Bezerros
+Benevides
+Belo Jardim
+Belém
+Belém
+Beberibe
+Bayeux
+Baturité
+Barreiros
+Barreirinhas
+Barras
+Barra do Corda
+Barcarena
+Barbalha
+Balsas
+Bacabal
+Augusto Corrêa
+Atalaia
+Areia Branca
+Arcoverde
+Araripina
+Arari
+Arapiraca
+Araguaína
+Aracati
+Aquiraz
+Apodi
+Ananindeua
+Amaraji
+Altos
+Altamira
+Almeirim
+Alenquer
+Alagoa Grande
+Águas Belas
+Água Preta
+Afogados da Ingazeira
+Açu
+Acopiara
+Acaraú
+Abreu e Lima
+Abaetetuba
+Xique Xique
+Xanxerê
+Votuporanga
+Votorantim
+Volta Redonda
+Vitória da Conquista
+Vitória
+Visconde do Rio Branco
+Viradouro
+Vinhedo
+Vila Velha
+Videira
+Viçosa
+Viana
+Viamão
+Vespasiano
+Veranópolis
+Vera Cruz
+Wenceslau Braz
+Venâncio Aires
+Vazante
+Vassouras
+Várzea Paulista
+Várzea Grande
+Várzea da Palma
+Varginha
+Vargem Grande do Sul
+Valparaíso
+Valinhos
+Valença
+Valença
+Vacaria
+Uruguaiana
+Uruçuca
+Uruaçu
+União da Vitória
+Unaí
+Una
+Umuarama
+Uberlândia
+Uberaba
+Ubatuba
+Ubatã
+Ubaitaba
+Ubá
+Tupanciretã
+Tupaciguara
+Tupã
+Tucano
+Tubarão
+Trindade
+Três Rios
+Três Pontas
+Três Passos
+Três Lagoas
+Três de Maio
+Três Coroas
+Três Corações
+Tremembé
+Tramandaí
+Torres
+Toledo
+Tobias Barreto
+Timóteo
+Timbó
+Tijucas
+Tietê
+Teutônia
+Teresópolis
+Teófilo Otoni
+Teodoro Sampaio
+Telêmaco Borba
+Taubaté
+Tatuí
+Taquarituba
+Taquaritinga
+Taquari
+Taquara
+Tapiramutá
+Tapes
+Tanguá
+Tanabi
+Tambaú
+Taiobeiras
+Taboão da Serra
+Suzano
+Sumaré
+Sorocaba
+Soledade
+Socorro
+Sobradinho
+Simão Dias
+Silva Jardim
+Sidrolândia
+Sete Lagoas
+Sertãozinho
+Serrinha
+Serra Negra
+Serrana
+Serra
+Seropédica
+Senhor do Bonfim
+Senador Canedo
+Seabra
+Schroeder
+Saubara
+Sarzedo
+Sarandi
+Sarandi
+Saquarema
+Sapucaia
+Sapiranga
+São Vicente
+São Sepé
+São Sebastião do Passé
+São Sebastião do Paraíso
+São Sebastião do Caí
+São Sebastião
+São Roque
+São Pedro da Aldeia
+São Pedro
+São Paulo
+São Miguel do Iguaçu
+São Miguel do Araguaia
+São Mateus do Sul
+São Mateus
+São Marcos
+São Manuel
+São Luiz Gonzaga
+São Luís de Montes Belos
+São Lourenço do Sul
+São Lourenço
+São Leopoldo
+São José dos Pinhais
+São José dos Campos
+São José do Rio Preto
+São José do Rio Pardo
+São José
+São Joaquim da Barra
+São Joaquim
+São João Nepomuceno
+São João de Meriti
+São João del Rei
+São João da Boa Vista
+São João da Barra
+São Jerônimo
+São Gotardo
+São Gonçalo do Sapucaí
+São Gabriel
+São Francisco do Sul
+São Francisco do Conde
+São Francisco
+São Fidélis
+São Cristóvão
+São Carlos
+São Caetano do Sul
+São Borja
+São Bernardo do Campo
+São Bento do Sul
+Santos Dumont
+Santos
+Santo Estêvão
+Santo Antônio do Monte
+Santo Antônio do Amparo
+Santo Antônio de Posse
+Santo Antônio de Pádua
+Santo Antônio de Jesus
+Santo Antônio da Platina
+Santo Ângelo
+Santo André
+Santo Anastácio
+Santo Amaro da Imperatriz
+Santo Amaro
+Santiago
+Santa Vitória do Palmar
+Santa Rosa de Viterbo
+Santa Rosa
+Santa Rita do Sapucaí
+Santa Rita do Passa Quatro
+Santana do Paraíso
+Santana do Livramento
+Santana de Parnaíba
+Santa Maria da Vitória
+Santa Maria
+Santa Luzia
+Santaluz
+Santa Isabel
+Santa Helena de Goiás
+Santa Gertrudes
+Santa Fé do Sul
+Santa Cruz do Sul
+Santa Cruz do Rio Pardo
+Santa Cruz das Palmeiras
+Santa Cruz Cabrália
+Santa Cecília
+Santa Bárbara d'Oeste
+Salvador
+Salto de Pirapora
+Salto
+Salinas
+Sacramento
+Ruy Barbosa
+Rubiataba
+Rosário do Sul
+Rondonópolis
+Rolante
+Rolândia
+Rio Verde de Mato Grosso
+Rio Real
+Rio Pardo
+Rio Negro
+Rio Negrinho
+Rio Grande da Serra
+Rio Grande
+Rio do Sul
+Rio de Janeiro
+Rio das Pedras
+Rio das Ostras
+Rio Claro
+Rio Brilhante
+Rio Branco do Sul
+Rio Bonito
+Ribeirão Preto
+Ribeirão Pires
+Ribeirão das Neves
+Ribeirão da Ilha
+Ribeira do Pombal
+Riachão do Jacuípe
+Resplendor
+Resende
+Registro
+Regente Feijó
+Rancharia
+Quirinópolis
+Queimados
+Quatro Barras
+Quaraí
+Prudentópolis
+Propriá
+Promissão
+Presidente Venceslau
+Presidente Prudente
+Presidente Epitácio
+Prata
+Praia Grande
+Prado
+Pouso Alegre
+Posse
+Porto União
+Porto Seguro
+Porto Ferreira
+Porto Feliz
+Porto Alegre
+Portão
+Porangatu
+Pontes e Lacerda
+Ponte Nova
+Ponta Porã
+Pontal
+Ponta Grossa
+Pompéu
+Pompéia
+Pomerode
+Poços de Caldas
+Poconé
+Poções
+Poá
+Planaltina
+Piúma
+Piuí
+Pitangui
+Pitangueiras
+Pitanga
+Piritiba
+Pires do Rio
+Piraquara
+Pirapozinho
+Pirapora
+Pirajuí
+Piraju
+Piraí do Sul
+Piraí
+Pirassununga
+Piracicaba
+Piracanjuba
+Piracaia
+Pinheiral
+Pinhão
+Espírito Santo do Pinhal
+Pindobaçu
+Pindamonhangaba
+Pilar do Sul
+Piedade
+Petrópolis
+Peruíbe
+Pereira Barreto
+Perdões
+Penha
+Penedo
+Penápolis
+Pelotas
+Pedro Leopoldo
+Pedreira
+Pedra Azul
+Pederneiras
+Paulínia
+Patrocínio
+Patos de Minas
+Pato Branco
+Paty do Alferes
+Passos
+Passo Fundo
+Parobé
+Paraty
+Paranavaí
+Paranapanema
+Paranaíba
+Paranaguá
+Paraíba do Sul
+Paraguaçu Paulista
+Paraguaçu
+Pará de Minas
+Paracatu
+Paracambi
+Panambi
+Palotina
+Palmital
+Palmeira das Missões
+Palmeira
+Palmas
+Palhoça
+Paiçandu
+Padre Bernardo
+Ouro Preto
+Ouro Branco
+Ourinhos
+Osvaldo Cruz
+Osório
+Osasco
+Orleans
+Orlândia
+Oliveira
+Olímpia
+Novo Horizonte
+Novo Hamburgo
+Nova Viçosa
+Nova Venécia
+Nova Prata
+Nova Petrópolis
+Nova Olímpia
+Nova Odessa
+Nova Lima
+Nova Iguaçu
+Nova Granada
+Nova Friburgo
+Nova Era
+Nossa Senhora do Socorro
+Nossa Senhora da Glória
+Niterói
+Niquelândia
+Nilópolis
+Nerópolis
+Nepomuceno
+Nazaré
+Naviraí
+Navegantes
+Nanuque
+Muzambinho
+Muritiba
+Muriaé
+Mucuri
+Morro do Chapéu
+Morro Agudo
+Morrinhos
+Montes Claros
+Monte Santo de Minas
+Montenegro
+Monte Mor
+Monte Carmelo
+Monte Azul Paulista
+Monte Aprazível
+Monte Alto
+Mongaguá
+Mogi Mirim
+Mogi-Gaucu
+Mogi das Cruzes
+Mococa
+Mirandopólis
+Miracema
+Mineiros
+Miguel Pereira
+Miguelópolis
+Mendes
+Medianeira
+Medeiros Neto
+Mauá
+Matozinhos
+Mateus Leme
+Matão
+Mata de São João
+Mascote
+Martinópolis
+Maringá
+Marília
+Maricá
+Mariana
+Marialva
+Marechal Cândido Rondon
+Marau
+Marataizes
+Maragogipe
+Maracás
+Maracaju
+Manhumirim
+Manhuaçu
+Mangaratiba
+Mandaguari
+Mairiporã
+Mairinque
+Mafra
+Machado
+Macatuba
+Macaé
+Luziânia
+Lucas
+Louveira
+Lorena
+Londrina
+Loanda
+Livramento do Brumado
+Lins
+Linhares
+Limeira
+Leopoldina
+Lençóis Paulista
+Leme
+Lavras
+Laranjeiras do Sul
+Laranjeiras
+Laranjal Paulista
+Lapa
+Lajinha
+Lages
+Lajeado
+Laguna
+Lagoa Vermelha
+Lagoa Santa
+Lagoa da Prata
+Lagarto
+Ladário
+Jundiaí
+Júlio de Castilhos
+Juiz de Fora
+Juatuba
+José Bonifácio
+Joinville
+João Pinheiro
+João Monlevade
+Joaçaba
+Jeremoabo
+Jequitinhonha
+Jequié
+Jaú
+Jataí
+Jarinu
+Jardinópolis
+Jardim
+Jaraguá do Sul
+Jaraguá
+Japeri
+Januária
+Jandira
+Jandaia do Sul
+Janaúba
+Jales
+Jaguariúna
+Jaguariaíva
+Jaguarari
+Jaguarão
+Jaguaquara
+Jacutinga
+Jacobina
+Jaciara
+Jacarezinho
+Jacareí
+Jaboticabal
+Ivoti
+Ituverava
+Iturama
+Itupeva
+Itumbiara
+Ituiutaba
+Ituberá
+Itu
+Itororó
+Itaúna
+Itatinga
+Itatiba
+Itararé
+Itaqui
+Itaquaquecetuba
+Itapuranga
+Itápolis
+Itapira
+Itapevi
+Itapeva
+Itapetininga
+Itapetinga
+Itaperuna
+Itaperuçu
+Itapemirim
+Itapema
+Itapecerica da Serra
+Itapecerica
+Itaparica
+Itapaci
+Itaocara
+Itanhaém
+Itambé
+Itamarandiba
+Itamaraju
+Itajuípe
+Itajubá
+Itajaí
+Itaí
+Itaguaí
+Itabuna
+Itaboraí
+Itabirito
+Itabira
+Itaberaí
+Itaberaba
+Itabaianinha
+Itabaiana
+Irecê
+Irati
+Iracemápolis
+Iporá
+Ipirá
+Ipiaú
+Iperó
+Ipatinga
+Ipameri
+Ipaba
+Inhumas
+Indaiatuba
+Indaial
+Imbituva
+Imbituba
+Ilhéus
+Ilha Solteira
+Ilhabela
+Ijuí
+Iguape
+Igrejinha
+Igarapé
+Igarapava
+Igaraçu do Tietê
+Içara
+Ibotirama
+Ibiúna
+Ibitinga
+Ibirité
+Ibirataia
+Ibirama
+Ibiporã
+Ibicaraí
+Ibiá
+Ibaté
+Ibaiti
+Iaçu
+Hortolândia
+Herval
+Gurupi
+Guaxupé
+Guarulhos
+Guarujá
+Guariba
+Guaratuba
+Guaratinguetá
+Guararema
+Guararapes
+Guarapuava
+Guarapari
+Guaranésia
+Guaramirim
+Guará
+Guaporé
+Guapimirim
+Guanhães
+Guanambi
+Guaíra
+Guaçuí
+Gravataí
+Governador Valadares
+Goiatuba
+Goiás
+Goianira
+Goiânia
+Goianésia
+Gaspar
+Garibaldi
+Garça
+Gandu
+Frutal
+Frederico Westphalen
+Franco da Rocha
+Francisco Morato
+Francisco Beltrão
+Franca
+Foz do Iguaçu
+Forquilhinha
+Formosa
+Formiga
+Florianópolis
+Flores da Cunha
+Ferraz de Vasconcelos
+Fernandópolis
+Feira de Santana
+Farroupilha
+Euclides da Cunha
+Estrela
+Esteio
+Estância Velha
+Estância
+Esplanada
+Espinosa
+Esmeraldas
+Erechim
+Entre Rios
+Encruzilhada do Sul
+Encantado
+Embu Guaçu
+Embu
+Elói Mendes
+Duque de Caxias
+Dourados
+Dom Pedrito
+Dois Vizinhos
+Dois Córregos
+Divinópolis
+Diamantino
+Diamantina
+Diadema
+Descalvado
+Curvelo
+Curitibanos
+Curitiba
+Cuiabá
+Cubatão
+Cruzeiro do Oeste
+Cruzeiro
+Cruz das Almas
+Cruz Alta
+Cristalina
+Criciúma
+Cravinhos
+Coxim
+Cotia
+Cosmópolis
+Coruripe
+Corumbá
+Coronel Vivida
+Coronel Fabriciano
+Coromandel
+Cornélio Procópio
+Corinto
+Cordeirópolis
+Cordeiro
+Contagem
+Conselheiro Lafaiete
+Congonhas
+Conde
+Concórdia
+Conchal
+Conceição do Coité
+Conceição do Jacuípe
+Conceição das Alagoas
+Conceição da Feira
+Conceição da Barra
+Colorado
+Colombo
+Colatina
+Coaraci
+Cláudio
+Cícero Dantas
+Cianorte
+Charqueadas
+Chapecó
+Cerquilho
+Ceres
+Celso Ramos
+Caxias do Sul
+Caxambu
+Catu
+Catanduva
+Catalão
+Cataguases
+Castro
+Castelo
+Cassilândia
+Casimiro de Abreu
+Cascavel
+Casa Branca
+Carmo do Paranaíba
+Carmo do Cajuru
+Carlos Barbosa
+Carazinho
+Caratinga
+Carapicuíba
+Carangola
+Carandaí
+Caraguatatuba
+Capivari
+Capinzal
+Capim Grosso
+Capelinha
+Capela
+Capão da Canoa
+Capâo Bonito
+Canoinhas
+Canoas
+Canguçu
+Canela
+Cândido Mota
+Candelária
+Canavieiras
+Campo Verde
+Campos Novos
+Campos Gerais
+Campos do Jordão
+Campos Belos
+Campos
+Campo Mourão
+Campo Largo
+Campo Grande
+Campo Formoso
+Campo Belo
+Campinas
+Campina Grande do Sul
+Cambuí
+Cambé
+Cambará
+Camaquã
+Camanducaia
+Camaçari
+Caldas Novas
+Cajuru
+Cajati
+Cajamar
+Caieiras
+Caetité
+Caeté
+Cachoeiro de Itapemirim
+Cachoeirinha
+Cachoeiras de Macacu
+Cachoeira do Sul
+Cachoeira
+Caçapava do Sul
+Caçapava
+Caçador
+Cabreúva
+Cabo Frio
+Butiá
+Buritizeiro
+Buritis
+Buri
+Buerarema
+Brusque
+Brumado
+Brumadinho
+Brotas
+Brodósqui
+Brasília
+Bragança Paulista
+Braço do Norte
+Botucatu
+Bom Jesus do Itabapoana
+Bom Jesus da Lapa
+Bom Despacho
+Boituva
+Bocaiúva
+Boa Esperança
+Blumenau
+Biritiba Mirim
+Birigui
+Biguaçu
+Betim
+Bertioga
+Bento Gonçalves
+Belo Oriente
+Belo Horizonte
+Belford Roxo
+Bela Vista
+Bebedouro
+Bauru
+Batatais
+Bastos
+Barueri
+Barroso
+Barrinha
+Barretos
+Barreiro do Jaíba
+Barreiras
+Barra Velha
+Barra Mansa
+Barra dos Coqueiros
+Barra do Piraí
+Barra do Garças
+Barra do Bugres
+Barra de São Francisco
+Barra Bonita
+Barra
+Bariri
+Barbacena
+Barão de Cocais
+Bandeirantes
+Bambuí
+Balneário Camboriú
+Baixo Guandu
+Bagé
+Avaré
+Atibaia
+Astorga
+Assis
+Arujá
+Artur Nogueira
+Arroio Grande
+Arroio do Meio
+Arraial do Cabo
+Armação de Búzios
+Arcos
+Araxá
+Araucária
+Araruama
+Araras
+Araraquara
+Araranguá
+Arapongas
+Araguari
+Aragarças
+Araçuaí
+Aracruz
+Araçoiaba da Serra
+Araci
+Araçatuba
+Aracaju
+Aquidauana
+Apucarana
+Apiaí
+Aparecida do Taboado
+Aparecida
+Antonina
+Anicuns
+Angra dos Reis
+Andradina
+Andradas
+Anastácio
+Anápolis
+Amparo
+Américo Brasiliense
+Americana
+Amargosa
+Álvares Machado
+Almirante Tamandaré
+Almenara
+Alfenas
+Além Paraíba
+Alegrete
+Alegre
+Alagoinhas
+Aimorés
+Agudos
+Águas Vermelhas
+Águas de Lindóia
+Aguaí
+Adamantina
+Abaeté
+Guaíba
+Palmas
+Tefé
+Tarauacá
+Tabatinga
+Sena Madureira
+São Gabriel da Cachoeira
+Rio Branco
+Porto Velho
+Manaus
+Manacapuru
+Humaitá
+Fonte Boa
+Eirunepé
+Cruzeiro do Sul
+Coari
+Carauari
+Boa Vista
+Ariquemes
+Aripuanã
+Vilhena
+Pôsto Fiscal Rolim de Moura
+Pimenta Bueno
+Ouro Preto do Oeste
+Ji Paraná
+Jaru
+Guajará Mirim
+Cacoal
+Aparecida de Goiânia
+Campinas
+Jaboatão dos Guararapes
+Lauro de Freitas
+Pinhais
+Rio Preto da Eva
+Simões Filho
+Sinop
+Cambebba
+Trindade
+Freguesia do Ribeirao da Ilha
+Nassau
+Lucaya
+Freeport
+Thimphu
+Punākha
+Phuntsholing
+Tsirang
+Tonota
+Thamaga
+Serowe
+Selebi-Phikwe
+Ramotswa
+Palapye
+Mosopa
+Molepolole
+Mogoditshane
+Mochudi
+Maun
+Mahalapye
+Lobatse
+Letlhakane
+Kanye
+Janeng
+Gaborone
+Francistown
+Horad Zhodzina
+Zhlobin
+Vitebsk
+Vilyeyka
+Vawkavysk
+Svyetlahorsk
+Stowbtsy
+Smarhon’
+Slutsk
+Slonim
+Shchuchin
+Salihorsk
+Rahachow
+Rechytsa
+Pruzhany
+Polatsk
+Pinsk
+Pastavy
+Asipovichy
+Orsha
+Novoye Medvezhino
+Navapolatsk
+Navahrudak
+Minsk
+Mazyr
+Masty
+Mar’’ina Horka
+Maladzyechna
+Mahilyow
+Lyepyel’
+Luninyets
+Lida
+Krychaw
+Kalodzishchy
+Kobryn
+Kalinkavichy
+Ivatsevichy
+Hrodna
+Horki
+Gomel
+Hlybokaye
+Dzyarzhynsk
+Dobrush
+Bykhaw
+Byaroza
+Brest
+Horad Barysaw
+Baranovichi
+Babruysk
+Malinovka
+San Ignacio
+Orange Walk
+Belmopan
+Belize City
+Abbotsford
+Airdrie
+Ajax
+Alma
+Amos
+Anmore
+Baie-Comeau
+Barrie
+Beaconsfield
+Belleville
+Beloeil
+Blainville
+Boisbriand
+Boucherville
+Bradford West Gwillimbury
+Brampton
+Brandon
+Brant
+Brantford
+Brockville
+Brossard
+Burlington
+Burnaby
+Calgary
+Cambridge
+Campbell River
+Camrose
+Candiac
+Chambly
+Charlottetown
+Châteauguay
+Chilliwack
+Clarence-Rockland
+Cobourg
+Cochrane
+Collingwood
+Conception Bay South
+Coquitlam
+Corner Brook
+Cornwall
+Côte-Saint-Luc
+Courtenay
+Cranbrook
+Dartmouth
+Delta
+Deux-Montagnes
+Dieppe
+Dollard-Des Ormeaux
+Dorval
+Drummondville
+Duncan
+Edmonton
+Etobicoke
+Fort Erie
+Fort McMurray
+Fort St. John
+Fredericton
+Gatineau
+Glace Bay
+Granby
+Grande Prairie
+Greater Sudbury
+Greater Napanee
+Guelph
+Hamilton
+Huntsville
+Joliette
+Kamloops
+Kelowna
+Keswick
+Kingston
+Kirkland
+Kitchener
+Langford
+Langley
+Langley
+La Prairie
+L'Assomption
+Laval
+Leduc
+Lethbridge
+Lloydminster
+London
+Longueuil
+Magog
+Maple Ridge
+Markham
+Mascouche
+Medicine Hat
+Midland
+Milton
+Mirabel
+Miramichi
+Mississauga
+Moncton
+Montréal
+Mont-Royal
+Mont-Saint-Hilaire
+Moose Jaw
+Mount Pearl
+Nanaimo
+New Glasgow
+Newmarket
+New Westminster
+Niagara Falls
+Norfolk County
+North Battleford
+North Bay
+North Cowichan
+North Vancouver
+North York
+Oak Bay
+Oakville
+Orangeville
+Orillia
+Oshawa
+Ottawa
+Owen Sound
+Parksville
+Pembroke
+Penticton
+Petawawa
+Peterborough
+Pickering
+Pitt Meadows
+Pointe-Claire
+Port Alberni
+Port Colborne
+Port Moody
+Prince Albert
+Prince Edward
+Prince George
+Quinte West
+Rayside-Balfour
+Red Deer
+Regina
+Repentigny
+Richmond
+Richmond Hill
+Rouyn-Noranda
+Saguenay
+Saint-Basile-le-Grand
+Saint-Bruno-de-Montarville
+Saint-Constant
+Sainte-Catherine
+Sainte-Julie
+Sainte-Thérèse
+Saint-Eustache
+Saint-Hyacinthe
+Saint-Jean-sur-Richelieu
+Saint-Jérôme
+Saint John
+Saint-Laurent
+Saint-Lazare
+Saint-Léonard
+Salaberry-de-Valleyfield
+Salmon Arm
+Sarnia
+Saskatoon
+Sault Ste. Marie
+Sept-Îles
+Shawinigan
+Sherbrooke
+Sherwood Park
+Sorel-Tracy
+Spruce Grove
+St. Albert
+St. Catharines
+Stratford
+St. Thomas
+Surrey
+Terrace
+Terrebonne
+Thorold
+Thunder Bay
+Timmins
+Toronto
+Trois-Rivières
+Truro
+Val-d'Or
+Vancouver
+Varennes
+Vaudreuil-Dorion
+Vaughan
+Vernon
+Victoria
+Victoriaville
+Waterloo
+Welland
+West End
+Westmount
+Whitehorse
+White Rock
+Windsor
+Winnipeg
+Woodstock
+Yellowknife
+Yorkton
+Halifax
+St. John's
+Québec
+Lévis
+Rimouski
+Rivière-du-Loup
+Sydney
+L'Ancienne-Lorette
+Edmundston
+Thetford-Mines
+Scarborough
+Cole Harbour
+Okanagan
+West Kelowna
+Bellechasse Regional County Municipality
+Jonquière
+Saint-Augustin-de-Desmaures
+Ladner
+Walnut Grove
+Ancaster
+West Vancouver
+Willowdale
+Lower Sacvkille
+West Island
+Yangambi
+Watsa
+Wamba
+Uvira
+Tshikapa
+Sake
+Mwene-Ditu
+Mweka
+Mbuji-Mayi
+Lusambo
+Luebo
+Lubao
+Lodja
+Lisala
+Kongolo
+Kisangani
+Kindu
+Kasongo
+Kananga
+Kampene
+Kamina
+Kalemie
+Kabinda
+Kabare
+Kabalo
+Isiro
+Ilebo
+Goma
+Gbadolite
+Gandajika
+Demba
+Butembo
+Buta
+Businga
+Bunia
+Bumba
+Bukavu
+Bukama
+Bondo
+Boende
+Beni
+Basoko
+Aketi
+Lubumbashi
+Likasi
+Kolwezi
+Kipushi
+Kambove
+Tshela
+Nioki
+Mushie
+Mbanza-Ngungu
+Mbandaka
+Matadi
+Mangai
+Libenge
+Kinshasa
+Kikwit
+Kasongo-Lunda
+Kasangulu
+Inongo
+Gemena
+Bulungu
+Bolobo
+Bandundu
+Masina
+Mobaye
+Ippy
+Bria
+Bangassou
+Bambari
+Sibut
+Paoua
+Nola
+Mbaïki
+Kaga Bandoro
+Damara
+Carnot
+Bozoum
+Bouar
+Bossangoa
+Boda
+Bimbo
+Berbérati
+Batangafo
+Bangui
+Sibiti
+Pointe-Noire
+Owando
+Ouésso
+Mossendjo
+Madingou
+Dolisie
+Loandjili
+Kayes
+Impfondo
+Gamboma
+Brazzaville
+Zürich
+Zug
+Yverdon-les-Bains
+Winterthur
+Wil
+Wettingen
+Vevey
+Vernier
+Uster
+Thun
+Steffisburg
+Sitten
+Sierre
+Zürich (Kreis 11) / Seebach
+Schaffhausen
+Sankt Gallen
+Renens
+Rapperswil
+Pully
+Onex
+Olten
+Zürich (Kreis 11) / Oerlikon
+Nyon
+Neuchâtel
+Muttenz
+Montreux
+Monthey
+Meyrin
+Luzern
+Lugano
+Littau
+Le Châtelard
+Lausanne
+La Chaux-de-Fonds
+Kriens
+Kreuzlingen
+Köniz
+Kloten
+Jona
+Horgen
+Zürich (Kreis 10) / Höngg
+Herisau
+Grenchen
+Gossau
+Genève
+Fribourg
+Frauenfeld
+Emmen
+Dübendorf
+Dietikon
+Chur
+Carouge
+Biel/Bienne
+Bern
+Bellinzona
+Basel
+Baden
+Baar
+Zürich (Kreis 4)
+Allschwil
+Adliswil
+Aarau
+Riehen
+Zürich (Kreis 10) / Wipkingen
+Zürich (Kreis 11) / Affoltern
+Zürich (Kreis 2) / Wollishofen
+Zürich (Kreis 3) / Sihlfeld
+Zürich (Kreis 6) / Unterstrass
+Zürich (Kreis 9) / Albisrieden
+Zürich (Kreis 9) / Altstetten
+Stadt Winterthur (Kreis 1)
+Zürich (Kreis 12)
+Seen (Kreis 3)
+Zürich (Kreis 3)
+Zürich (Kreis 11)
+Zürich (Kreis 9)
+Oberwinterthur (Kreis 2)
+Zürich (Kreis 10)
+Zürich (Kreis 2)
+Zürich (Kreis 8)
+Zürich (Kreis 7)
+Zürich (Kreis 6)
+Lancy
+Zuénoula
+Yamoussoukro
+Vavoua
+Toumodi
+Touba
+Tengrela
+Tiassalé
+Tanda
+Tabou
+Sinfra
+Sassandra
+San-Pédro
+Sakassou
+Oumé
+Odienné
+Mankono
+Man
+Lakota
+Korhogo
+Katiola
+Issia
+Guiglo
+Grand-Bassam
+Affery
+Gagnoa
+Ferkessédougou
+Duekoué
+Divo
+Dimbokro
+Daoukro
+Danané
+Daloa
+Dabou
+Boundiali
+Bouna
+Bouaké
+Bouaflé
+Bonoua
+Bongouanou
+Bondoukou
+Bingerville
+Biankouma
+Béoumi
+Bangolo
+Arrah
+Anyama
+Akoupé
+Agnibilékrou
+Agboville
+Adzopé
+Adiaké
+Aboisso
+Abobo
+Abidjan
+Abengourou
+Séguéla
+Soubré
+Avarua
+Viña del Mar
+Villarrica
+Villa Alemana
+Victoria
+Valparaíso
+Vallenar
+Valdivia
+Tomé
+Tocopilla
+Temuco
+Talcahuano
+Talca
+Talagante
+San Vicente de Tagua Tagua
+San Vicente
+Santiago
+Santa Cruz
+San Javier
+San Felipe
+San Carlos
+San Bernardo
+San Antonio
+Río Bueno
+Rengo
+Rancagua
+Quilpué
+Quillota
+Punta Arenas
+Puerto Varas
+Puerto Quellón
+Puerto Natales
+Puerto Montt
+Puerto Aisén
+Puente Alto
+Pucón
+Penco
+Peñaflor
+Parral
+Panguipulli
+Paine
+Ovalle
+Osorno
+Nueva Imperial
+Nacimiento
+Mulchén
+Molina
+Melipilla
+Machalí
+Lota
+Los Ángeles
+Los Andes
+Loncoche
+Llaillay
+Linares
+Limache
+Lebu
+Lautaro
+La Unión
+La Serena
+Lampa
+La Ligua
+La Laja
+Iquique
+Illapel
+Hacienda La Calera
+Graneros
+Frutillar
+El Monte
+Diego de Almagro
+Curicó
+Curanilahue
+Coronel
+Coquimbo
+Copiapó
+Constitución
+Concepción
+Collipulli
+Coihaique
+Chimbarongo
+Chillán
+Chiguayante
+Chicureo Abajo
+Cauquenes
+Castro
+Cartagena
+Cañete
+Calama
+Cabrero
+Buin
+Arica
+Arauco
+Antofagasta
+Angol
+Ancud
+Las Animas
+La Pintana
+Lo Prado
+Yaoundé
+Yagoua
+Wum
+Tonga
+Tiko
+Tibati
+Tcholliré
+Sangmélima
+Penja
+Obala
+Nkoteng
+Nkongsamba
+Ngaoundéré
+Nanga Eboko
+Muyuka
+Mutengene
+Mora
+Mokolo
+Melong
+Meïganga
+Mbouda
+Mbanga
+Mbandjok
+Mbalmayo
+Maroua
+Manjo
+Mamfe
+Loum
+Lolodorf
+Limbe
+Lagdo
+Kumbo
+Kumba
+Kribi
+Kousséri
+Kaélé
+Guider
+Garoua Boulaï
+Garoua
+Fundong
+Foumbot
+Foumban
+Fontem
+Eséka
+Edéa
+Ébolowa
+Dschang
+Douala
+Dizangué
+Buea
+Bogo
+Bertoua
+Bélabo
+Batouri
+Banyo
+Bangangté
+Bamusso
+Bamenda
+Bali
+Bafoussam
+Bafia
+Bafang
+Akonolinga
+Idenao
+Rikaze
+Jiuquan
+Shache
+Qamdo
+Nagqu
+Lhasa
+Laojunmiao
+Kashgar
+Jiayuguan
+Hotan
+Dêqên
+Ürümqi
+Laochenglu
+Shihezi
+Kuche
+Sayibage
+Hoxtolgay
+Hami
+Changji
+Baijiantan
+Aral
+Altay
+Yingbazha
+Zunyi
+Zoucheng
+Yanjiang
+Zigong
+Zhuzhou
+Zhumadian
+Zhujiajiao
+Shangqiu
+Zhuji
+Mizhou
+Zhuanghe
+Zhouzhuang
+Zhoukou
+Zhoucun
+Yuxi
+Zhongxing
+Zhongshu
+Zhicheng
+Zhicheng
+Zhenzhou
+Zhenjiang
+Zhaobaoshan
+Zhengzhou
+Xinghua
+Zhaotong
+Zhaoqing
+Zhaogezhuang
+Luofeng
+Zhanjiang
+Zhangzhou
+Zhangye
+Zibo
+Anyang
+Zaozhuang
+Zaoyang
+Yuyao
+Yingchuan
+Yuxia
+Kunshan
+Yunyang
+Yunmeng Chengguanzhen
+Jinghong
+Pizhou
+Yunfu
+Yuncheng
+Yulin
+Yulin
+Yudong
+Yuci
+Yucheng
+Yuanping
+Qianjiang
+Heyuan
+Yongfeng
+Yongchuan
+Yishui
+Zhongxiang
+Yingshang Chengguanzhen
+Chengzhong
+Yinchuan
+Yima
+Yigou
+Qingzhou
+Yichun
+Yicheng
+Yicheng
+Yichang
+Yibin
+Yatou
+Yashan
+Yanzhou
+Yantai
+Yanliang
+Yangzhou
+Yangshuo
+Zhangjiagang
+Yangquan
+Yangliuqing
+Yanggu
+Yangcun
+Yancheng
+Tongshan
+Xucheng
+Shangrao
+Xunchang
+Jiangguanchi
+Xuanzhou
+Xixiang
+Xiuying
+Xiulin
+Xiongzhou
+Guixi
+Xinzhou
+Xinzhou
+Xinzhi
+Xinyu
+Hancheng
+Xinyang
+Nangandao
+Xintai
+Xinshi
+Xinpu
+Xinji
+Xining
+Shangmei
+Xingtai
+Ankang
+Xindian
+Xindi
+Feicheng
+Sanshui
+Ximei
+Wacheng
+Xihe
+Xichang
+Xiazhuang
+Xiazhen
+Xiashi
+Zijinglu
+Xiaoweizhai
+Xiaoshan
+Xiaolingwei
+Xiaogan
+Xianyang
+Xiantao
+Xianshuigu
+Xiannü
+Xianning
+Xianju
+Zhuhai
+Wenxing
+Xiangxiang
+Xiangtan
+Xiangyang
+Xiangcheng Chengguanzhen
+Xi’an
+Xiamen
+Wuzhou
+Wuyang
+Wuxue
+Wuxi
+Dongyang
+Changde
+Wuhu
+Wuhan
+Wuhai
+Wuda
+Wucheng
+Wenzhou
+Wenshang
+Wenling
+Tianfu
+Weinan
+Weihai
+Weifang
+Wanxian
+Wanning
+Yinzhu
+Wafangdian
+Huangshan
+Loushanguan
+Tongzhou
+Fuding
+Tongren
+Wusong
+Tongchuan
+Tianshui
+Tianpeng
+Tianjin
+Tengzhou
+Taozhuang
+Tantou
+Tangzhai
+Tangshan
+Tangping
+Tangjiazhuang
+Binhe
+Tanggu
+Taizhou
+Taiyuan
+Taixing
+Taishan
+Tai’an
+Suzhou
+Suozhen
+Suizhou
+Suixi
+Suicheng
+Suining
+Songjiang
+Sishui
+Laixi
+Shouguang
+Shizuishan
+Shizilu
+Shiyan
+Shiyan
+Shiwan
+Shitanjing
+Shiqiao
+Shiqi
+Shima
+Shilong
+Tongchuan
+Shijiazhuang
+Shenzhen
+Yanta
+Shenjiamen
+Shashi
+Shaping
+Shaoxing
+Shaowu
+Shaoguan
+Shancheng
+Shanwei
+Shantou
+Shanting
+Shanghai
+Shahecheng
+Sanya
+Sanming
+Runing
+Fuqing
+Jieyang
+Rizhao
+Renqiu
+Quzhou
+Qujing
+Qufu
+Quanzhou
+Wuxi
+Zhuangyuan
+Qiongshan
+Qionghu
+Qinzhou
+Qinnan
+Qinhuangdao
+Jinjiang
+Qingquan
+Huai'an
+Qingdao
+Qingyuan
+Hongqiao
+Puyang Chengguanzhen
+Puyang
+Putian
+Puqi
+Pumiao
+Pulandian
+Poyang
+Pingyin
+Pingyi
+Gutao
+Pingxiang
+Pingshan
+Pingnan
+Pingliang
+Pingdu
+Pingdingshan
+Pengcheng
+Dadukou
+Ningyang
+Yutan
+Ninghai
+Ninghai
+Ningbo
+Neijiang
+Nanzhou
+Nanzhang Chengguanzhen
+Nanyang
+Nantong
+Pucheng
+Nanping
+Nanning
+Nanma
+Nanlong
+Nanjing
+Nangong
+Nanfeng
+Nandu
+Nanding
+Nanchong
+Nanchang
+Miyang
+Mingshui
+Mingguang
+Minggang
+Mianyang
+Mentougou
+Mengyin
+Mengcheng Chengguanzhen
+Meizhou
+Wuchuan
+Majie
+Zhijiang
+Macheng
+Maba
+Lüshun
+Luqiao
+Luoyang
+Luoyang
+Luoyang
+Luorong
+Luohe
+Luocheng
+Lucheng
+Kangding
+Lubu
+Luancheng
+Loudi
+Longquan
+Longgang
+Licheng
+Guankou
+Puning
+Lishui
+Lintong
+Linyi
+Linxia Chengguanzhen
+Linxi
+Linshui
+Linqu
+Linqiong
+Qingnian
+Linping
+Linhai
+Lingcheng
+Lincheng
+Linfen
+Xishan
+Lichuan
+Licheng
+Liaocheng
+Lianzhou
+Lianzhou
+Lianran
+Wuwei
+Liangxiang
+Lianjiang
+Leshan
+Lengshuitan
+Lengshuijiang
+Leiyang
+Lecheng
+Laohekou
+Lanzhou
+Lanxi
+Lianyuan
+Langfang
+Weichanglu
+Laiyang
+Laiwu
+Laibin
+Kunyang
+Kunming
+Kaiyuan
+Kaihua
+Kaifeng
+Juye
+Juegang
+Jiujiang
+Jishui
+Qianzhou
+Jinzhou
+Jinxiang
+Jinshi
+Jinsha
+Jinjiang
+Jinji
+Jining
+Jinhua
+Jingzhou
+Tianchang
+Jingmen
+Jingling
+Jingdezhen
+Jinchang
+Jincheng
+Jinan
+Jimo
+Jijiang
+Jiexiu
+Jieshou
+Jieshi
+Jiehu
+Jiazi
+Jiaxing
+Jiaozuo
+Jiaozhou
+Ningde
+Jian’ou
+Jiangyan
+Jianguang
+Jiangmen
+Jiangkou
+Yangjiang
+Ji’an
+Guangyuan
+Huzhou
+Hutang
+Huoqiu Chengguanzhen
+Humen
+Huizhou
+Huilong
+Huicheng
+Xinhui
+Huazhou
+Huangzhou
+Huangyan
+Huangshi
+Dasha
+Huangpi
+Huangmei
+Huanggang
+Daxing
+Dingcheng
+Huaiyuan Chengguanzhen
+Huainan
+Huaicheng
+Huaihua
+Huaidian
+Huaibei
+Hongjiang
+Heze
+Hechuan
+Yiyang
+Hepo
+Hengyang
+Hengshui
+Hefei
+Hede
+Hecun
+Hebi
+Hanzhong
+Chengyang
+Hanting
+Hangzhou
+Hangu
+Handan
+Hanchuan
+Hancheng
+Haizhou
+Jiaojiang
+Haimen
+Haikou
+Haikou
+Guye
+Guozhen
+Guli
+Guiyang
+Guiren
+Guiping
+Guilin
+Guigang
+Gucheng Chengguanzhen
+Guangzhou
+Guangshui
+Gejiu
+Gaozhou
+Gaoyou
+Gaoping
+Gaomi
+Gaogou
+Fuzhou
+Fuyang
+Fuyang
+Qingyang
+Fuling
+Foshan
+Fenyi
+Fengxian
+Fengrun
+Fengkou
+Feicheng
+Fangshan
+Ezhou
+Enshi
+Encheng
+Duyun
+Duobao
+Ducheng
+Xinyi
+Shengli
+Dongtai
+Dongsheng
+Dongkan
+Donghai
+Dongguan
+Dongdu
+Dongcun
+Dingzhou
+Dingtao
+Dezhou
+Deyang
+Deqing
+Dengzhou
+Huazhou
+Songyang
+Dazhong
+Zhangjiajie
+Daye
+Lijiang
+Dazhou
+Dawukou
+Datong
+Fenghua
+Daokou
+Danshui
+Danjiangkou
+Gushu
+Xincheng
+Daliang
+Dalian
+Dali
+Chuzhou
+Yangchun
+Yiwu
+Chongqing
+Chonglong
+Chizhou
+Chenzhou
+Chengyang
+Jiangyin
+Chengdu
+Chenghua
+Chaozhou
+Chaohu
+Changzhou
+Changzhi
+Changsha
+Changqing
+Changli
+Changleng
+Caohe
+Weining
+Cangzhou
+Caidian
+Buhe
+Bozhou
+Botou
+Boshan
+Baise City
+Binzhou
+Luxu
+Bijie
+Bianzhuang
+Bengbu
+Beijing
+Beihai
+Beidao
+Beidaihehaibin
+Beibei
+Baoying
+Langzhong
+Baoding
+Baiyin
+Baihe
+Shangyu
+Babu
+Anxiang
+Anshun
+Anqiu
+Anqing
+Mabai
+Anlu
+Anjiang
+Anbu
+Jiangyou
+Suzhou
+Zhoushan
+Mudu
+Songling
+Zhongshan
+Lianghu
+Zhoucheng
+Dalianwan
+Yueyang
+Bojia
+Zhenlai
+Zhengjiatun
+Zhaozhou
+Zhaoyuan
+Zhaodong
+Zhangjiakou
+Zalantun
+Yushu
+Youhao
+Yingkou
+Yilan
+Yichun
+Yebaishou
+Yantongshan
+Yanji
+Yakeshi
+Zhangjiakou Shi Xuanhua Qu
+Xiuyan
+Xinqing
+Xinmin
+Xinglongshan
+Xingcheng
+Xilin Hot
+Xifeng
+Xiaoshi
+Wuchang
+Wangqing
+Hepingjie
+Wangkui
+Ulanhot
+Tumen
+Tongliao
+Tieling
+Tieli
+Guangming
+Tailai
+Taikang
+Tahe
+Sujiatun
+Suileng
+Suihua
+Suifenhe
+Songjianghe
+Siping
+Shunyi
+Shulan
+Shuangyashan
+Shuangyang
+Shuangcheng
+Shiguai
+Shenyang
+Shanhetun
+Shanhaiguan
+Shangzhi
+Sanchazi
+Salaqi
+Fendou
+Taihe
+Qiqihar
+Qinggang
+Qianguo
+Pingzhuang
+Panshi
+Panshan
+Nianzishan
+Nenjiang
+Nehe
+Nantai
+Nanpiao
+Lianhe
+Mujiayingzi
+Mudanjiang
+Mishan
+Mingyue
+Mingshui
+Meihekou
+Manzhouli
+Longjing
+Longjiang
+Longfeng
+Liuhe
+Lishu
+Linkou
+Linjiang
+Lingyuan
+Lingdong
+Liaozhong
+Liaoyuan
+Liaoyang
+Lanxi
+Langxiang
+Langtou
+Kuandian
+Kaiyuan
+Kaitong
+Jixi
+Jiutai
+Jiupu
+Jishu
+Jinzhou
+Lianshan
+Jining
+Jilin
+Jidong
+Minzhu
+Jiamusi
+Jalai Nur
+Jagdaqi
+Hushitai
+Hunchun
+Hulan Ergi
+Hulan
+Huinan
+Huanren
+Huangnihe
+Huanan
+Huadian
+Honggang
+Hohhot
+Fendou
+Helong
+Heishan
+Heihe
+Hegang
+Harbin
+Hailun
+Hailin
+Hailar
+Haicheng
+Gongzhuling
+Gongchangling
+Genhe
+Gannan
+Fuyuan
+Fuyu
+Fuyu
+Fuxin
+Fuxin
+Fushun
+Fuli
+Fujin
+Beichengqu
+Fengxiang
+Fengcheng
+Erenhot
+Erdaojiang
+Dunhua
+Dongning
+Dongling
+Dongfeng
+Dongxing
+Dehui
+Datong
+Dashitou
+Dashiqiao
+Daqing
+Dandong
+Linghai
+Dalai
+Chifeng
+Chengzihe
+Chengde
+Chaoyang
+Chaoyang
+Changtu
+Changping
+Changling
+Changchun
+Chaihe
+Boli
+Binzhou
+Benxi
+Beipiao
+Bei’an
+Bayan
+Baotou
+Baoshan
+Baoqing
+Bamiantong
+Baishishan
+Baiquan
+Baicheng
+Baishan
+Anshan
+Anda
+Oroqen Zizhiqi
+Acheng
+Songling
+Shilin
+Changshu City
+Shixing
+Jiashan
+Fenghuang
+Zhu Cheng City
+Shangri-La
+Ordos
+Wenshan City
+Liupanshui
+Zipaquirá
+Zarzal
+Zaragoza
+Yumbo
+Yopal
+Yarumal
+Viterbo
+Villeta
+Villavicencio
+Villa del Rosario
+Villanueva
+Villanueva
+Villamaría
+Valledupar
+Urrao
+Ubaté
+Turbo
+Turbaco
+Túquerres
+Tunja
+Tumaco
+Tuluá
+Tolú
+Tierralta
+Tame
+Sucre
+Sonsón
+Soledad
+Sogamoso
+Socorro
+Soacha
+Sincelejo
+Sincé
+Sibaté
+Sevilla
+Segovia
+Santuario
+Santo Tomás
+Santa Rosa de Cabal
+Santander de Quilichao
+Santa Marta
+Santa Lucía
+San Onofre
+San Martín
+San Marcos
+San Juan Nepomuceno
+San Juan del Cesar
+San Jacinto
+San Gil
+San Carlos
+San Carlos
+San Benito Abad
+San Andrés
+Sampués
+Salamina
+Sahagún
+Sabaneta
+Sabanalarga
+Sabanagrande
+Roldanillo
+Riosucio
+Rionegro
+Ríohacha
+Repelón
+Quimbaya
+Quibdó
+Puerto Tejada
+Puerto Santander
+Puerto López
+Puerto Colombia
+Puerto Boyacá
+Puerto Berrío
+Puerto Asís
+Pradera
+Popayán
+Planeta Rica
+Pivijay
+Pitalito
+Piedecuesta
+Pereira
+Patía
+Pasto
+Pamplona
+Palmira
+Palmar de Varela
+Belalcazar
+Pacho
+Ocaña
+Neiva
+Mosquera
+Morales
+Montería
+Montenegro
+Montelíbano
+Mompós
+Mocoa
+Melgar
+Medellín
+Mariquita
+Marinilla
+María la Baja
+Manzanares
+Manizales
+Malambo
+Málaga
+Maicao
+Magangué
+Madrid
+Los Patios
+Lorica
+Líbano
+Leticia
+Lérida
+La Virginia
+La Unión
+La Unión
+La Tebaida
+La Plata
+La Mesa
+La Jagua de Ibirico
+La Estrella
+La Dorada
+La Ceja
+Jamundí
+Itagüí
+Ipiales
+Ibagué
+Honda
+Guacarí
+Granada
+Girón
+Girardot City
+Garzón
+Galapa
+Fusagasuga
+Funza
+Fundación
+Fresno
+Fonseca
+Floridablanca
+Florida
+Florencia
+Flandes
+Facatativá
+Espinal
+Envigado
+El Retén
+El Copey
+El Charco
+El Cerrito
+El Carmen de Bolívar
+El Banco
+El Bagre
+Duitama
+Dos Quebradas
+Curumaní
+Cúcuta
+Corozal
+Corinto
+Municipio de Copacabana
+Circasia
+Ciénaga de Oro
+Ciénaga
+Chiriguaná
+Chiquinquirá
+Chinú
+Chinchiná
+Chimichagua
+Chigorodó
+Chía
+Chaparral
+Cereté
+Caucasia
+Cartago
+Cartagena
+Carmen de Viboral
+Candelaria
+Campo de la Cruz
+Campoalegre
+Cali
+Caldas
+Calarcá
+Cajicá
+Caicedonia
+Buga
+Buenaventura
+Buenaventura
+Bucaramanga
+Bogotá
+Bello
+Belén de Umbría
+Barranquilla
+Barrancas
+Barrancabermeja
+Barbosa
+Barbosa
+Baranoa
+Ayapel
+Armenia
+Arjona
+Ariguaní
+Arauca
+Aracataca
+Apartadó
+Anserma
+Andes
+Andalucía
+Aguazul
+Aguadas
+Aguachica
+Acacías
+Morales
+Carepa
+Ciudad Bolívar
+Agustín Codazzi
+Plato
+San José del Guaviare
+Turrialba
+Tejar
+Siquirres
+San Vicente
+San Rafael Arriba
+San Rafael Abajo
+San Rafael
+San Rafael
+San Pedro
+San Pablo
+San Miguel
+San Juan de Dios
+San Juan
+San José
+San José
+San Isidro
+San Francisco
+San Felipe
+San Diego
+Quesada
+Purral
+Puntarenas
+Limón
+Patarrá
+Paraíso
+Nicoya
+Mercedes
+Liberia
+Ipís
+Heredia
+Guápiles
+Guadalupe
+Esparza
+Curridabat
+Colima
+Chacarita
+Cartago
+Cañas
+Calle Blancos
+Aserrí
+Alajuela
+San Vicente de Moravia
+Yara
+Yaguajay
+Viñales
+Vertientes
+Venezuela
+Varadero
+San Germán
+Unión de Reyes
+Trinidad
+Sibanicú
+Santo Domingo
+Santiago de las Vegas
+Santiago de Cuba
+Santa Cruz del Sur
+Santa Cruz del Norte
+Santa Clara
+San Miguel del Padrón
+San Luis
+San José de las Lajas
+Sancti Spíritus
+San Cristobal
+San Antonio de los Baños
+Sagua la Grande
+Sagua de Tánamo
+Rodas
+Río Guayabal de Yateras
+Río Cauto
+Remedios
+Regla
+Ranchuelo
+Puerto Padre
+Primero de Enero
+Placetas
+Pinar del Río
+Perico
+Pedro Betancourt
+Palmira
+Palma Soriano
+Nuevitas
+Nueva Gerona
+Niquero
+Morón
+Moa
+Minas de Matahambre
+Minas
+Media Luna
+Matanzas
+Mariel
+Manzanillo
+Manicaragua
+Maisí
+Madruga
+Los Palacios
+Las Tunas
+La Sierpe
+La Salud
+Havana
+Jovellanos
+Jobabo
+Jobabo
+Jiguaní
+Jesús Menéndez
+Jatibonico
+Jaruco
+Jagüey Grande
+Holguín
+Guisa
+Güira de Melena
+Güines
+Guantánamo
+Guane
+Guanajay
+Guanabacoa
+Guáimaro
+Gibara
+Fomento
+Florida
+Florencia
+Esmeralda
+Encrucijada
+Cumanayagua
+Cueto
+Cruces
+Corralillo
+Contramaestre
+Consolación del Sur
+Condado
+Colón
+Colombia
+Ciro Redondo
+Cifuentes
+Cienfuegos
+Ciego de Ávila
+Chambas
+Cerro
+Cauto Cristo
+Cárdenas
+Campechuela
+Camajuaní
+Camagüey
+Calimete
+Caibarién
+Cacocum
+Cabaiguán
+Bejucal
+Bayamo
+Bauta
+Bartolomé Masó
+Baraguá
+Baracoa
+Banes
+Bahía Honda
+Artemisa
+Arroyo Naranjo
+Amancio
+Alquízar
+Alamar
+Aguada de Pasajeros
+Abreus
+Habana del Este
+Centro Habana
+La Habana Vieja
+Báguanos
+Jimaguayú
+Arroyo Naranjo
+Boyeros
+Diez de Octubre
+Santa Maria
+Praia
+Mindelo
+Cova Figueira
+Willemstad
+Flying Fish Cove
+Protaras
+Paphos
+Nicosia
+Limassol
+Larnaca
+Kyrenia
+Famagusta
+Dvůr Králové nad Labem
+Znojmo
+Zlín
+Žďár nad Sázavou Druhy
+Žďár nad Sázavou
+Žatec
+Vyškov
+Vsetín
+Varnsdorf
+Valašské Meziříčí
+Ústí nad Orlicí
+Ústí nad Labem
+Uherský Brod
+Uherské Hradiště
+Trutnov
+Třinec
+Třebíč
+Teplice
+Tábor
+Svitavy
+Šumperk
+Strakonice
+Starý Bohumín
+Sokolov
+Slaný
+Rožnov pod Radhoštěm
+Rakovník
+Prostějov
+Prosek
+Příbram
+Přerov
+Prague
+Pilsen
+Písek
+Pelhřimov
+Pardubice
+Otrokovice
+Otrokovice
+Ostrov
+Ostrava
+Orlová
+Opava
+Olomouc
+Nový Jičín
+Neratovice
+Náchod
+Most
+Modřany
+Mladá Boleslav
+Mělník
+Louny
+Litvínov
+Litoměřice
+Liberec
+Libeň
+Letňany
+Kutná Hora
+Kroměříž
+Krnov
+Kralupy nad Vltavou
+Kopřivnice
+Kolín
+Klatovy
+Klášterec nad Ohří
+Kladno
+Karviná
+Karlovy Vary
+Kadaň
+Kadaň
+Jirkov
+Jindřichův Hradec
+Jihlava
+Jičín
+Jablonec nad Nisou
+Hranice
+Hradec Králové
+Hodonín
+Havlíčkův Brod
+Havířov
+Frýdek-Místek
+Děčín
+Chrudim
+Chomutov
+Cheb
+Český Těšín
+České Budějovice
+Česká Třebová
+Česká Lípa
+Bruntál
+Brno
+Břeclav
+Braník
+Brandýs nad Labem-Stará Boleslav
+Bohumín
+Blansko
+Bílina Kyselka
+Bílina
+Beroun
+Benešov
+Černý Most
+Zwickau
+Zweibrücken
+Zulpich
+Zossen
+Zittau
+Zirndorf
+Zerbst
+Zeitz
+Zehlendorf
+Xanten
+Wurzen
+Würzburg
+Würselen
+Wuppertal
+Wunstorf
+Wülfrath
+Wörth am Rhein
+Worms
+Wolfsburg
+Wolfratshausen
+Wolfenbüttel
+Wolfen
+Witzenhausen
+Wittstock
+Wittmund
+Wittlich
+Wittenberge
+Wittenau
+Witten
+Wismar
+Wipperfürth
+Winterhude
+Winsen
+Winnenden
+Wilnsdorf
+Wilmersdorf
+Willich
+Wilhelmstadt
+Wilhelmshaven
+Wildeshausen
+Wiesloch
+Wiesbaden
+Wiehl
+Wetzlar
+Wetter (Ruhr)
+Westerstede
+Westend
+Wesseling
+Wesel
+Wertheim
+Wernigerode
+Werne
+Wermelskirchen
+Werl
+Werdohl
+Werder
+Werdau
+Wendlingen am Neckar
+Wenden
+Wendelstein
+Weiterstadt
+Weißwasser
+Weißenfels
+Weißenburg in Bayern
+Weinstadt-Endersbach
+Weinheim
+Weingarten
+Weimar
+Weilheim
+Weilerswist
+Weil der Stadt
+Weil am Rhein
+Weiden
+Weißensee
+Wegberg
+Weener
+Wedel
+Wedding
+Wassenberg
+Warstein
+Warendorf
+Waren
+Wardenburg
+Warburg
+Wangen im Allgäu
+Wandlitz
+Waltrop
+Walsrode
+Wallenhorst
+Waldshut-Tiengen
+Waldkraiburg
+Waldkirch
+Waldbröl
+Waiblingen
+Waghäusel
+Wadgassen
+Wadern
+Wachtberg
+Vreden
+Völklingen
+Voerde
+Vlotho
+Vilshofen
+Villingen-Schwenningen
+Viersen
+Viernheim
+Versmold
+Verl
+Verden
+Velbert
+Vechta
+Vechelde
+Vaterstetten
+Varel
+Vaihingen an der Enz
+Uetersen
+Uslar
+Unterschleißheim
+Unterhaching
+Unterkrozingen
+Unna
+Ulm
+Uelzen
+Überlingen
+Übach-Palenberg
+Tuttlingen
+Tübingen
+Trossingen
+Troisdorf
+Trier
+Traunstein
+Traunreut
+Torgau
+Tönisvorst
+Tettnang
+Templin
+Tempelhof
+Teltow
+Telgte
+Tegel
+Taunusstein
+Taufkirchen
+Syke
+Sundern
+Sulzbach-Rosenberg
+Sulzbach
+Suhl
+Stuttgart
+Stuhr
+Strausberg
+Straubing
+Stralsund
+Straelen
+Stolberg
+Stockelsdorf
+Stockach
+Stendal
+Stellingen
+Steinhagen
+Steinfurt
+Steilshoop
+Steglitz
+Staßfurt
+Starnberg
+Stadtlohn
+Stadthagen
+Stadtallendorf
+Stade
+Staaken
+Sprockhövel
+Springe
+Speyer
+Spenge
+Sonthofen
+Sonneberg
+Sondershausen
+Sömmerda
+Soltau
+Solingen
+Soest
+Sinzig
+Sinsheim
+Singen
+Sindelfingen
+Simmerath
+Sigmaringen
+Siegen
+Siegburg
+Senftenberg
+Senden
+Senden
+Selm
+Seligenstadt
+Selb
+Sehnde
+Seevetal
+Seesen
+Seelze
+Schwetzingen
+Schwerte
+Schwerin
+Schwelm
+Schweinfurt
+Schwedt (Oder)
+Schwarzenberg
+Schwanewede
+Schwandorf in Bayern
+Schwalmtal
+Schwalmstadt
+Schwalbach
+Schwäbisch Hall
+Schwäbisch Gmünd
+Schwabach
+Schrobenhausen
+Schramberg
+Schortens
+Schorndorf
+Schopfheim
+Schöneberg
+Schönebeck
+Schneverdingen
+Schneeberg
+Schmelz
+Schmargendorf
+Schmallenberg
+Schmalkalden
+Schlüchtern
+Schleswig
+Schkeuditz
+Schiffweiler
+Schifferstadt
+Saulgau
+Sasel
+Sarstedt
+Sankt Wendel
+Sankt Ingbert
+Sankt Augustin
+Sangerhausen
+Salzwedel
+Salzkotten
+Saarlouis
+Saarbrücken
+Saalfeld
+Rüsselsheim
+Rummelsburg
+Rudow
+Rudolstadt
+Rottweil
+Rottenburg
+Roth
+Rotenburg
+Rostock
+Rösrath
+Rosenheim
+Ronnenberg
+Rinteln
+Rietberg
+Riesa
+Riegelsberg
+Ribnitz-Damgarten
+Rheinfelden (Baden)
+Rheine
+Rheinberg
+Rheinbach
+Rhede
+Rheda-Wiedenbrück
+Reutlingen
+Renningen
+Rendsburg
+Remscheid
+Remagen
+Reinickendorf
+Reinheim
+Reinbek
+Reichenbach/Vogtland
+Regensburg
+Rees
+Recklinghausen
+Ravensburg
+Ratingen
+Rathenow
+Ratekau
+Rastede
+Rastatt
+Rahden
+Radolfzell am Bodensee
+Radevormwald
+Radebeul
+Radeberg
+Quickborn
+Quedlinburg
+Püttlingen
+Pulheim
+Puchheim
+Prenzlauer Berg
+Prenzlau
+Preetz
+Potsdam
+Porta Westfalica
+Poppenbüttel
+Plettenberg
+Plauen
+Pirna
+Pirmasens
+Pinneberg
+Pfungstadt
+Pfullingen
+Pforzheim
+Pfaffenhofen an der Ilm
+Petershagen
+Penzberg
+Peine
+Passau
+Pasing
+Parchim
+Papenburg
+Pankow
+Paderborn
+Oyten
+Overath
+Ottweiler
+Ottobrunn
+Osterholz-Scharmbeck
+Osnabrück
+Oschersleben
+Oschatz
+Oranienburg
+Opladen
+Olsberg
+Olpe
+Oldenburg
+Olching
+Öhringen
+Offenburg
+Offenbach
+Oerlinghausen
+Oer-Erkenschwick
+Oelde
+Odenthal
+Ochtrup
+Oberursel
+Obertshausen
+Oberschöneweide
+Ober-Ramstadt
+Oberkirch
+Oberhausen
+Oberasbach
+Nürtingen
+Nürnberg
+Nümbrecht
+Nottuln
+Northeim
+Nördlingen
+Nordhorn
+Nordhausen
+Norderstedt
+Nordenham
+Norden
+Nippes
+Nikolassee
+Nienburg
+Niederschönhausen
+Niederkrüchten
+Niederkassel
+Nieder-Ingelheim
+Nidderau
+Nidda
+Neu Wulmstorf
+Neuwied
+Neu-Ulm
+Neustrelitz
+Neustadt in Holstein
+Neustadt bei Coburg
+Neustadt
+Neustadt am Rübenberge
+Neue Neustadt
+Neuss
+Neuruppin
+Neunkirchen
+Neumünster
+Neumarkt in der Oberpfalz
+Neu Isenburg
+Neufahrn bei Freising
+Neuenhagen
+Neuburg an der Donau
+Neubrück
+Neubrandenburg
+Neu-Anspach
+Nettetal
+Netphen
+Neckarsulm
+Naumburg
+Nauen
+Nagold
+Munster
+Münster
+Hannoversch Münden
+Munich
+Müllheim
+Mülheim (Ruhr)
+Mühlheim am Main
+Stuttgart Mühlhausen
+Mühlhausen
+Mühldorf
+Mühlacker
+Much
+Mössingen
+Mosbach
+Moosburg
+Monheim am Rhein
+Mönchengladbach
+Mölln
+Moers
+Moabit
+Mittweida
+Minden
+Michelstadt
+Metzingen
+Mettmann
+Meschede
+Merzig
+Merseburg
+Meppen
+Menden
+Memmingen
+Melle
+Meissen
+Meiningen
+Meinerzhagen
+Meiderich
+Meerbusch
+Meerane
+Meckenheim
+Mechernich
+Mayen
+Marzahn
+Marsberg
+Marl
+Marktredwitz
+Marktoberdorf
+Markkleeberg
+Märkisches Viertel
+Marienfelde
+Mariendorf
+Marburg an der Lahn
+Marbach am Neckar
+Mannheim
+Mainz
+Maintal
+Mahlsdorf
+Magdeburg
+Lünen
+Lüneburg
+Ludwigshafen am Rhein
+Ludwigsfelde
+Ludwigsburg
+Lüdinghausen
+Lüdenscheid
+Luckenwalde
+Lübeck
+Lübbenau
+Lübbecke
+Loxstedt
+Losheim
+Lörrach
+Lohr am Main
+Lohne
+Löhne
+Lohmar
+Löbau
+Lippstadt
+Lingen
+Lindlar
+Lindau
+Limburg an der Lahn
+Limbach-Oberfrohna
+Lilienthal
+Lichterfelde
+Lichtenrade
+Lichtenfels
+Lichtenberg
+Leverkusen
+Leutkirch im Allgäu
+Leopoldshöhe
+Leonberg
+Lennestadt
+Lengerich
+Lemgo
+Leipzig
+Leinfelden-Echterdingen
+Leimen
+Leichlingen
+Lehrte
+Leer
+Lebach
+Laupheim
+Lauf an der Pegnitz
+Lauchhammer
+Lankwitz
+Langenhorn
+Langenhagen
+Langenfeld
+Langen
+Langen
+Landshut
+Landsberg am Lech
+Landau in der Pfalz
+Lampertheim
+Lahr
+Lahnstein
+Lage
+Laatzen
+Bad Laasphe
+Kürten
+Künzelsau
+Künzell
+Kulmbach
+Kronberg
+Kronach
+Kreuztal
+Kreuzberg
+Kreuzau
+Krefeld
+Köthen
+Korschenbroich
+Kornwestheim
+Korntal
+Korbach
+Köpenick
+Berlin Köpenick
+Konz
+Konstanz
+Königs Wusterhausen
+Königswinter
+Königstein im Taunus
+Königslutter am Elm
+Königsbrunn
+Köln
+Kolbermoor
+Koblenz
+Kleve
+Kleinmachnow
+Kitzingen
+Kirchlengern
+Kirchheim unter Teck
+Kirchhain
+Kierspe
+Kiel
+Kevelaer
+Kerpen
+Kempten (Allgäu)
+Kempen
+Kelkheim (Taunus)
+Kelheim
+Kehl
+Kaulsdorf
+Kaufbeuren
+Kassel
+Karow
+Karlstadt
+Karlsruhe
+Karlshorst
+Karlsfeld
+Karben
+Kamp-Lintfort
+Kamenz
+Kamen
+Kaltenkirchen
+Kaiserslautern
+Kaarst
+Jülich
+Jüchen
+Johannisthal
+Jena
+Itzehoe
+Isernhagen Farster Bauerschaft
+Iserlohn
+Ingolstadt
+Ilmenau
+Illingen
+Illertissen
+Idstein
+Idar-Oberstein
+Ibbenbüren
+Husum
+Hürth
+Hünfeld
+Hummelsbüttel
+Humboldtkolonie
+Hude
+Hückeswagen
+Hückelhoven
+Hoyerswerda
+Höxter
+Hövelhof
+Hörstel
+Horb am Neckar
+Homburg
+Holzwickede
+Holzminden
+Holzkirchen
+Hohenstein-Ernstthal
+Hohen Neuendorf
+Hofheim am Taunus
+Hofgeismar
+Hof
+Hockenheim
+Hochheim am Main
+Hochfeld
+Hille
+Hildesheim
+Hilden
+Hilchenbach
+Hiddenhausen
+Heusweiler
+Heusenstamm
+Hettstedt
+Hessisch Oldendorf
+Herzogenrath
+Herzogenaurach
+Herten
+Herrenberg
+Herne
+Hermsdorf
+Herford
+Herdecke
+Herborn
+Heppenheim an der Bergstrasse
+Hennigsdorf
+Hennef
+Hemmingen
+Hemer
+Helmstedt
+Hellersdorf
+Heinsberg
+Heilbad Heiligenstadt
+Heiligensee
+Heiligenhaus
+Heilbronn
+Heidenheim an der Brenz
+Heidenau
+Heidelberg
+Heide
+Hechingen
+Hattingen
+Hattersheim
+Haßloch
+Harsewinkel
+Haren
+Harburg
+Hannover
+Hanau am Main
+Hamminkeln
+Hamm
+Hameln
+Wandsbek
+Marienthal
+Hamburg-Mitte
+Eimsbüttel
+Altona
+Hamburg
+Halver
+Haltern
+Halstenbek
+Halle
+Halle (Saale)
+Haldensleben I
+Halberstadt
+Hakenfelde
+Haiger
+Hagen
+Haar
+Haan
+Gütersloh
+Güstrow
+Gunzenhausen
+Günzburg
+Gummersbach
+Guben
+Groß-Umstadt
+Großostheim
+Groß-Gerau
+Großenhain
+Gronau
+Gröbenzell
+Grimma
+Griesheim
+Grevenbroich
+Greven
+Greiz
+Greifswald
+Grefrath
+Göttingen
+Gotha
+Goslar
+Görlitz
+Göppingen
+Goch
+Glinde
+Glauchau
+Gladbeck
+Ginsheim-Gustavsburg
+Gilching
+Gifhorn
+Gießen
+Giengen an der Brenz
+Gevelsberg
+Gesundbrunnen
+Geseke
+Gescher
+Gersthofen
+Germersheim
+Germering
+Gerlingen
+Geretsried
+Gera
+Georgsmarienhütte
+Gelsenkirchen
+Gelnhausen
+Geldern
+Geislingen an der Steige
+Geilenkirchen
+Geesthacht
+Gauting
+Garmisch-Partenkirchen
+Garching bei München
+Garbsen
+Ganderkesee
+Gaggenau
+Fürth
+Fürstenwalde
+Fürstenfeldbruck
+Fulda
+Fröndenberg
+Frohnau
+Friesoythe
+Friedrichshain
+Friedrichshagen
+Friedrichshafen
+Friedrichsfelde
+Friedrichsdorf
+Friedenau
+Friedberg
+Friedberg
+Freudenstadt
+Freudenberg
+Freital
+Freising
+Freilassing
+Freiburg
+Freiberg am Neckar
+Freiberg
+Frechen
+Frankfurt am Main
+Frankfurt (Oder)
+Frankenthal
+Frankenberg
+Frankenberg
+Forst
+Forchheim
+Flörsheim
+Flensburg
+Finsterwalde
+Finnentrop
+Stuttgart Feuerbach
+Fellbach
+Falkensee
+Eutin
+Euskirchen
+Ettlingen
+Esslingen
+Essen
+Espelkamp
+Eschweiler
+Eschwege
+Eschborn
+Erwitte
+Erlangen
+Erkrath
+Erkelenz
+Erfurt
+Erftstadt
+Erding
+Eppingen
+Eppelborn
+Ennigerloh
+Ennepetal
+Enger
+Engelskirchen
+Emsdetten
+Emmerich
+Emmendingen
+Emden
+Eltville
+Elsdorf
+Elmshorn
+Ellwangen
+Eitorf
+Eislingen
+Eisenhüttenstadt
+Eisenach
+Einbeck
+Eilenburg
+Ehingen
+Eggenstein-Leopoldshafen
+Edewecht
+Eckernförde
+Eberswalde
+Ebersbach an der Fils
+Eberbach
+Düsseldorf
+Düren
+Dülmen
+Duisburg
+Duderstadt
+Dresden
+Drensteinfurt
+Dreieich
+Dortmund
+Dorsten
+Dormagen
+Donauwörth
+Donaueschingen
+Döbeln
+Ditzingen
+Dinslaken
+Dingolfing
+Dillingen an der Donau
+Dillingen
+Dillenburg
+Dietzenbach
+Diepholz
+Dieburg
+Deutz
+Detmold
+Dessau
+Delmenhorst
+Delitzsch
+Delbrück
+Deggendorf
+Datteln
+Darmstadt
+Damme
+Dahlem
+Dachau
+Cuxhaven
+Crimmitschau
+Crailsheim
+Cottbus
+Coswig
+Coesfeld
+Coburg
+Cloppenburg
+Clausthal-Zellerfeld
+Chemnitz
+Charlottenburg
+Cham
+Celle
+Castrop-Rauxel
+Calw
+Buxtehude
+Butzbach
+Bürstadt
+Burscheid
+Burghausen
+Burgdorf
+Burg bei Magdeburg
+Büren
+Bünde
+Bühl
+Büdingen
+Buckow
+Bückeburg
+Buchholz in der Nordheide
+Französisch Buchholz
+Buchen
+Brühl
+Brüggen
+Bruckmühl
+Bruchsal
+Bruchköbel
+Britz
+Brilon
+Bretten
+Bremervörde
+Bremerhaven
+Bremen
+Braunschweig
+Brandenburg an der Havel
+Bramsche
+Brakel
+Brake (Unterweser)
+Brackenheim
+Bottrop
+Bornheim
+Borna
+Borken
+Boppard
+Bonn
+Bönen
+Bogenhausen
+Bochum
+Bocholt
+Böblingen
+Bobingen
+Blomberg
+Blieskastel
+Blankenburg
+Bitterfeld-Wolfen
+Bingen am Rhein
+Bietigheim-Bissingen
+Biesdorf
+Bielefeld
+Biberach an der Riß
+Bexbach
+Beverungen
+Bernburg
+Bernau bei Berlin
+Berlin
+Bergneustadt
+Bergkamen
+Bergisch Gladbach
+Bergheim
+Bensheim
+Bendorf
+Bedburg
+Beckum
+Beckingen
+Bayreuth
+Bautzen
+Baunatal
+Baumschulenweg
+Bassum
+Bamberg
+Balingen
+Baiersbronn
+Baesweiler
+Bad Zwischenahn
+Bad Wildungen
+Bad Waldsee
+Bad Vilbel
+Bad Tölz
+Bad Soden am Taunus
+Bad Segeberg
+Bad Schwartau
+Bad Salzungen
+Bad Salzuflen
+Bad Säckingen
+Bad Reichenhall
+Bad Rappenau
+Bad Pyrmont
+Bad Oldesloe
+Bad Oeynhausen
+Bad Neustadt an der Saale
+Bad Neuenahr-Ahrweiler
+Bad Nauheim
+Bad Münstereifel
+Bad Münder am Deister
+Bad Mergentheim
+Bad Lippspringe
+Bad Langensalza
+Bad Kreuznach
+Bad Kissingen
+Bad Honnef
+Bad Homburg vor der Höhe
+Bad Hersfeld
+Bad Harzburg
+Bad Essen
+Baden-Baden
+Bad Dürkheim
+Bad Driburg
+Bad Berleburg
+Bad Bentheim
+Bad Aibling
+Backnang
+Babenhausen
+Aurich
+Augsburg
+Auerbach
+Aue
+Attendorn
+Aschersleben
+Ascheberg
+Aschaffenburg
+Bad Arolsen
+Arnstadt
+Arnsberg
+Apolda
+Ansbach
+Annaberg-Buchholz
+Angermünde
+Andernach
+Amberg
+Alzey
+Alzenau in Unterfranken
+Altglienicke
+Altenburg
+Altena
+Altdorf
+Alsfeld
+Alsdorf
+Alfter
+Alfeld
+Albstadt
+Aichach
+Ahrensburg
+Ahlen
+Ahaus
+Adlershof
+Achim
+Achern
+Aalen
+Vellmar
+Henstedt-Ulzburg
+Aachen
+Mörfelden-Walldorf
+Riedstadt
+Lauda-Königshofen
+Filderstadt
+Ostfildern
+Rodgau
+Gropiusstadt
+Seeheim-Jugenheim
+Charlottenburg-Nord
+Mitte
+Spremberg
+Rheinstetten
+Altstadt Sud
+Altstadt Nord
+Neuehrenfeld
+Bilderstoeckchen
+Stuttgart-Ost
+Bochum-Hordel
+St. Pauli
+Eidelstedt
+Halle Neustadt
+Bergedorf
+Spandau
+Berlin Schöneberg
+Berlin Treptow
+Niederrad
+Haselbachtal
+Barmbek-Nord
+Farmsen-Berne
+Falkenhagener Feld
+Neu-Hohenschönhausen
+Alt-Hohenschönhausen
+Fennpfuhl
+Hamburg-Nord
+Burg Unter-Falkenstein
+Neustadt/Nord
+Neustadt/Süd
+Kalk
+Mülheim
+Gartenstadt
+Tadjoura
+Obock
+Djibouti
+Ḏânan
+'Ali Sabieh
+Viborg
+Vejle
+Vanløse
+Taastrup
+Svendborg
+Stenløse
+Sønderborg
+Slagelse
+Skive
+Silkeborg
+Roskilde
+Rødovre
+Ringsted
+Randers
+Odense
+Nykøbing Falster
+Nyborg
+Næstved
+Nørresundby
+Lillerød
+Korsør
+Køge
+Copenhagen
+Kolding
+Kalundborg
+Ishøj
+Hvidovre
+Horsens
+Hørsholm
+Holstebro
+Holbæk
+Hjørring
+Hillerød
+Herning
+Helsingør
+Haderslev
+Greve
+Glostrup
+Frederikshavn
+Frederiksberg
+Fredericia
+Farum
+Esbjerg
+Charlottenlund
+Birkerød
+Ballerup
+Århus
+Aalborg
+Albertslund
+Aabenraa
+Roseau
+Villa Francisca
+Villa Consuelo
+Villa Bisonó
+Villa Altagracia
+Tamboril
+Santo Domingo
+Santiago de los Caballeros
+Santa Cruz de El Seibo
+Santa Cruz de Barahona
+San Pedro de Macorís
+San Juan de la Maguana
+San José de Ocoa
+San Francisco de Macorís
+San Fernando de Monte Cristi
+Puerto Plata
+Salvaleón de Higüey
+Salcedo
+Sabaneta
+Sabana Grande de Boyá
+Río Grande
+Quisqueya
+Punta Cana
+Neiba
+Nagua
+Monte Plata
+Moca
+Mao
+Las Matas de Farfán
+La Romana
+Jarabacoa
+Hato Mayor del Rey
+Esperanza
+Dajabón
+Cotuí
+Constanza
+Concepción de La Vega
+Ciudad Nueva
+Bonao
+Boca Chica
+San Cristóbal
+Bella Vista
+Bayaguana
+Baní
+Bajos de Haina
+Azua
+Santo Domingo Oeste
+Boumerdas
+Zeribet el Oued
+Zeralda
+Zemoura
+Touggourt
+Tolga
+Tlemcen
+Tizi Rached
+Tizi Ouzou
+Tizi-n-Tleta
+Tizi Gheniff
+Tissemsilt
+Tirmitine
+Tipasa
+Tindouf
+Timizart
+Timimoun
+el hed
+Tiaret
+Theniet el Had
+Thenia
+Telerghma
+Tébessa
+Tebesbest
+Tazoult-Lambese
+Tamanrasset
+Tamalous
+Tadmaït
+Sour el Ghozlane
+Souma
+Lardjem
+Souk Ahras
+Sougueur
+Skikda
+Sig
+Sidi Okba
+Sidi Moussa
+Sidi Mérouane
+Sidi Khaled
+Sidi ech Chahmi
+Sidi Bel Abbès
+Sidi Amrane
+Sidi Akkacha
+Sidi Aïssa
+Sidi Abdelli
+Sfizef
+Sétif
+Sedrata
+Seddouk
+Sebdou
+Saoula
+Salah Bey
+Saïda
+Rouissat
+Rouiba
+Rouached
+Robbah
+Remchi
+Relizane
+Reguiba
+Reghaïa
+Reggane
+Râs el Oued
+Râs el Aïoun
+Oum el Bouaghi
+Ouled Mimoun
+Oued Sly
+Oued Rhiou
+Oued Fodda
+Oued el Alleug
+Oued el Abtal
+Ouargla
+Oran
+Nedroma
+Naciria
+M’Sila
+Mouzaïa
+Mostaganem
+Mila
+Metlili Chaamba
+Messaad
+Meskiana
+Mers el Kebir
+Merouana
+Melouza
+Mekla
+Mehdia
+Megarine
+Meftah
+Médéa
+Mazouna
+Mascara
+Mansourah
+Mansoûra
+Makouda
+L’Arbaa Naït Irathen
+Larbaâ
+Lakhdaria
+Laghouat
+Ksar el Boukhari
+Ksar Chellala
+Kolea
+Khenchela
+Khemis Miliana
+Khemis el Khechna
+Kerkera
+Jijel
+Djidiouia
+Isser
+I-n-Salah
+Ighram
+Hennaya
+Héliopolis
+Hassi Messaoud
+Hammamet
+Hammam Bou Hadjar
+Hamma Bouziane
+Hadjout
+Guelma
+Ghardaïa
+Frenda
+Freha
+Feraoun
+Es Senia
+El Tarf
+El Oued
+El Malah
+El Kseur
+El Khroub
+El Kala
+El Idrissia
+El Hadjira
+El Hadjar
+El Eulma
+El Bayadh
+El Attaf
+Chlef
+El Aouinet
+El Amria
+El Affroun
+El Achir
+El Abiodh Sidi Cheikh
+El Abadia
+Ech Chettia
+Drean
+Draa el Mizan
+Draa Ben Khedda
+Douera
+Djelfa
+Djamaa
+Didouche Mourad
+Dellys
+Debila
+Dar el Beïda
+Dar Chioukh
+Constantine
+Chorfa
+Chiffa
+Chetouane
+Cheria
+Cheraga
+Chemini
+Chelghoum el Aïd
+Chebli
+Charef
+Chabet el Ameur
+Brezina
+Bou Tlelis
+Boumahra Ahmed
+Boukadir
+Bou Ismaïl
+Bouïra
+Bouinan
+Bou Hanifia el Hamamat
+Bougara
+Bougaa
+Boufarik
+Boudouaou
+Boudjima
+Boû Arfa
+Bordj Zemoura
+Bordj Ghdir
+Bordj el Kiffan
+Bordj Bou Arreridj
+Boghni
+Blida
+Biskra
+Birkhadem
+Birine
+Bir el Djir
+Bir el Ater
+Besbes
+Berrouaghia
+Berriane
+Berrahal
+Bensekrane
+Ben Mehidi
+Beni Saf
+Beni Mester
+Beni Mered
+Beni Douala
+Beni Amrane
+Bejaïa
+Béchar
+Batna
+Barika
+Barbacha
+Baraki
+Bab Ezzouar
+Azzaba
+Azazga
+Arris
+Arhribs
+Arbatache
+Aoulef
+Annaba
+Ammi Moussa
+Amizour
+Algiers
+Akbou
+Aïn Touta
+Aïn Temouchent
+Aïn Taya
+Aïn Smara
+Aïn Sefra
+Aïn Oussera
+’Aïn Merane
+Aïn Kercha
+Aïn Fakroun
+’Aïn el Turk
+’Aïn el Melh
+’Aïn el Hammam
+‘Aïn el Hadjel
+Aïn el Bya
+’Aïn el Berd
+’Aïn el Bell
+’Aïn Deheb
+Aïn Defla
+Aïn Bessem
+’Aïn Benian
+Aïn Beïda
+Aïn Arnat
+’Aïn Abid
+Aflou
+Adrar
+Abou el Hassan
+BABOR - VILLE
+Zamora
+Yaguachi Nuevo
+Vinces
+Ventanas
+Velasco Ibarra
+Tulcán
+Tena
+Sucre
+Santo Domingo de los Colorados
+Santa Rosa
+Santa Elena
+San Lorenzo de Esmeraldas
+San Gabriel
+Samborondón
+Salinas
+Rosa Zarate
+Riobamba
+Quito
+Quevedo
+Puyo
+Pujilí
+Puerto Francisco de Orellana
+Portoviejo
+Playas
+Piñas
+Pelileo
+Pedro Carbo
+Pasaje
+Otavalo
+Naranjito
+Naranjal
+Montecristi
+Montalvo
+Manta
+Machala
+Machachi
+Macas
+Loja
+La Troncal
+Latacunga
+La Maná
+La Libertad
+Nueva Loja
+Jipijapa
+Ibarra
+Huaquillas
+Guayaquil
+Guaranda
+Gualaceo
+Esmeraldas
+El Triunfo
+Eloy Alfaro
+Cuenca
+Chone
+Cayambe
+Catamayo
+Cariamanga
+Calceta
+Boca Suno
+Balzar
+Bahía de Caráquez
+Babahoyo
+Azogues
+Atuntaqui
+Ambato
+Tutamandahostel
+Viljandi
+Tartu
+Tallinn
+Sillamäe
+Rakvere
+Pärnu
+Narva
+Maardu
+Kohtla-Järve
+Ziftá
+Toukh
+Tanda
+Ţāmiyah
+Ţalkhā
+Talā
+Ţahţā
+Sumusţā as Sulţānī
+Sohag
+Sīdī Sālim
+Shirbīn
+Shibīn al Qanāţir
+Shibīn al Kawm
+Samannūd
+Samālūţ
+Rosetta
+Ras Gharib
+Quwaysinā
+Quţūr
+Kousa
+Qinā
+Qalyūb
+Naj‘ Ḩammādī
+Minyat an Naşr
+Minūf
+Maţāy
+Mashtūl as Sūq
+Mersa Matruh
+Manfalūţ
+Mallawī
+Madīnat Sittah Uktūbar
+Kawm Umbū
+Kawm Ḩamādah
+Kafr Şaqr
+Kafr az Zayyāt
+Kafr ash Shaykh
+Kafr ad Dawwār
+Juhaynah
+Jirjā
+‘Izbat al Burj
+Iţsā
+Isnā
+Idkū
+Idfū
+Ibshawāy
+Ḩalwān
+Hihyā
+Ḩawsh ‘Īsá
+Fuwwah
+Farshūţ
+Fāraskūr
+Fāqūs
+Damietta
+Diyarb Najm
+Disūq
+Dishnā
+Dikirnis
+Dayrūţ
+Dayr Mawās
+Damanhūr
+Būsh
+Port Said
+Būr Safājah
+Bilqās
+Bilbays
+Basyūn
+Banī Suwayf
+Banī Mazār
+Banhā
+Zagazig
+Awsīm
+At Tall al Kabīr
+Asyūţ
+Aswan
+Suez
+Aş Şaff
+Ash Shuhadā’
+Ashmūn
+Al Wāsiţah
+Luxor
+Al Qūşīyah
+Al Quşayr
+Al Qurayn
+Al Qanāyāt
+Al Qanāţir al Khayrīyah
+Cairo
+Al Minyā
+Al Maţarīyah
+Al Manzilah
+Al Manşūrah
+Al Manshāh
+Al Maḩallah al Kubrá
+Al Khārijah
+Al Khānkah
+Al Jīzah
+Al Jamālīyah
+Ismailia
+Alexandria
+Al Ibrāhīmīyah
+Al Ḩawāmidīyah
+Al Ḩāmūl
+Hurghada
+Al Fayyūm
+Al Fashn
+Al Bawīţī
+Al Balyanā
+Al Bājūr
+Al Badārī
+Al ‘Ayyāţ
+Arish
+Akhmīm
+Ajā
+Ad Dilinjāt
+Abū Tīj
+Abū Qurqāş
+Abū Kabīr
+Abū al Maţāmīr
+Abnūb
+Az Zarqā
+Ain Sukhna
+Smara
+Laâyoune / El Aaiún
+Dakhla
+Massawa
+Keren
+Barentu
+Asmara
+Assab
+Mendefera
+Zubia
+Zafra
+Yecla
+Villena
+Villarrobledo
+Vila-real
+Villanueva de la Serena
+Villajoyosa
+Vícar
+Vélez-Málaga
+Valencia
+Valdepeñas
+Utrera
+Ubrique
+Úbeda
+Totana
+Torrox
+Torrevieja
+Torre-Pacheco
+Torrent
+Torremolinos
+Tomelloso
+Tomares
+Toledo
+Tías
+Telde
+Teguise
+Tarifa
+Talavera de la Reina
+Tacoronte
+Tavernes de la Valldigna
+Sueca
+Silla
+Sevilla
+San Vicent del Raspeig
+Santomera
+Santa Pola
+Santa Lucía
+Santafé
+Santa Eulària des Riu
+Santa Cruz de Tenerife
+Santa Cruz de la Palma
+Santa Brígida
+San Roque
+San Pedro del Pinatar
+San Pedro de Alcántara
+San Miguel De Abona
+Sanlúcar de Barrameda
+San Juan de Aznalfarache
+San Juan de Alicante
+San Javier
+San Isidro
+San Fernando
+La Laguna
+San Bartolomé de Tirajana
+San Bartolomé
+Sant Antoni de Portmany
+Sagunto
+Rota
+Roquetas de Mar
+Ronda
+Rojales
+Rincón de la Victoria
+Ribarroja
+Requena
+Realejo Alto
+Puçol
+Puerto Real
+Puertollano
+Puerto del Rosario
+Puerto de la Cruz
+Puente-Genil
+La Pobla de Vallbona
+Priego de Córdoba
+Pozoblanco
+Pollença
+Pilar de la Horadada
+Picassent
+Paterna
+Palma
+Palma del Río
+Pájara
+Paiporta
+Osuna
+Orihuela
+Ontinyent
+Onda
+Oliva
+Novelda
+Níjar
+Nerja
+Navalmoral de la Mata
+Murcia
+Mula
+Muchamiel
+Motril
+Morón de la Frontera
+Montilla
+Montijo
+Moncada
+Molina de Segura
+Moguer
+Mogán
+Mislata
+Mijas
+Mérida
+Melilla
+Mazarrón
+Maspalomas
+Massamagrell
+Martos
+Marratxí
+Marchena
+Marbella
+Maracena
+Manzanares
+Manises
+Manacor
+Málaga
+Mairena del Aljarafe
+Mairena del Alcor
+Maó
+Lucena
+Los Palacios y Villafranca
+Los Llanos de Aridane
+Los Barrios
+Los Alcázares
+Lorca
+Lora del Río
+Loja
+Llucmajor
+Llíria
+Linares
+Lepe
+Lebrija
+La Unión
+Las Torres de Cotillas
+Las Palmas de Gran Canaria
+La Solana
+Las Cabezas de San Juan
+La Roda
+La Rinconada
+La Orotava
+La Oliva
+la Nucia
+La Línea de la Concepción
+L'Eliana
+La Carolina
+Jumilla
+Jerez de la Frontera
+Javea
+Xàtiva
+Jaén
+Isla Cristina
+Ingenio
+Inca
+Icod de los Vinos
+Ibiza
+Ibi
+Huércal-Overa
+Huelva
+Hellín
+Güimar
+Guía de Isora
+Guardamar del Segura
+Guadix
+Granadilla de Abona
+Granada
+Gandia
+Gáldar
+Fuengirola
+Felanitx
+Estepona
+El Viso del Alcor
+El Puerto de Santa María
+El Ejido
+Elda
+Elche
+El Arahal
+Écija
+Dos Hermanas
+Don Benito
+Denia
+Daimiel
+Cullera
+Quart de Poblet
+Crevillente
+Coria del Río
+Córdoba
+Conil de la Frontera
+Coín
+Ciudad Real
+Cieza
+Xirivella
+Chipiona
+Chiclana de la Frontera
+Cehegín
+Catarroja
+Castilleja de la Cuesta
+Castelló de la Plana
+Cartaya
+Cártama
+Cartagena
+Carmona
+Carlet
+Carcaixent
+Caravaca
+Candelaria
+Campo de Criptana
+Campiña
+el Campello
+Camas
+Calvià
+Calp
+Callosa de Segura
+Cadiz
+Cáceres
+Cabra
+Burriana
+Burjassot
+Bormujos
+Bétera
+Berja
+Benidorm
+Benetússer
+Benalmádena
+Baza
+Barbate de Franco
+Bailén
+Baeza
+Baena
+Badajoz
+Ayamonte
+Atarfe
+Atamaría
+Aspe
+Arucas
+Arrecife
+Arona
+Armilla
+Arcos de la Frontera
+Archena
+Antequera
+Andújar
+Altea
+Almuñécar
+Almoradí
+Almonte
+Almería
+Almendralejo
+Almassora
+Almansa
+Aljaraque
+Alicante
+Alhaurín el Grande
+Alhaurín de la Torre
+Alhama de Murcia
+Algemesí
+Algeciras
+Alfafar
+Aldaia
+Alcúdia
+Alcoy
+Alzira
+Alcázar de San Juan
+Alcantarilla
+Alcalá la Real
+Alcalá de Guadaira
+Alboraya
+Albolote
+Albal
+Albacete
+Alaquàs
+Agüimes
+Águilas
+Adra
+Adeje
+Groa de Murviedro
+Zarautz
+Zaragoza
+Zamora
+Viveiro
+Gasteiz / Vitoria
+Vinaròs
+Villaviciosa de Odón
+Villaverde
+Villaquilambre
+Vilanova i la Geltrú
+Villanueva del Pardillo
+Villanueva de la Cañada
+Vilalba
+Vilagarcía de Arousa
+Vilafranca del Penedès
+Vila-seca
+Vilaseca
+Viladecans
+Vigo
+Vic
+Vicálvaro
+El Vendrell
+Valls
+Valladolid
+Valdemoro
+Rivas-Vaciamadrid
+Utebo
+Tui
+Tudela
+Tortosa
+Torrelodones
+Torrelavega
+Torrejón de Ardoz
+Torredembarra
+Tordera
+Tolosa
+Tetuán de las Victorias
+Teruel
+Teo
+Tàrrega
+Terrassa
+Tarragona
+Tarancón
+Soria
+Sitges
+Sestao
+Seseña
+Segovia
+Cerdanyola del Vallès
+Sant Vicenç dels Horts
+Barakaldo
+Santurtzi
+Sant Just Desvern
+Santiago de Compostela
+Santa Perpètua de Mogoda
+Santander
+Barberà del Vallès
+Santa Coloma de Gramenet
+San Sebastián de los Reyes
+Donostia / San Sebastián
+Sant Quirze del Vallès
+Sant Pere de Ribes
+San Martín de la Vega
+San Lorenzo de El Escorial
+Vilassar de Mar
+Sant Joan Despí
+Sanxenxo
+San Fernando de Henares
+Sant Feliu de Llobregat
+Sant Feliu de Guíxols
+Sant Cugat del Vallès
+Sant Celoni
+Sant Carles de la Ràpita
+Sant Boi de Llobregat
+Sant Andreu de Palomar
+San Andrés del Rabanedo
+Sant Andreu de la Barca
+Sant Adrià de Besòs
+Sama
+Salt
+Salou
+Salamanca
+Sabadell
+Rubí
+Roses
+Ripollet
+Ribeira
+Reus
+Errenteria
+Redondela
+Puente de Vallecas
+Ponteareas
+Premià de Mar
+Pozuelo de Alarcón
+Poio
+Portugalete
+Porriño
+Pontevedra
+Ponferrada
+Plasencia
+Pinto
+Pineda de Mar
+Parla
+Parets del Vallès
+Pamplona
+Palencia
+Palamós
+Palafrugell
+Oviedo
+Oria
+Ourense
+Olot
+Olesa de Montserrat
+Oleiros
+Nigrán
+Navalcarnero
+Narón
+Mungia
+Móstoles
+Moratalaz
+Monzón
+Montornès del Vallès
+Monforte de Lemos
+Arrasate / Mondragón
+Montcada i Reixac
+Mollet del Vallès
+Molins de Rei
+Moaña
+Miranda de Ebro
+Mieres
+Mejorada del Campo
+Medina del Campo
+Mataró
+El Masnou
+Martorell
+Marín
+Manresa
+Manlleu
+Malgrat de Mar
+Majadahonda
+Madrid
+Lugo
+Logroño
+Lloret de Mar
+Laudio / Llodio
+Lleida
+León
+Leioa
+Leganés
+Las Rozas de Madrid
+Lasarte
+La Pineda
+Lalín
+Laguna de Duero
+A Estrada
+A Coruña
+Irun
+Illescas
+Igualada
+Humanes de Madrid
+Huesca
+L'Hospitalet de Llobregat
+Hortaleza
+Hernani
+Gernika-Lumo
+Getxo
+Guadalajara
+Granollers
+Gràcia
+Gijón
+Getafe
+Girona
+Gavà
+Galdakao
+Galapagar
+Hondarribia
+Fuenlabrada
+Figueras
+Figueres
+Esplugues de Llobregat
+Esparreguera
+Ermua
+Erandio
+El Prat de Llobregat
+Ferrol
+El Astillero
+Ejea de los Caballeros
+Eibar
+Durango
+Culleredo
+Cuenca
+Coslada
+Cornellà de Llobregat
+Colmenar Viejo
+Collado-Villalba
+Ciudad Lineal
+Ciutadella
+Ciempozuelos
+Chamartín
+Castro-Urdiales
+Castelldefels
+Castellar del Vallès
+Cardedeu
+Carballo
+Canovelles
+Cangas do Morrazo
+Cambrils
+Cambre
+Camargo
+Calella
+Caldes de Montbui
+Calatayud
+Calahorra
+Calafell
+Burlata
+Burgos
+Boiro
+Boadilla del Monte
+Blanes
+Bilbao
+Bermeo
+Berga
+Benicàssim
+Benicarló
+Benavente
+Béjar
+Barcelona
+Barbastro
+Barañáin
+Barajas de Madrid
+Banyoles
+Balaguer
+Badalona
+Azuqueca de Henares
+Avilés
+Ávila
+Arteixo
+Arganda
+Aranjuez
+Aranda de Duero
+Amposta
+Amorebieta
+Amés
+Algorta
+Algete
+Alcorcón
+Alcobendas
+Alcañiz
+Alcalá de Henares
+Nou Barris
+Pinar de Chamartín
+Playa del Ingles
+Puerto del Carmen
+Ceuta
+Moncloa-Aravaca
+Eixample
+les Corts
+Sarrià-Sant Gervasi
+Horta-Guinardó
+Sants-Montjuïc
+Sant Martí
+Ciutat Vella
+Arganzuela
+San Blas
+Latina
+Usera
+Salamanca
+Chamberí
+Carabanchel
+City Center
+Retiro
+l'Alfàs del Pi
+Las Gabias
+Delicias
+Almozara
+Montecanal
+Oliver-Valdefierro
+Santutxu
+Los Realejos
+Pasaia
+Basauri
+Llefià
+Corvera de Asturias
+Tres Cantos
+Iturrama
+Ermitagaña
+Primer Ensanche
+Segundo Ensanche
+Fuencarral-El Pardo
+Villa de Vallecas
+Natahoyo
+Ziway
+Yirga ‘Alem
+Yabēlo
+Werota
+Wenjī
+Tippi
+Shashemenē
+Shambu
+Shakīso
+Sebeta
+Robīt
+Nejo
+Nazrēt
+Mojo
+Metu
+Metahāra
+Mendī
+Mekele
+Maych’ew
+Korem
+K’olīto
+Kibre Mengist
+Kemisē
+Kombolcha
+Jinka
+Jīma
+Jijiga
+Inda Silasē
+Harar
+Hāgere Hiywet
+Gondar
+Goba
+Waliso
+Ginir
+Gimbi
+Genet
+Gelemso
+Gebre Guracha
+Gambēla
+Finote Selam
+Fichē
+Felege Neway
+Dubti
+Dodola
+Dire Dawa
+Dīla
+Desē
+Dembī Dolo
+Bishoftu
+Debre Tabor
+Debre Mark’os
+Debre Birhan
+Debark’
+Butajīra
+Burē
+Bonga
+Bodītī
+Bichena
+Bedēsa
+Bedelē
+Batī
+Bako
+Bahir Dar
+Hawassa
+Āsosa
+Āsbe Teferī
+Asaita
+Āsasa
+Āreka
+Ārba Minch’
+Axum
+Hagere Maryam
+Āgaro
+Ādīs Zemen
+Addis Ababa
+Ādīgrat
+Addiet Canna
+Abomsa
+Ylöjärvi
+Vihti
+Varkaus
+Vantaa
+Valkeakoski
+Vaasa
+Uusikaupunki
+Tuusula
+Turku
+Tornio
+Tampere
+Siilinjärvi
+Sibbo
+Seinäjoki
+Savonlinna
+Salo
+Rovaniemi
+Riihimäki
+Rauma
+Raisio
+Raahe
+Pori
+Pirkkala
+Oulu
+Nurmijärvi
+Nokia
+Mikkeli
+Mäntsälä
+Lovisa
+Lohja
+Lieto
+Lempäälä
+Laukaa
+Lappeenranta
+Lahti
+Kirkkonummi
+Kuusamo
+Kuopio
+Kouvola
+Kotka
+Korsholm
+Kokkola
+Kerava
+Kemi
+Karhula
+Kangasala
+Kajaani
+Kaarina
+Jyväskylä
+Joensuu
+Järvenpää
+Janakkala
+Jämsä
+Jakobstad
+Imatra
+Iisalmi
+Hyvinge
+Hollola
+Helsinki
+Heinola
+Haukipudas
+Hamina
+Hämeenlinna
+Forssa
+Espoo
+Porvoo
+Anjala
+Länsi-Turunmaa
+Suva
+Nadi
+Lautoka
+Labasa
+Stanley
+Palikir - National Government Center
+Tórshavn
+Yerres
+Wittenheim
+Wattrelos
+Wasquehal
+Voiron
+Vitry-sur-Seine
+Vitry-le-François
+Vitrolles
+Vitré
+Viry-Châtillon
+Viroflay
+Vincennes
+Villiers-sur-Marne
+Villiers-le-Bel
+Villeurbanne
+Villers-lès-Nancy
+Villepinte
+Villeparisis
+Villeneuve-sur-Lot
+Villeneuve-Saint-Georges
+Villeneuve-le-Roi
+Villeneuve-la-Garenne
+Villenave-d’Ornon
+Villemomble
+Villejuif
+Villefranche-sur-Saône
+Villefontaine
+Vigneux-sur-Seine
+Vierzon
+Vienne
+Vichy
+Vesoul
+Vertou
+Versailles
+Verrières-le-Buisson
+Vernon
+Verneuil-sur-Seine
+Verdun
+Vénissieux
+Vendôme
+Vence
+Vélizy-Villacoublay
+Vauréal
+Vaulx-en-Velin
+Vanves
+Vannes
+Vandœuvre-lès-Nancy
+Vallauris
+Valenciennes
+Valence
+Tulle
+Troyes
+Tremblay-en-France
+Trappes
+Tours
+Tournefeuille
+Tourlaville
+Tourcoing
+Toulouse
+Toulon
+Toul
+Torcy
+Thonon-les-Bains
+Thionville
+Thiais
+Tergnier
+Taverny
+Tassin-la-Demi-Lune
+Tarbes
+Talence
+Suresnes
+Sucy-en-Brie
+Strasbourg
+Stains
+Sotteville-lès-Rouen
+Sorgues
+Soisy-sous-Montmorency
+Soissons
+Six-Fours-les-Plages
+Sin-le-Noble
+Seynod
+Sèvres
+Sevran
+Sète
+Sens
+Senlis
+Sélestat
+Sedan
+Schiltigheim
+Sceaux
+Savigny-sur-Orge
+Savigny-le-Temple
+Saumur
+Sartrouville
+Sarreguemines
+Sarcelles
+Saran
+Sannois
+Sanary-sur-Mer
+Salon-de-Provence
+Sallanches
+Saint-Sébastien-sur-Loire
+Saint-Raphaël
+Saint-Quentin
+Saint-Priest
+Saint-Pol-sur-Mer
+Saint-Pierre-des-Corps
+Saint-Ouen-l’Aumône
+Saint-Ouen
+Saint-Omer
+Saint-Nazaire
+Saint-Michel-sur-Orge
+Saint-Médard-en-Jalles
+Saint-Maximin-la-Sainte-Baume
+Saint-Maur-des-Fossés
+Saint-Martin-d’Hères
+Saint-Mandé
+Saint-Malo
+Saint-Louis
+Saint-Lô
+Saint-Leu-la-Forêt
+Saint-Leu
+Saint-Laurent-du-Var
+Saint-Jean-de-la-Ruelle
+Saint-Jean-de-Braye
+Saint-Herblain
+Saint-Gratien
+Saint-Germain-en-Laye
+Saint-Genis-Laval
+Saint-Fons
+Saint-Étienne-du-Rouvray
+Saint-Étienne
+Saintes
+Sainte-Geneviève-des-Bois
+Sainte-Foy-lès-Lyon
+Saint-Égrève
+Saint-Dizier
+Saint-Dié-des-Vosges
+Saint-Denis
+Saint-Cyr-sur-Loire
+Saint-Cyr-l’École
+Saint-Cloud
+Saint-Chamond
+Saint-Brieuc
+Saint-Avold
+Saint-Avertin
+Saint-Amand-les-Eaux
+Rueil-Malmaison
+Royan
+Rouen
+Roubaix
+Rosny-sous-Bois
+Ronchin
+Romorantin-Lanthenay
+Romans-sur-Isère
+Romainville
+Roissy-en-Brie
+Rodez
+Rochefort
+Roanne
+Ris-Orangis
+Riom
+Rillieux-la-Pape
+Rezé
+Rennes
+Reims
+Rambouillet
+Quimper
+Puteaux
+Port-de-Bouc
+Pontoise
+Pontivy
+Pontarlier
+Pont-à-Mousson
+Poitiers
+Poissy
+Ploemeur
+Plaisir
+Plaisance-du-Touch
+Pierrefitte-sur-Seine
+Pessac
+Pertuis
+Perpignan
+Périgueux
+Pau
+Paris
+Pantin
+Pamiers
+Palaiseau
+Ozoir-la-Ferrière
+Oyonnax
+Outreau
+Oullins
+Osny
+Orvault
+Orsay
+Orly
+Orléans
+Orange
+Olivet
+Octeville
+Noyon
+Noisy-le-Sec
+Noisy-le-Grand
+Noisiel
+Nogent-sur-Oise
+Nogent-sur-Marne
+Niort
+Nîmes
+Nice
+Nevers
+Neuilly-sur-Seine
+Neuilly-sur-Marne
+Neuilly-Plaisance
+Narbonne
+Nantes
+Nanterre
+Nancy
+Muret
+Mulhouse
+Moulins
+Mougins
+Morsang-sur-Orge
+Morlaix
+Mont-Saint-Aignan
+Montrouge
+Montreuil
+Montpellier
+Montmorency
+Montluçon
+Montivilliers
+Montigny-lès-Metz
+Montigny-lès-Cormeilles
+Montigny-le-Bretonneux
+Montgeron
+Montfermeil
+Montesson
+Montereau-Fault-Yonne
+Montélimar
+Mont-de-Marsan
+Montceau-les-Mines
+Montbrison
+Montbéliard
+Montauban
+Montargis
+Mons-en-Barœul
+Moissy-Cramayel
+Mitry-Mory
+Miramas
+Millau
+Meyzieu
+Meylan
+Meudon
+Metz
+Mérignac
+Menton
+Melun
+Meaux
+Mayenne
+Maurepas
+Mauguio
+Maubeuge
+Massy
+Martigues
+Marseille
+Marmande
+Marly-le-Roi
+Marignane
+Marcq-en-Barœul
+Mantes-la-Ville
+Mantes-la-Jolie
+Manosque
+Mandelieu-la-Napoule
+Malakoff
+Maisons-Laffitte
+Maisons-Alfort
+Mâcon
+Lyon
+Lunéville
+Lunel
+Lucé
+Louviers
+Lourdes
+Lormont
+Lorient
+Loos
+Lons-le-Saunier
+Longjumeau
+Lomme
+Lognes
+Livry-Gargan
+L’Isle-sur-la-Sorgue
+Lisieux
+Lingolsheim
+Limoges
+Limeil-Brévannes
+Limay
+Lille
+Liévin
+Libourne
+L'Haÿ-les-Roses
+Le Vésinet
+Levallois-Perret
+Les Sables-d'Olonne
+Les Pennes-Mirabeau
+Les Pavillons-sous-Bois
+Les Mureaux
+Les Lilas
+Les Herbiers
+Les Clayes-sous-Bois
+Le Puy-en-Velay
+Le Pré-Saint-Gervais
+Le Pontet
+Le Plessis-Trévise
+Le Plessis-Robinson
+Le Petit-Quevilly
+Le Perreux-sur-Marne
+Le Pecq
+Lens
+Le Mée-sur-Seine
+Le Mans
+Le Kremlin-Bicêtre
+Le Havre
+Le Grand-Quevilly
+Le Creusot
+Le Chesnay
+Le Cannet
+Le Bouscat
+Le Blanc-Mesnil
+Laxou
+La Valette-du-Var
+Laval
+Lattes
+La Teste-de-Buch
+La Seyne-sur-Mer
+La Roche-sur-Yon
+La Rochelle
+Laon
+Lannion
+Lanester
+Landerneau
+Lambersart
+La Madeleine
+Lagny-sur-Marne
+La Garenne-Colombes
+La Garde
+La Flèche
+La Crau
+La Courneuve
+La Ciotat
+La Chapelle-sur-Erdre
+La Celle-Saint-Cloud
+Jouy-le-Moutier
+Joué-lés-Tours
+Joinville-le-Pont
+Ivry-sur-Seine
+Istres
+Issy-les-Moulineaux
+Issoire
+Illzach
+Illkirch-Graffenstaden
+Hyères
+Houilles
+Hérouville-Saint-Clair
+Herblay
+Hénin-Beaumont
+Hem
+Hazebrouck
+Hayange
+Hautmont
+Yutz
+Haubourdin
+Halluin
+Haguenau
+Guyancourt
+Gujan-Mestras
+Guéret
+Guérande
+Grigny
+Grenoble
+Grasse
+Grande-Synthe
+Gradignan
+Goussainville
+Gonesse
+Givors
+Gif-sur-Yvette
+Gien
+Gentilly
+Gennevilliers
+Garges-lès-Gonesse
+Gardanne
+Garches
+Gap
+Gagny
+Frontignan
+Fresnes
+Fréjus
+Franconville
+Fougères
+Fos-sur-Mer
+Forbach
+Fontenay-sous-Bois
+Fontenay-le-Comte
+Fontenay-aux-Roses
+Fontainebleau
+Fontaine
+Floirac
+Fleury-les-Aubrais
+Flers
+Firminy
+Fécamp
+Faches-Thumesnil
+Eysines
+Évry
+Évreux
+Étampes
+La Baule-Escoublac
+Ermont
+Éragny
+Équeurdreville-Hainneville
+Épinay-sur-Seine
+Épinal
+Épernay
+Elbeuf
+Élancourt
+Écully
+Échirolles
+Eaubonne
+Dunkerque
+Dreux
+Draveil
+Drancy
+Draguignan
+Douarnenez
+Douai
+Domont
+Dole
+Dijon
+Digne-les-Bains
+Dieppe
+Deuil-la-Barre
+Denain
+Décines-Charpieu
+Dax
+Dammarie-les-Lys
+Cugnaux
+Croix
+Créteil
+Crépy-en-Valois
+Creil
+Cran-Gevrier
+Cournon-d’Auvergne
+Courbevoie
+Coulommiers
+Couëron
+Coudekerque-Branche
+Cormeilles-en-Parisis
+Corbeil-Essonnes
+Conflans-Sainte-Honorine
+Concarneau
+Compiègne
+Combs-la-Ville
+Pontault-Combault
+Colomiers
+Colombes
+Colmar
+Cognac
+Cluses
+Clichy-sous-Bois
+Clichy
+Clermont-Ferrand
+Clamart
+Cholet
+Choisy-le-Roi
+Chilly-Mazarin
+Chevilly-Larue
+Cherbourg-Octeville
+Chenôve
+Chennevières-sur-Marne
+Chelles
+Chaville
+Chaumont
+Chatou
+Châtillon
+Châtenay-Malabry
+Châtellerault
+Château-Thierry
+Châteauroux
+Châteaudun
+Chartres
+Charleville-Mézières
+Charenton-le-Pont
+Champs-sur-Marne
+Champigny-sur-Marne
+Chambéry
+Chamalières
+Chalon-sur-Saône
+Châlons-en-Champagne
+Challans
+Cestas
+Cesson-Sévigné
+Cergy
+Cenon
+Cavaillon
+Castres
+Castelnau-le-Lez
+Carvin
+Carrières-sous-Poissy
+Carquefou
+Carpentras
+Carcassonne
+Canteleu
+Cannes
+Cambrai
+Caluire-et-Cuire
+Calais
+Cahors
+Cagnes-sur-Mer
+Caen
+Cachan
+Bry-sur-Marne
+Brunoy
+Bruay-la-Buissière
+Bron
+Brive-la-Gaillarde
+Brignoles
+Brie-Comte-Robert
+Brétigny-sur-Orge
+Brest
+Bressuire
+Bourgoin
+Bourg-lès-Valence
+Bourg-la-Reine
+Bourges
+Bourg-en-Bresse
+Boulogne-sur-Mer
+Boulogne-Billancourt
+Bouguenais
+Bordeaux
+Bonneuil-sur-Marne
+Bondy
+Boissy-Saint-Léger
+Bois-Colombes
+Bobigny
+Blois
+Blanquefort
+Blagnac
+Bischheim
+Biarritz
+Bezons
+Béziers
+Béthune
+Besançon
+Bergerac
+Berck
+Berck-Plage
+Belfort
+Bègles
+Beauvais
+Beaune
+Bayonne
+Bayeux
+Bastia
+Bar-le-Duc
+Balma
+Bagnols-sur-Cèze
+Bagnolet
+Bagneux
+Avon
+Avion
+Avignon
+Auxerre
+Autun
+Aurillac
+Aulnay-sous-Bois
+Audincourt
+Auch
+Aubervilliers
+Aubagne
+Athis-Mons
+Asnières-sur-Seine
+Arras
+Armentières
+Arles
+Argenteuil
+Argentan
+Arcueil
+Antony
+Antibes
+Annonay
+Annemasse
+Annecy-le-Vieux
+Annecy
+Angoulême
+Anglet
+Angers
+Amiens
+Allauch
+Alfortville
+Alès
+Alençon
+Albi
+Albertville
+Ajaccio
+Aix-les-Bains
+Aix-en-Provence
+Agen
+Agde
+Achères
+Abbeville
+Villeneuve-d'Ascq
+Les Ulis
+Bourgoin-Jallieu
+Marseille 01
+Marseille 02
+Marseille 03
+Marseille 04
+Marseille 05
+Marseille 06
+Marseille 07
+Marseille 08
+Marseille 10
+Marseille 09
+Marseille 11
+Marseille 12
+Marseille 13
+Marseille 14
+Marseille 15
+Marseille 16
+La Defense
+Saint-Quentin-en-Yvelines
+Cergy-Pontoise
+Tchibanga
+Port-Gentil
+Oyem
+Mouila
+Moanda
+Libreville
+Lambaréné
+Koulamoutou
+Franceville
+York
+Yeovil
+Yeadon
+Yate
+Wrexham
+Worthing
+Worksop
+Workington
+Worcester
+Woodford Green
+Wombwell
+Wolverhampton
+Wokingham
+Woking
+Witney
+Witham
+Wishaw
+Wisbech
+Winsford
+Windsor
+Winchester
+Wilmslow
+Willenhall
+Wigston Magna
+Wigan
+Widnes
+Wickford
+Whitstable
+Whitley Bay
+Whitehaven
+Whitefield
+Whickham
+Weymouth
+Weybridge
+Weston-super-Mare
+West Molesey
+Westhoughton
+West Bromwich
+West Bridgford
+Welwyn Garden City
+Wellington
+Wellingborough
+Welling
+Wednesfield
+Wednesbury
+Wath upon Dearne
+Watford
+Waterlooville
+Washington
+Warwick
+Warrington
+Warminster
+Ware
+Walton-on-Thames
+Waltham Abbey
+Walsall
+Wallsend
+Wallasey
+Walkden
+Wakefield
+Urmston
+Uckfield
+Stowmarket
+Stourport-on-Severn
+Stourbridge
+Stoke-on-Trent
+Stockton-on-Tees
+Stockport
+Stirling
+Stevenage
+Staveley
+Stamford
+Stalybridge
+Staines
+Stafford
+Spennymoor
+Spalding
+South Shields
+Southsea
+Southport
+South Ockendon
+Southend-on-Sea
+South Elmsall
+South Benfleet
+Southampton
+Southall
+Solihull
+Slough
+Sleaford
+Skelmersdale
+Skegness
+Sittingbourne
+Shrewsbury
+Shoreham-by-Sea
+Shoreham
+Shipley
+Sheffield
+Sevenoaks
+Selby
+Seaham
+Seaford
+Scunthorpe
+Scarborough
+Sandown
+Sandbach
+Salisbury
+Salford
+Sale
+Saint Neots
+St Helens
+St Austell
+Saint Andrews
+St Albans
+Ryton
+Ryde
+Rutherglen
+Rushden
+Runcorn
+Ruislip
+Rugeley
+Rugby
+Royton
+Royal Tunbridge Wells
+Rottingdean
+Rotherham
+Romsey
+Rochford
+Rochester
+Rochdale
+Risca
+Ripon
+Ripley
+Rhyl
+Rhondda
+Renfrew
+Reigate
+Redhill
+Redditch
+Redcar
+Reading
+Rayleigh
+Rawtenstall
+Rawmarsh
+Ramsgate
+Ramsbottom
+Purley
+Pudsey
+Prestwick
+Prestwich
+Preston
+Prestatyn
+Prescot
+Poulton le Fylde
+Potters Bar
+Portsmouth
+Portslade
+Portishead
+Porthcawl
+Port Glasgow
+Portadown
+Poole
+Pontypridd
+Pontypool
+Pontefract
+Polmont
+Plymstock
+Plymouth
+Pitsea
+Pinner
+Peterlee
+Peterhead
+Peterborough
+Perth
+Penzance
+Penicuik
+Penarth
+Paisley
+Paignton
+Oxford
+Oswestry
+Ossett
+Orpington
+Ormskirk
+Omagh
+Oldham
+Oadby
+Nuneaton
+Nottingham
+Norwich
+Northwich
+North Shields
+Northolt
+Lancing
+Northampton
+Northallerton
+Newtownards
+Newtownabbey
+Newton Mearns
+Newton-le-Willows
+Newton Aycliffe
+Newton Abbot
+Newry
+Newquay
+Newport Pagnell
+Newport
+Newport
+New Milton
+Newmarket
+New Malden
+Newcastle upon Tyne
+Newcastle under Lyme
+Newbury
+Newburn
+Newark on Trent
+Nelson
+Neath
+Nailsea
+Musselburgh
+Motherwell
+Morley
+Moreton
+Morecambe
+Mitcham
+Mirfield
+Milton Keynes
+Middleton
+Middlesbrough
+Mexborough
+Merthyr Tydfil
+Melton Mowbray
+Marple
+Marlow
+Market Harborough
+Margate
+March
+Mansfield Woodhouse
+Mansfield
+Mangotsfield
+Manchester
+Maltby
+Maldon
+Maidstone
+Maidenhead
+Maghull
+Maesteg
+Macclesfield
+Luton
+Lowestoft
+Louth
+Loughborough
+Longfield
+Long Eaton
+Londonderry County Borough
+Derry
+City of London
+London
+Lofthouse
+Llanelli
+Llandudno
+Livingston
+Liverpool
+Littlehampton
+Litherland
+Lisburn
+Lincoln
+Lichfield
+Leyland
+Lewes
+Letchworth
+Leighton Buzzard
+Leigh
+Leicester
+Leek
+Leeds
+Leatherhead
+Royal Leamington Spa
+Larne
+Larkhall
+Lancaster
+Kirkintilloch
+Kirkcaldy
+Kirkby in Ashfield
+Kirkby
+Kingswood
+Kingswinford
+Hull
+King's Lynn
+Kilwinning
+Kilmarnock
+Kidsgrove
+Kidlington
+Kidderminster
+Keynsham
+Kettering
+Kenilworth
+Kendal
+Kempston
+Keighley
+Johnstone
+Jarrow
+Islington
+Isleworth
+Irvine
+Coity
+Cobham
+Coatbridge
+Coalville
+Clydebank
+Clydach
+Clitheroe
+Clevedon
+Cleethorpes
+Cleckheaton
+Clacton-on-Sea
+Cirencester
+Christchurch
+Chorley
+Chislehurst
+Chipping Sodbury
+Chippenham
+Chichester
+Chester-le-Street
+Chesterfield
+Chester
+Chessington
+Cheshunt
+Chesham
+Cheltenham
+Chelsea
+Chelmsford
+Cheadle Hulme
+Chatham
+Chapletown
+Chalfont Saint Peter
+Caterham
+Castlereagh
+Castleford
+Carshalton
+Carrickfergus
+Carmarthen
+Carlisle
+Cardiff
+Canterbury
+Cannock
+Cambridge
+Camborne
+Camberley
+Caerphilly
+Buxton
+Bushey
+Bury St Edmunds
+Bury
+Burton upon Trent
+Burntwood
+Burnley
+Burnham-on-Sea
+Burgess Hill
+Buckley
+Buckhaven
+Brymbo
+Brownhills
+Bromsgrove
+Broadstairs
+Brixham
+Briton Ferry
+Bristol
+Brighton
+Brighouse
+Brierley Hill
+Bridlington
+Bridgwater
+Bridgend
+Brentwood
+Bredbury
+Bramhall
+Braintree
+Bradford
+Bracknell
+Bournemouth
+Boston
+Borehamwood
+Bootle
+Bolton
+Bognor Regis
+Blyth
+Bloxwich
+Bletchley
+Blackpool
+Blackburn
+Bishopstoke
+Bishops Stortford
+Bishopbriggs
+Bishop Auckland
+Birmingham
+Birkenhead
+Bingley
+Billingham
+Billericay
+Biggleswade
+Bideford
+Biddulph
+Bicester
+Bexley
+Bexhill-on-Sea
+Beverley
+Berwick-Upon-Tweed
+Berkhamsted
+Bentley
+Belper
+Bellshill
+Belfast
+Bedworth
+Bedlington
+Bedford
+Beckenham
+Bebington
+Bearsden
+Batley
+Bathgate
+Bath
+Basingstoke
+Basildon
+Barry
+Barrow in Furness
+Barrhead
+Barnstaple
+Barnsley
+Barnet
+Barking
+Banstead
+Bangor
+Bangor
+Banbury
+Banbridge
+Ballymena
+Baildon
+Ayr
+Aylesbury
+Atherton
+Ashton-under-Lyne
+Ashton in Makerfield
+Ashford
+Ascot
+Arnold
+Arbroath
+Antrim
+Andover
+Amersham
+Altrincham
+Alton
+Alloa
+Alfreton
+Aldridge
+Aldershot
+Airdrie
+Acton
+Acocks Green
+Accrington
+Abingdon
+Aberystwyth
+Abergele
+Aberdeen
+Aberdare
+Crosby
+Blackwood
+Neston
+Camden Town
+Telford
+Craigavon
+Bayswater
+Yateley
+Bowthorpe
+Hedge End
+Erskine
+Hale
+Amersham on the Hill
+Battersea
+South Croydon
+Hornchurch
+Surbiton
+Ewell
+Becontree
+Brixton
+Bethnal Green
+Failsworth
+Radcliffe
+Heywood
+Longsight
+Heavitree
+Ferndown
+Canary Wharf
+Lytham St Annes
+Hadley Wood
+Chapel Allerton
+Blackheath
+Kempston Hardwick
+Mendip
+Lower Earley
+Bartley Green
+Earlsfield
+Letchworth Garden City
+Shirley
+Stanley
+Rossendale
+Thornton-Cleveleys
+Deeside
+High Peak
+Hayling Island
+Isle of Lewis
+Shetland
+Orkney
+Holloway
+Harringay
+Saint George's
+Zugdidi
+Zestap’oni
+Ts’khinvali
+Tqvarch'eli
+Telavi
+Tbilisi
+Sokhumi
+Senak’i
+Samtredia
+Rust’avi
+P’ot’i
+Ozurgeti
+Och’amch’ire
+Marneuli
+Kutaisi
+Kobuleti
+Khashuri
+Gori
+Batumi
+Akhaltsikhe
+Stantsiya Novyy Afon
+Tsqaltubo
+Saint-Laurent-du-Maroni
+Rémire-Montjoly
+Matoury
+Kourou
+Cayenne
+Saint Peter Port
+Yendi
+Winneba
+Wenchi
+Wa
+Teshi Old Town
+Tema
+Techiman
+Tarkwa
+Tamale
+Takoradi
+Tafo
+Swedru
+Sunyani
+Suhum
+Shama Junction
+Sekondi-Takoradi
+Savelugu
+Saltpond
+Salaga
+Prestea
+Kasoa
+Akim Oda
+Obuasi
+Nungua
+Nsawam
+Nkawkaw
+Navrongo
+Mampong
+Medina Estates
+Kumasi
+Kpandu
+Konongo
+Koforidua
+Kintampo
+Keta
+Hohoe
+Ho
+Gbawe
+Foso
+Elmina
+Ejura
+Dunkwa
+Dome
+Cape Coast
+Bolgatanga
+Bibiani
+Berekum
+Begoro
+Bawku
+Axim
+Asamankese
+Apam
+Anloga
+Akwatia
+Agogo
+Achiaman
+Accra
+Aburi
+Gibraltar
+Nuuk
+Sukuta
+Lamin
+Farafenni
+Brikama
+Banjul
+Bakau
+Tougué
+Télimélé
+Siguiri
+Pita
+Nzérékoré
+Mamou
+Macenta
+Labé
+Kissidougou
+Kindia
+Kankan
+Kamsar
+Gueckedou
+Fria
+Coyah
+Conakry
+Camayenne
+Boké
+Sainte-Rose
+Sainte-Anne
+Pointe-à-Pitre
+Petit-Bourg
+Les Abymes
+Le Moule
+Le Gosier
+Capesterre-Belle-Eau
+Basse-Terre
+Baie-Mahault
+Ebebiyin
+Malabo
+Bata
+Voúla
+Vólos
+Výronas
+Vári
+Trípoli
+Tríkala
+Thívai
+Spárti
+Salamína
+Rethymno
+Préveza
+Pýrgos
+Piraeus
+Petroúpolis
+Peristéri
+Pérama
+Pátra
+Palaió Fáliro
+Níkaia
+Néa Smýrni
+Néa Mákri
+Ílion
+Néa Ionía
+Néa Filadélfeia
+Néa Erythraía
+Moskháton
+Mytilíni
+Melíssia
+Mégara
+Artémida
+Livadeiá
+Lárisa
+Lamía
+Metamórfosi
+Kos
+Koropí
+Kórinthos
+Kifisiá
+Cholargós
+Chios
+Chaniá
+Chalkída
+Khalándrion
+Chaïdári
+Keratsíni
+Kardítsa
+Kamaterón
+Kallithéa
+Kalamáta
+Álimos
+Kaisarianí
+Irákleio
+Irákleion
+Ioánnina
+Glyfáda
+Galátsi
+Ellinikó
+Elefsína
+Dhafní
+Agios Dimitrios
+Agía Varvára
+Agía Paraskeví
+Athens
+Asprópyrgos
+Argyroúpoli
+Árta
+Árgos
+Áno Liósia
+Maroúsi
+Amaliáda
+Acharnés
+Aígio
+Aigáleo
+Agrínio
+Ródos
+Giannitsá
+Xánthi
+Véroia
+Thessaloníki
+Sykiés
+Sérres
+Ptolemaḯda
+Políchni
+Pylaía
+Peraía
+Panórama
+Orestiáda
+Oraiókastro
+Náousa
+Meneméni
+Kozáni
+Komotiní
+Kilkís
+Kavála
+Kateríni
+Kalamariá
+Flórina
+Édessa
+Dráma
+Alexandroúpoli
+Corfu
+Vrilissia
+Gérakas
+Ilioúpoli
+Korydallós
+Zográfos
+Péfki
+Ágioi Anárgyroi
+Agios Ioannis Rentis
+Néa Ionía
+Grytviken
+Zacapa
+Villa Nueva
+Villa Canales
+Totonicapán
+Tecpán Guatemala
+Sumpango
+Sololá
+Santiago Sacatepéquez
+Santiago Atitlán
+Santa María de Jesús
+Santa Lucía Cotzumalguapa
+Santa Cruz del Quiché
+Santa Catarina Pinula
+San Pedro Sacatepéquez
+San Pedro Ayampuc
+San Pablo Jocopilas
+San Marcos
+San Lucas Sacatepéquez
+San Juan Sacatepéquez
+San José Pinula
+San Francisco El Alto
+San Cristóbal Verapaz
+San Benito
+Sanarate
+San Andrés Itzapa
+Salamá
+Retalhuleu
+Quetzaltenango
+Puerto San José
+Puerto Barrios
+Tiquisate
+Poptún
+Petapa
+Patzún
+Patzicía
+Panzós
+Palín
+Palencia
+Ostuncalco
+Nuevo San Carlos
+Nebaj
+Nahualá
+Morales
+Momostenango
+Mixco
+Mazatenango
+La Gomera
+La Esperanza
+Jutiapa
+Jocotenango
+Jalapa
+Jacaltenango
+Huehuetenango
+Gualán
+Fraijanes
+Flores
+Esquipulas
+Escuintla
+El Tejar
+El Palmar
+El Estor
+Cuilapa
+Comitancillo
+Comalapa
+Colomba
+Cobán
+Coatepeque
+Ciudad Vieja
+Guatemala City
+Chisec
+Chiquimula
+Chinautla
+Chimaltenango
+Chichicastenango
+Chicacao
+Cantel
+Barberena
+Asunción Mita
+Antigua Guatemala
+Amatitlán
+Alotenango
+Tamuning-Tumon-Harmon Village
+Yigo Village
+Guam Government House
+Dededo Village
+Hagåtña
+Mangilao Village
+Bissau
+Bafatá
+New Amsterdam
+Linden
+Georgetown
+Tsuen Wan
+Yuen Long Kau Hui
+Tuen Mun
+Tai Po
+Sha Tin
+Kowloon
+Hong Kong
+Puerto Cortez
+Yoro
+Villanueva
+Tocoa
+Tela
+Tegucigalpa
+Siguatepeque
+Santa Rosa de Copán
+Santa Bárbara
+San Pedro Sula
+San Lorenzo
+Potrerillos
+Olanchito
+La Paz
+La Lima
+La Ceiba
+Juticalpa
+El Progreso
+El Paraíso
+Danlí
+Comayagua
+Cofradía
+Ciudad Choluteca
+Choloma
+Zaprešić
+Zagreb
+Zadar
+Vukovar
+Virovitica
+Vinkovci
+Velika Gorica
+Varaždin
+Split
+Solin
+Slavonski Brod
+Požega
+Sisak
+Šibenik
+Sesvete
+Samobor
+Rijeka
+Pula
+Osijek
+Koprivnica
+Karlovac
+Dubrovnik
+Čakovec
+Bjelovar
+Zagreb- Stenjevec
+Zagreb - Centar
+Verrettes
+Thomazeau
+Saint-Raphaël
+Saint-Marc
+Port-de-Paix
+Port-au-Prince
+Tigwav
+Pétionville
+Miragoâne
+Lenbe
+Léogâne
+Kenscoff
+Jérémie
+Jacmel
+Hinche
+Gressier
+Grangwav
+Gonayiv
+Fond Parisien
+Désarmes
+Delmas 73
+Croix des Bouquets
+Les Cayes
+Carrefour
+Okap
+Ti Port-de-Paix
+Törökszentmiklós
+Tiszaújváros
+Szolnok
+Szentes
+Szeged
+Szarvas
+Sátoraljaújhely
+Püspökladány
+Ózd
+Orosháza
+Nyíregyháza
+Miskolc
+Mezőtúr
+Mezőkövesd
+Mátészalka
+Makó
+Kisvárda
+Kazincbarcika
+Karcag
+Hódmezővásárhely
+Hajdúszoboszló
+Hajdúnánás
+Hajdúböszörmény
+Gyula
+Gyomaendrőd
+Eger
+Debrecen
+Csongrád
+Berettyóújfalu
+Békéscsaba
+Békés
+Balmazújváros
+Abony
+Zalaegerszeg
+Veszprém
+Vecsés
+Várpalota
+Vác
+Tatabánya
+Tata
+Tapolca
+Szombathely
+Szigetszentmiklós
+Szentendre
+Szekszárd
+Székesfehérvár
+Százhalombatta
+Sopron
+Siófok
+Sárvár
+Salgótarján
+Pécs
+Parádsasvár
+Pápa
+Paks
+Oroszlány
+Nagykőrös
+Nagykanizsa
+Mosonmagyaróvár
+Monor
+Mohács
+Komló
+Komárom
+Kiskunhalas
+Kiskunfélegyháza
+Kiskőrös
+Keszthely
+Kecskemét
+Kaposvár
+Kalocsa
+Jászberény
+Hatvan
+Győr
+Gyöngyös
+Gyál
+Gödöllő
+Göd
+Fót
+Esztergom
+Érd
+Dunaújváros
+Dunakeszi
+Dunaharaszti
+Dombóvár
+Dabas
+Cegléd
+Budapest
+Budaörs
+Balassagyarmat
+Baja
+Ajka
+Budapest XII. kerület
+Budapest XI. kerület
+Budapest IX. kerület
+Budapest VIII. kerület
+Budapest VII. kerület
+Budapest VI. kerület
+Budapest XIV. kerület
+Budapest XIII. kerület
+Budapest IV. kerület
+Budapest XV. kerület
+Budapest XVI. kerület
+Budapest X. kerület
+Budapest XIX. kerület
+Budapest XVIII. kerület
+Budapest XXIII. kerület
+Budapest XXII. kerület
+Budapest XXI. kerület
+Budapest XX. kerület
+Budapest XVII. kerület
+Budapest III. kerület
+Budapest II. kerület
+Budapest I. kerület
+Tongging
+Teluk Nibung
+Tebingtinggi
+Tanjungtiram
+Tanjungbalai
+Sunggal
+Stabat
+Singkil
+Sigli
+Sibolga
+Sabang
+Reuleuet
+Rantauprapat
+Percut
+Perbaungan
+Pematangsiantar
+Pangkalan Brandan
+Padangsidempuan
+Meulaboh
+Medan
+Lhokseumawe
+Langsa
+Labuhan Deli
+Kisaran
+Kabanjahe
+Deli Tua
+Bireun
+Binjai
+Berastagi
+Belawan
+Bandar
+Banda Aceh
+Yogyakarta
+Wonosobo
+Wonopringgo
+Wongsorejo
+Wiradesa
+Weru
+Weleri
+Welahan
+Wedi
+Watampone
+Wangon
+Wanaraja
+Waingapu
+Ungaran
+Makassar
+Ubud
+Tulungagung
+Tulangan Utara
+Tuban
+Tual
+Trucuk
+Trenggalek
+Tondano
+Tomohon
+Ternate
+Terbanggi Besar
+Tegal
+Tayu
+Tasikmalaya
+Tarub
+Tarakan
+Tanjungpinang
+Tanjung Pandan
+Bandar Lampung
+Tanjungagung
+Tanggulangin
+Tangerang
+Tabanan
+Surakarta
+Surabaya
+Sungai Raya
+Sungai Penuh
+Sungailiat
+Sumenep
+Sumedang Utara
+Sumberpucung
+Sumber
+Sumbawa Besar
+Sokaraja
+Sukabumi
+Srono
+Srandakan
+Sragen
+Sorong
+Soreang
+Solok
+Soko
+Sofifi
+Soe
+Sleman
+Slawi
+Situbondo
+Sinjai
+Singosari
+Singojuruh
+Singkawang
+Sengkang
+Singaraja
+Singaparna
+Simpang
+Sijunjung
+Sidoarjo
+Sidareja
+Sewon
+Serpong
+Serang
+Sepatan
+Semarang
+Selogiri
+Sawangan
+Sampit
+Sampang
+Samarinda
+Salatiga
+Ruteng
+Rengasdengklok
+Rembangan
+Rantepao
+Rangkasbitung
+Randudongkal
+Rajapolah
+Purwokerto
+Purwodadi
+Purwakarta
+Purbalingga
+Pundong
+Probolinggo
+Prigen
+Praya
+Candi Prambanan
+Poso
+Pontianak
+Ponorogo
+Polewali
+Plumbon
+Petarukan
+Prabumulih
+Pemangkat
+Pemalang
+Pelabuhanratu
+Pekanbaru
+Pekalongan
+Pecangaan
+Payakumbuh
+Pati
+Pasuruan
+Paseh
+Pasarkemis
+Parung
+Pariaman
+Parepare
+Pare
+Panji
+Pangkalpinang
+Pangkalanbuun
+Pandeglang
+Pandaan
+Pandak
+Panarukan
+Pamulang
+Pameungpeuk
+Pamekasan
+Pamanukan
+Palu
+Palopo
+Palimanan
+Palembang
+Palangkaraya
+Pakisaji
+Pageralam
+Padang
+Paciran
+Ngunut
+Ngoro
+Ngawi
+Nganjuk
+Negara
+Nabire
+Muntok
+Muntilan
+Muncar
+Mranggen
+Mojokerto
+Mojoagung
+Mlonggo
+Metro
+Mertoyudan
+Melati
+Maumere
+Mataram
+Martapura
+Margasari
+Margahayukencana
+Manokwari
+Manismata
+Manggar
+Mendaha
+Manado
+Malang
+Majene
+Majenang
+Majalengka
+Magelang
+Madiun
+Luwuk
+Lumajang
+Lubuklinggau
+Loa Janan
+Lembang
+Lebaksiu
+Lawang
+Lasem
+Lamongan
+Lahat
+Labuan Bajo
+Labuan
+Kutoarjo
+Kuta
+Kuningan
+Kudus
+Kuala Tungkal
+Kualakapuas
+Kroya
+Krian
+Kresek
+Kraksaan
+Kotabumi
+Klungkung
+Klaten
+Klangenan
+Kijang
+Ketanggungan
+Kertosono
+Kepanjen
+Kendari
+Kencong
+Kefamenanu
+Kedungwuni
+Kedungwaru
+Kediri
+Kebonarun
+Kebomas
+Kawalu
+Katabu
+Karangsembung
+Karangasem
+Karanganom
+Karangampel
+Kamal
+Kalianget
+Juwana
+Jombang
+Jogonalan
+Jember
+Jekulo
+Jatiwangi
+Jatiroto
+Jatibarang
+Jaten
+Jambi City
+Jakarta
+Indramayu
+Grogol
+Gresik
+Gorontalo
+Gongdanglegi Kulon
+Gombong
+Godean
+Genteng
+Gedangan
+Gebog
+Gampengrejo
+Gambiran Satu
+Galesong
+Ende
+Dumai
+Dukuhturi
+Driyorejo
+Dompu
+Diwek
+Depok
+Depok
+Denpasar
+Demak
+Delanggu
+Dampit
+Curup
+Curug
+Comal
+Colomadu
+Citeureup
+Cirebon
+Ciputat
+Cimahi
+Cileunyi
+Cileungsir
+Cikarang
+Cikampek
+Cicurug
+Cibinong
+Ciamis
+Cepu
+Ceper
+Caringin
+Ciampea
+Bulakamba
+Bukittinggi
+Buduran
+Buaran
+Boyolangu
+Boyolali
+Bontang
+Bondowoso
+Bojonegoro
+Bogor
+Blora
+Blitar
+Bitung
+Bima
+Besuki
+Bengkulu
+Bekasi
+Baturaja
+Baturaden
+Batu
+Batang
+Barabai
+Banyuwangi
+Banyumas
+Bantul
+Banjarmasin
+Banjaran
+Banjar
+Banjar
+Bangkalan
+Bangil
+Bandung
+Bambanglipuro
+Balung
+Balikpapan
+Balapulang
+Balaipungut
+Baki
+Baekrajan
+Babat
+Atambua
+Astanajapura
+Arjawinangun
+Amuntai
+Ambon
+Ambarawa
+Amahai
+Adiwerna
+Padalarang
+Ciranjang-hilir
+Cikupa
+Teluknaga
+Wonosari
+Gamping Lor
+Kasihan
+Ngemplak
+Kartasura
+Gatak
+Kupang
+Jayapura
+Abepura
+Seririt
+City of Balikpapan
+Pekan Bahapal
+South Tangerang
+Loch Garman
+Waterford
+Tralee
+Tallaght
+Swords
+Sligo
+Droichead Nua
+Navan
+Naas
+An Muileann gCearr
+Malahide
+Lucan
+Luimneach
+Letterkenny
+Leixlip
+Kilkenny
+Gaillimh
+Finglas
+Ennis
+Dún Laoghaire
+Dundalk
+Dublin
+Drogheda
+Cork
+Cluain Meala
+Celbridge
+Carlow
+Blanchardstown
+Balbriggan
+Athlone
+Sandyford
+Donaghmede
+Jerusalem
+Safed
+Yehud
+Yavné
+Yafo
+Umm el Faḥm
+Tirat Karmel
+Tiberias
+Tel Aviv
+maalot Tarshīhā
+Tamra
+Sederot
+Sakhnīn
+Rosh Ha‘Ayin
+Rishon LeẔiyyon
+Ramla
+Ramat HaSharon
+Ramat Gan
+Ra'anana
+Qiryat Yam
+Qiryat Shemona
+Qiryat Moẕqin
+Qiryat Gat
+Qiryat Bialik
+Qiryat Ata
+Qalansuwa
+Petaẖ Tiqwa
+Or Yehuda
+Ofaqim
+Netivot
+Netanya
+Ness Ziona
+Nesher
+Nazareth
+Nahariya
+Migdal Ha‘Emeq
+Mevo Betar
+Maghār
+Lod
+Kfar Saba
+Karmi’el
+Kafr Qāsim
+Kafr Mandā
+Kafr Kannā
+Judeida Makr
+H̱olon
+Hod HaSharon
+Herzliyya
+Haifa
+H̱adera
+Giv‘at Shemu’él
+Giv‘atayim
+Tirah
+Eṭ Ṭaiyiba
+Er Reina
+Eilat
+Dimona
+Dāliyat el Karmil
+Bet Shemesh
+Bet She’an
+Bené Beraq
+Beersheba
+Bat Yam
+Ashqelon
+Ashdod
+‘Arad
+‘Akko
+‘Afula ‘Illit
+Modiin
+West Jerusalem
+Modiin Ilit
+Ariel
+Douglas
+Pūnch
+Keelakarai
+Zunheboto
+Zamānia
+Zaidpur
+Zahirābād
+Yeola
+Yellāpur
+Yellandu
+Yelahanka
+Yavatmāl
+Yāval
+Yanam
+Yamunānagar
+Yādgīr
+Wokha
+Wer
+Wellington
+Wazīrganj
+Wāshīm
+Warud
+Warora
+Wāris Alīganj
+Wardha
+Wārāseonī
+Warangal
+Wanparti
+Wānkāner
+Wani
+Walajapet
+Wai
+Wādi
+Vyāra
+Vuyyūru
+Vrindāvan
+Vriddhāchalam
+Vizianagaram
+Vite
+Visnagar
+Visakhapatnam
+Vīsāvadar
+Virudunagar
+Viravanallūr
+Vīrarājendrapet
+Virār
+Vinukonda
+Villupuram
+Vikārābād
+Vijayawada
+Vijāpur
+Vidisha
+Vettūr
+Vettaikkaranpudur
+Vetapālem
+Verāval
+Vepagunta
+Venkatagiri
+Vemalwāda
+Velur
+Vellore
+Vejalpur
+Vedaraniyam
+Vayalār
+Vattalkundu
+Vāsudevanallūr
+Vasind
+Vāsco Da Gāma
+Vasa
+Varkala
+Varangaon
+Varanasi
+Vaniyambadi
+Vandavāsi
+Valsād
+Valparai
+Vallabh Vidyanagar
+Valabhīpur
+Vaikam
+Vaijāpur
+Vadodara
+Vadnagar
+Vadlapūdi
+Vādippatti
+Vadamadurai
+Vadakku Valliyūr
+Vāda
+Uttiramerūr
+Uttarkāshi
+Uttamapālaiyam
+Utraula
+Usilampatti
+Usehat
+Uravakonda
+Uran
+Upleta
+Uppal Kalan
+Unnāo
+Unjha
+Unhel
+Una
+Una
+Ūn
+Un
+Umreth
+Umred
+Umarkot
+Umarkhed
+Umaria
+Umarga
+Ullal
+Ulhasnagar
+Ujjain
+Ujhāni
+Udumalaippettai
+Udipi
+Udhampur
+Udgīr
+Udankudi
+Udalguri
+Udaipura
+Udaipur
+Udaipur
+Udaipur
+Ooty
+Bara Uchāna
+Turaiyūr
+Tura
+Tuni
+Tūndla
+Tumsar
+Tumkūr
+Tulsīpur
+Tuljāpur
+Tufānganj
+Tuensang
+Thiruvananthapuram
+Trichūr
+Tonk
+Tondi
+Tohāna
+Todaraisingh
+Todabhim
+Titlāgarh
+Titāgarh
+Tisaiyanvilai
+Tiruvottiyūr
+Cheyyar
+Tiruvannāmalai
+Tiruvallur
+Tiruvalla
+Thiruthani
+Tiruttangal
+Tirur
+Tiruppuvanam
+Tiruppur
+Tirupparangunram
+Tirupati
+Tirunelveli
+Tirumala
+Tirukkoyilur
+Tiruchengode
+Tiruchirappalli
+Tiruchchendur
+Tīrthahalli
+Tiptūr
+Tinsukia
+Tinnanūr
+Tindivanam
+Tilhar
+Tīkamgarh
+Tijāra
+Thoubāl
+Thiruvarur
+Thāsra
+Tharād
+Thanjāvūr
+Thānesar
+Thāne
+Thāna Bhawan
+Thān
+Thākurganj
+Thakurdwara
+Tezpur
+Terdāl
+Teonthar
+Thenkasi
+Teni
+Tellicherry
+Telhāra
+Tekkali
+Tekkalakote
+Tekāri
+Tehri
+Teghra
+Tāsgaon
+Tarn Tāran
+Tarikere
+Tharangambadi
+Tārānagar
+Tarāna
+Tāramangalam
+Tarakeswar
+Tāoru
+Tanuku
+Tāndūr
+Tānda
+Tāndā
+Tanakpur
+Tamlūk
+Talwāra
+Talwandi Bhai
+Taloda
+Talipparamba
+Tālīkota
+Taleigao
+Talegaon Dābhāde
+Tālcher
+Talāja
+Tāki
+Takhatpur
+Takhatgarh
+Tājpur
+Tādpatri
+Tādepallegūdem
+Tādepalle
+Suriāpet
+Suriānwān
+Surendranagar
+Sūratgarh
+Sūrat
+Sūrandai
+Sūrajgarh
+Supaul
+Sunel
+Sundarnagar
+Sundargarh
+Sunām
+Sulya
+Sūlūru
+Sulur
+Sultanpur
+Sultānpur
+Suket
+Sūjāngarh
+Suār
+Srivilliputhur
+Srīvardhan
+Srivaikuntam
+Srīsailain
+Srīrāmnagar
+Srīperumbūdūr
+Srīnivāspur
+Srinagar
+Srīnagar
+Sri Mādhopur
+Karanpur
+Chicacole
+Sri Dūngargarh
+Soygaon
+Soron
+Soro
+Sorada
+Sopur
+Sonīpat
+Songadh
+Sonepur
+Sonāri
+Sonāmukhi
+Sompeta
+Someshwar
+Solan
+Sojītra
+Sojat
+Sohna
+Sohāgpur
+Siwāna
+Siwān
+Sivakasi
+Sivagiri
+Sivagiri
+Sivaganga
+Siuri
+Sitārganj
+Sītāpur
+Sītāmarhi
+Siswā Bāzār
+Sisauli
+Sirūr
+Sirumugai
+Siruguppa
+Sirsilla
+Sirsi
+Sirsi
+Sirsāganj
+Sirsa
+Sironj
+Sirohi
+Sīrkāzhi
+Sirhind
+Sīra
+Sinnar
+Singur
+Singarāyakonda
+Singānallūr
+Sindhnūr
+Sindgi
+Shimla
+Simdega
+Silvassa
+Sillod
+Silchar
+Silao
+Sīkar
+Sikandra Rao
+Sikandarpur
+Sikandarābād
+Sikka
+Sijua
+Sihorā
+Sihor
+Sidlaghatta
+Sidhi
+Sidhaulī
+Siddipet
+Siddhapur
+Sibsāgar
+Shyamnagar
+Shujālpur
+Shrīrangapattana
+Shrīrāmpur
+Shrīgonda
+Shorāpur
+Shoranūr
+Sholinghur
+Solāpur
+Shivpuri
+Shīshgarh
+Shirpur
+Shirhatti
+Shirdi
+Shimoga
+Shillong
+Shiliguri
+Shikohābād
+Shikārpūr
+Shikārpur
+Shiggaon
+Shertallai
+Sherkot
+Sherghāti
+Sheopur
+Sheohar
+Sheoganj
+Shegaon
+Shāntipur
+Shamsābād
+Shamsābād
+Shāmli
+Shāmgarh
+Shājāpur
+Sheikhpura
+Shāhpura
+Shāhpura
+Shāhpur
+Shāhpur
+Shāhpur
+Shāhpur
+Shāhjānpur
+Shāhi
+Shāhganj
+Shahdol
+Shāhāda
+Shāhābād
+Shāhābād
+Shāhābād
+Shāhābād
+Serchhīp
+Seram
+Seoni Mālwa
+Seoni
+Seondha
+Seohāra
+Sendhwa
+Sehore
+Secunderabad
+Sāyla
+Sawāi Mādhopur
+Sāvda
+Savanūr
+Sāvantvādi
+Sausar
+Saundatti
+Sathyamangalam
+Sattur
+Sattenapalle
+Satna
+Sātāra
+Satānā
+Sāsvad
+Sarwār
+Sarkhej
+Sardulgarh
+Sardhana
+Sardārshahr
+Sarauli
+Sārangpur
+Saraipali
+Sarāi Mīr
+Sarāi Ākil
+Saoner
+Sānkrāil
+Sankeshwar
+Sangrūr
+Sāngola
+Sangod
+Sāngli
+Sangariā
+Sangāreddi
+Sangamner
+Sandūr
+Sandīla
+Sāndi
+Sancoale
+Sānchor
+Sanāwad
+Sanaur
+Sānand
+Samthar
+Samrāla
+Samdari
+Sāmbhar
+Sambhal
+Sambalpur
+Sāmba
+Samāstipur
+Sāmalkot
+Samālkha
+Sālūr
+Sālūmbar
+Salem
+Salāya
+Saktī
+Sakleshpur
+Saint Thomas Mount
+Sainthia
+Selu
+Saiha
+Saidpur
+Sāhibganj
+Sahāwar
+Sahaswān
+Sahaspur
+Saharsa
+Sahāranpur
+Sagauli
+Saugor
+Sāgar
+Safīpur
+Safidon
+Sādri
+Sadāseopet
+Sadalgi
+Sadābād
+Sabalgarh
+Rusera
+Rura
+Ropar
+Rūdarpur
+Roorkee
+Ron
+Rohtak
+Roha
+Robertsonpet
+Robertsganj
+Risod
+Rishra
+Rishīkesh
+Rīngas
+Richha
+Rewāri
+Rewa
+Revelganj
+Repalle
+Reoti
+Renukūt
+Renigunta
+Remuna
+Rehli
+Rāzām
+Rāybāg
+Rāyadrug
+Rāyachoti
+Rāya
+Raxaul
+Rāwatsār
+Rāwatbhāta
+Rāver
+Ratnagiri
+Ratlām
+Ratia
+Rāth
+Ratanpur
+Ratangarh
+Rasrā
+Rasipuram
+Rāpar
+Rānīpur
+Rānikhet
+Rānīganj
+Rānībennur
+Rānia
+Rangia
+Rangāpāra
+Ranchi
+Rānāvāv
+Rānāghāt
+Rāmtek
+Rampur Hat
+Rāmpura
+Rāmpura
+Rāmpur
+Rāmpur
+Rāmnagar
+Rāmnagar
+Rāmnagar
+Rāmjībanpur
+Rāmgundam
+Rāmgarh
+Rāmgarh
+Rāmganj Mandi
+Rameswaram
+Rāmāpuram
+Ramanathapuram
+Rāmanagaram
+Rāmachandrapuram
+Rājūra
+Rājula
+Rājsamand
+Rājpura
+Rajpur
+Rajpur
+Rājpīpla
+Rāj-Nāndgaon
+Rājmahal
+Rājkot
+Rājgurunagar
+Rājgīr
+Rājgarh
+Rājgarh
+Rājgarh
+Rājgarh
+Rajaori
+Rajapalaiyam
+Rājampet
+Rājaldesar
+Rājākhera
+Rājahmundry
+Rāisinghnagar
+Raisen
+Rāipur
+Raipur
+Raipur
+Rāikot
+Raigarh
+Rāiganj
+Rāichūr
+Rāhuri
+Rahimatpur
+Rāhatgarh
+Raghunathpur
+Rāghogarh
+Rafiganj
+Raebareli
+Rādhanpur
+Rabkavi
+Kollam
+Kasba
+Qādiān
+Puttūr
+Puttūr
+Pushkar
+Pusad
+Purwā
+Puruliya
+Purnia
+Pūrna
+Puri
+Pūranpur
+Pupri
+Punjai Puliyampatti
+Punganūru
+Pune
+Pūndri
+Punāsa
+Punalūr
+Pūnāhāna
+Pulwama
+Puliyangudi
+Pulivendla
+Pulgaon
+Pukhrāyān
+Pudukkottai
+Proddatūr
+Pratāpgarh
+Port Blair
+Porsa
+Porbandar
+Poonamalle
+Ponnūru
+Ponneri
+Ponnāni
+Puducherry
+Ponda
+Polūr
+Pollachi
+Polavaram
+Polasara
+Pokaran
+Pithorāgarh
+Pithāpuram
+Piro
+Piriyāpatna
+Piravam
+Pīpri
+Pipraich
+Pipili
+Pīpār
+Pinjaur
+Pindwāra
+Pināhat
+Pimpri
+Pilkhua
+Pīlibhīt
+Pilibangan
+Pilāni
+Pihānī
+Phulpur
+Phulera
+Phulabāni
+Phirangipuram
+Phillaur
+Phek
+Phaphūnd
+Phaltan
+Phalodi
+Phalauda
+Phagwāra
+Petlād
+Perundurai
+Perumpāvūr
+Periyanayakkanpalaiyam
+Periyakulam
+Peravurani
+Peranāmpattu
+Perambalur
+Penukonda
+Penugonda
+Pennāgaram
+Pennādam
+Pen
+Pehowa
+Peddāpuram
+Peddapalli
+Pedana
+Payyannūr
+Pawāyan
+Pāvugada
+Pauri
+Pawni
+Pātūr
+Pattukkottai
+Patti
+Patnāgarh
+Patna
+Patiāla
+Pāthri
+Patharia
+Pāthardih
+Pāthardi
+Pathānkot
+Pathanāmthitta
+Pathalgaon
+Pataudi
+Patancheru
+Pātan
+Patāmundai
+Pāsighāt
+Pasān
+Parvatsar
+Pārvatipuram
+Partūr
+Parola
+Parli Vaijnāth
+Parlākimidi
+Pariyāpuram
+Parīchhatgarh
+Pārdi
+Parbhani
+Paravūr
+Parāsia
+Paramagudi
+Parādīp Garh
+Pāppinisshēri
+Papanasam
+Pāonta Sāhib
+Panvel
+Panruti
+Panna
+Panmana
+Pānīpat
+Pānihāti
+Pandua
+Pāndhurnā
+Pandharpur
+French Rocks
+Panaji
+Panāgar
+Palwal
+Pāloncha
+Palani
+Palmaner
+Pallippatti
+Pallikondai
+Pallāvaram
+Pallappatti
+Palladam
+Pālkonda
+Pālitāna
+Paliā Kalān
+Pāli
+Pāli
+Palakkad
+Pālghar
+Palera
+Palāsa
+Pālanpur
+Pālakollu
+Pālakkodu
+Pākaur
+Pākāla
+Paithan
+Pahāsu
+Padrauna
+Padra
+Padmanābhapuram
+Padampur
+Padampur
+Padam
+Pachperwa
+Pāchora
+Ottappālam
+Osmanabad
+Orai
+Ongole
+Okha
+Ozar
+Obra
+Nūzvīd
+Nūrpur
+Nowrangapur
+North Lakhimpur
+North Guwāhāti
+Nongstoin
+Nokha
+Nohar
+Noāmundi
+Nizāmābād
+Nirmāli
+Nirmal
+Nipāni
+Neem ka Thana
+Nīmbāhera
+Nimāparha
+Nīmāj
+Nīlokheri
+Nīlēshwar
+Nilanga
+Nilakottai
+Nīlgiri
+Nihtaur
+Nidadavole
+Nichlaul
+Neyyāttinkara
+New Delhi
+Neral
+Nepānagar
+Nellore
+Nellikkuppam
+Nelamangala
+Nedumangād
+Nāyudupeta
+Nayāgarh
+Nawāshahr
+Nawalgarh
+Niwai
+Nawāda
+Nawābganj
+Nawābganj
+Nawābganj
+Nāwa
+Navalgund
+Navadwīp
+Nautanwa
+Naugachhia
+Nattam
+Nāthdwāra
+Nasrullāhganj
+Nāsriganj
+Nāspur
+Nasīrābād
+Nashik
+Narwar
+Narwāna
+Narsīpatnam
+Narsinghgarh
+Narsimhapur
+Nārnaund
+Nārnaul
+Nargund
+Naregal
+Nārāyanpet
+Narāyangarh
+Nāravārikuppam
+Naraura
+Narauli
+Narasaraopet
+Narasapur
+Narasannapeta
+Naraini
+Naraina
+Napāsar
+Nānpāra
+Nanjangūd
+Nāngloi Jāt
+Nāngal Township
+Nandyāl
+Nandurbar
+Nāndūra Buzurg
+Nandikotkūr
+Nandigāma
+Nāndgaon
+Nanded
+Nanauta
+Nāmrup
+Nambiyūr
+Nāmakkal
+Nāmagiripettai
+Nalhāti
+Nalgonda
+Naldurg
+Nakūr
+Naksalbāri
+Nakodar
+Najībābād
+Nainwa
+Nainpur
+Naini Tāl
+Naihāti
+Nahorkatiya
+Nāhan
+Nagpur
+Nāgod
+Nagīna
+Nāgercoil
+Nagda
+Nāgaur
+Nāgar Karnūl
+Nagari
+Nagar
+Nāgappattinam
+Nāgamangala
+Naduvannūr
+Nadiād
+Nādbai
+Nādāpuram
+Nabīnagar
+Nābha
+Mysore
+Muzaffarpur
+Muzaffarnagar
+Mūvattupula
+Muttupet
+Mussoorie
+Musiri
+Mushābani
+Murwāra
+Murtajāpur
+Murshidābād
+Murlīganj
+Morinda
+Murbād
+Murādnagar
+Munnar
+Monghyr
+Mungeli
+Mungaoli
+Mūndwa
+Mundra
+Mundgod
+Mundargi
+Multai
+Mūlki
+Mulgund
+Mulbāgal
+Muluppilagadu
+Mūl
+Muktsar
+Mukher
+Mukeriān
+Muhammadābād
+Muhammadābād
+Muhammadābād
+Mughal Sarāi
+Mudkhed
+Mudhol
+Mudgal
+Muddebihāl
+Mūdbidri
+Mubārakpur
+Mothīhāri
+Morwa
+Morsi
+Morena
+Morbi
+Morār
+Moram
+Morādābād
+Mon
+Mokokchūng
+Mokameh
+Moirāng
+Moga
+Modāsa
+Misrikh
+Mirzāpur
+Miriālgūda
+Mīrganj
+Mīrānpur Katra
+Mīrānpur
+Mīnjūr
+Milak
+Mihona
+Mhāsvād
+Mettur
+Mettupalayam
+Merta
+Mendarda
+Memāri
+Melur
+Mehndāwal
+Mehekar
+Meerut
+Medinīpur
+Medak
+Mayiladuthurai
+Mayāng Imphāl
+Mawāna
+Mavoor
+Māvelikara
+Maur
+Mauganj
+Maudaha
+Mau Aimma
+Mau
+Mau
+Mattanūr
+Mathura
+Mātābhānga
+Masaurhi Buzurg
+Marmagao
+Mārkāpur
+Mariāni
+Mariāhu
+Marhaura
+Margherita
+Marakkanam
+Mārahra
+Māpuca
+Mānwat
+Mānvi
+Manthani
+Mānsa
+Mānsa
+Manoharpur
+Mannargudi
+Mannārakkāt
+Manmād
+Mankāchar
+Mājalgaon
+Manjhanpur
+Manjeri
+Manihāri
+Maniar
+Mangrūl Pīr
+Māngrol
+Māngrol
+Manglaur
+Mangalore
+Mangaldai
+Mangalagiri
+Maner
+Mandya
+Māndvi
+Māndvi
+Māndu
+Mandsaur
+Mandlā
+Mandi
+Mandāwar
+Mandapeta
+Mandapam
+Māndalgarh
+Māndal
+Mancherāl
+Manāwar
+Mānāvadar
+Manāsa
+Manapparai
+Manamadurai
+Manali
+Mālvan
+Mālūr
+Mālpura
+Malpe
+Mallasamudram
+Malkāpur
+Malakanagiri
+Malīhābād
+Māler Kotla
+Mālegaon
+Malavalli
+Malaut
+Malappuram
+Mākum
+Maksi
+Makrāna
+Mairwa
+Mainpuri
+Maināguri
+Maihar
+Mahwah
+Mahudha
+Maholi
+Mahobā
+Mahmudābād
+Mahīshādal
+Mahgawān
+Maheshwar
+Mahendragarh
+Mahemdāvād
+Mahē
+Mahbūbnagar
+Mahbūbābād
+Mahāsamund
+Mahārāganj
+Mahārājgani
+Maham
+Mahālingpur
+Mahād
+Maghar
+Māgadi
+Madurāntakam
+Madurai
+Madukkūr
+Madukkarai
+Chennai
+Madikeri
+Madhyamgram
+Madhupur
+Maddagiri
+Madhubani
+Madhipura
+Madgaon
+Maddūr
+Madanapalle
+Machilīpatnam
+Machhlīshahr
+Māchhīwāra
+Mācherla
+Lunglei
+Lūnāvāda
+Ludhiāna
+Lucknow
+Luckeesarai
+Losal
+Loni
+Lonavla
+Lonār
+Lohārdaga
+Lingsugūr
+Limbdi
+Leteri
+Leh
+Lāwar Khās
+Laungowāl
+Latur
+Lāthi
+Lātehār
+Lar
+Lālsot
+Lālpur
+Lalitpur
+Lalgudi
+Lālgola
+Lālganj
+Lālganj
+Lakshmeshwar
+Laksar
+Lakhyabad
+Lakhnādon
+Lakhīmpur
+Lākheri
+Lāharpur
+Lahār
+Lādwa
+Lādnūn
+Lachhmangarh Sīkar
+Kuzhithurai
+Koothanallur
+Kuttampuzha
+Kutiyāna
+Kutiatodu
+Kushtagi
+Kurinjippādi
+Kurduvādi
+Kurandvād
+Kuppam
+Kunnamkulam
+Kunnamangalam
+Kunigal
+Kundla
+Kundgol
+Kundarkhi
+Kunda
+Kumta
+Kūmher
+Kumhāri
+Kumbhrāj
+Kumbakonam
+Kulu
+Kulti
+Kulpahār
+Kulittalai
+Kulgam
+Kukshi
+Kūkatpalli
+Kuju
+Kūdligi
+Kudachi
+Kuchera
+Kuchāman
+Kuchaiburi
+Krishnarājpet
+Krishnanagar
+Krishnagiri
+Kozhikode
+Koynanagar
+Kovvūr
+Kovūr
+Kovilpatti
+Kottūru
+Kottayam
+Kottagūdem
+Kotputli
+Kotma
+Kotdwāra
+Kotapārh
+Kotamangalam
+Kotagiri
+Kota
+Kotā
+Kosigi
+Kosi
+Kosamba
+Korwai
+Koregaon
+Korba
+Koratla
+Korāput
+Koppal
+Kopargaon
+Kopāganj
+Konnūr
+Konnagar
+Kondapalle
+Kondagaon
+Konch
+Konārka
+Kolasib
+Kollegāl
+Kolhāpur
+Kolāras
+Kolār
+Colachel
+Kokrajhar
+Kohima
+Koelwār
+Kodungallūr
+Kodoli
+Kodīnar
+Kodarmā
+Kodār
+Kodaikānāl
+Koch Bihār
+Koāth
+Kizhake Chālakudi
+Kithor
+Kishtwār
+Kishangarh
+Kishanganj
+Kīratpur
+Kiraoli
+Kinwat
+Kichha
+Khūtār
+Khurja
+Khurda
+Khurai
+Khunti
+Khuldābād
+Khowai
+Khopoli
+Khirkiyān
+Khilchipur
+Khetri
+Khetia
+Kheri
+Kherālu
+Khekra
+Khed Brahma
+Kheda
+Khātra
+Khatīma
+Khātegaon
+Khatauli
+Khārupatia
+Kharsia
+Kharkhauda
+Khargone
+Khardah
+Kharar
+Kharakvasla
+Kharagpur
+Kharagpur
+Khāpa
+Khanna
+Khandwa
+Khandela
+Khānāpur
+Khammam
+Khāmgaon
+Khambhāt
+Khambhāliya
+Khamaria
+Khalīlābād
+Khajurāho
+Khairāgarh
+Khairāgarh
+Khairābād
+Khair
+Khagaul
+Khagaria
+Khadki
+Khada
+Khāchrod
+Kesinga
+Keshorai Pātan
+Keshod
+Kerūr
+Kendrāparha
+Kenda
+Kemrī
+Kekri
+Kāyankulam
+Kayalpattinam
+Kawardha
+Kāvali
+Kattivākkam
+Kattanam
+Kātrās
+Kātpādi
+Kātoya
+Kātol
+Katihar
+Kathua
+Kāthor
+Katghora
+Katangi
+Katangi
+Kasrāwad
+Kashipur
+Kāsganj
+Kāsaragod
+Karwar
+Karur
+Kartārpur
+Kārsiyāng
+Karol Bāgh
+Karnāl
+Karmāla
+Kārkala
+Karjat
+Karīmnagar
+Karīmganj
+Karhal
+Karera
+Kareli
+Karauli
+Kāranja
+Karamsad
+Kāramadai
+Kāraikkudi
+Kāraikāl
+Karād
+Kapūrthala
+Kāpren
+Kapadvanj
+Kānth
+Kantābānji
+Kānt
+Kanpur
+Kannod
+Kanniyākumāri
+Kannauj
+Kānnangād
+Kannad
+Kānker
+Kānke
+Kankauli
+Kanigiri
+Kangayam
+Kandukūr
+Kāndla
+Kāndi
+Kāndhla
+Kānchipuram
+Kanakapura
+Kāmthi
+Kampli
+Cumbum
+Kāmārhāti
+Kāmāreddi
+Kāman
+Kamalganj
+Kāmākhyānagar
+Kalyani
+Kalyān
+Kalugumalai
+Kālpi
+Kalpetta
+Kālol
+Kālna
+Kalmeshwar
+Kallidaikurichchi
+Kallakkurichchi
+Kālka
+Kāliyāganj
+Kālimpong
+Kalghatgi
+Kālāvad
+Kālānwāli
+Kalānaur
+Kalamnūri
+Kalamb
+Kalakkādu
+Kakrāla
+Kākori
+Kākināda
+Kakching
+Kaithal
+Kairāna
+Kaimori
+Kaimganj
+Kailāshahar
+Kailāras
+Kaikalūr
+Kāgal
+Kadūr
+Kadod
+Kadiri
+Kadi
+Kadayanallur
+Kānchrāpāra
+Kachhwa
+Kabrāi
+Junnar
+Jūnāgarh
+Jūnāgadh
+Jumri Tilaiyā
+Jalandhar
+Jugsālai
+Jorhāt
+Jora
+Jolārpettai
+Jogbani
+Jodiya Bandar
+Jodhpur
+Jodhpur
+Jintūr
+Jīnd
+Jhūsi
+Jhunjhunūn
+Jhinjhāna
+Jhīnjhak
+Jhārsuguda
+Jharia
+Jhārgrām
+Jhānsi
+Jhanjhārpur
+Jhālu
+Jhālrapātan
+Jhalida
+Jhālāwār
+Jhajjar
+Jhā Jhā
+Jhābua
+Jewar
+Jevargi
+Jetpur
+Jeypore
+Jaynagar
+Jaynagar-Majilpur
+Jayamkondacholapuram
+Jāwad
+Jaunpur
+Jatāra
+Jatani
+Jaswantnagar
+Jaspur
+Jasidih
+Jashpurnagar
+Jasdan
+Jarwal
+Jaorā
+Jānsath
+Jānjgīr
+Jangipur
+Jangaon
+Jandiāla
+Jāmuria
+Jamūī
+Jāmtāra
+Jamshedpur
+Jāmnagar
+Jammu
+Jammalamadugu
+Jamkhandi
+Jambusar
+Jamālpur
+Jāmai
+Jāmadoba
+Jalpāiguri
+Jalor
+Jālna
+Jalgaon Jamod
+Jalgaon
+Jaleshwar
+Jalesar
+Jālaun
+Jalālpur
+Jalālpur
+Jalālī
+Jalālābād
+Jalālābad
+Jalālābād
+Jājpur
+Jaito
+Jaitāran
+Jaisingpur
+Jaisalmer
+Jais
+Jaipur
+Jahāzpur
+Jahāngīrābād
+Jahānābād
+Jagtiāl
+Jagraon
+Jaggayyapeta
+Jagdīspur
+Jagdīshpur
+Jagdalpur
+Jagatsinghapur
+Jagalūr
+Jagādhri
+Jabalpur
+Itimādpur
+Itārsi
+Itānagar
+Islāmpur
+Islāmpur
+Islāmnagar
+Irugūr
+Irinjālakuda
+Iringal
+Ingrāj Bāzār
+Indri
+Indore
+Indi
+Indergarh
+Indāpur
+Imphal
+Ilkal
+Igatpuri
+Idappadi
+Ichchāpuram
+Ichalkaranji
+Hyderabad
+Hadagalli
+Husainābād
+Hunsūr
+Hungund
+Hukeri
+Hugli
+Hubli
+Howli
+Hosūr
+Hospet
+Hoskote
+Hoshangābād
+Hosdurga
+Honnāli
+Honāvar
+Homnābād
+Hole Narsipur
+Holalkere
+Hojāi
+Hodal
+Hisuā
+Hisar
+Hiriyūr
+Hirekerūr
+Hīrākud
+Hinjilikatu
+Hingoli
+Hinganghāt
+Hindupur
+Hindoria
+Hindaun
+Himatnagar
+Hilsa
+Hazārībāg
+Hāveri
+Hatta
+Hāthras
+Hastināpur
+Hassan
+Hāsimāra
+Hasanpur
+Harūr
+Harsūd
+Harpanahalli
+Harpālpur
+Hārij
+Harihar
+Haridwar
+Hardoī
+Harda Khās
+Hāpur
+Hāora
+Hanumāngarh
+Hānsi
+Hāngal
+Handiā
+Hamīrpur
+Hamīrpur
+Halvad
+Hālol
+Haliyal
+Hālīsahar
+Haldwani
+Haldaur
+Hājo
+Hājīpur
+Hailākāndi
+Hāflong
+Hadgāon
+Hābra
+Gwalior
+Guskhara
+Guruvāyūr
+Guru Har Sahāi
+Gursarāi
+Gursahāiganj
+Gurmatkāl
+Gurgaon
+Gunupur
+Guntūr
+Guntakal Junction
+Gunnaur
+Gundlupet
+Guna
+Gummidipundi
+Gumla
+Gumia
+Guledagudda
+Gulbarga
+Gulāothi
+Gulābpura
+Gūduvāncheri
+Gūdūr
+Gudiyatham
+Gudivāda
+Gudalur
+Gubbi
+Goyerkāta
+Govardhan
+Gosāba
+Gorakhpur
+Gorakhpur
+Gobichettipalayam
+Gopālganj
+Gondiā
+Gondal
+Gondā City
+Gomoh
+Gola Gokarannāth
+Golāghāt
+Gokarna
+Gokak
+Gohāna
+Gohadi
+Godhra
+Godda
+Gobindpur
+Gobārdānga
+Goālpāra
+Girīdīh
+Gingee
+Giddarbāha
+Giddalūr
+Ghugus
+Ghoti Budrukh
+Ghosī
+Ghazīpur
+Ghāziābād
+Ghātsīla
+Ghātanji
+Ghātampur
+Ghātāl
+Gharaunda
+Gevrai
+Gaya
+Gauripur
+Goribidnūr
+Guwahati
+Garhwa
+Garui
+Gariadhar
+Garhshankar
+Garhmuktesar
+Garhākota
+Gannavaram
+Gangtok
+Gangolli
+Gangoh
+Gangāwati
+Gangārāmpur
+Gangāpur
+Gangāpur
+Gangāpur
+Gangānagar
+Gangākher
+Ghandinagar
+Gāndhīdhām
+Gandevi
+Gāndarbal
+Gajraula
+Gajendragarh
+Gadwāl
+Gadhinglaj
+Gadhada
+Gādarwāra
+Gadag
+Fort Gloster
+Forbesganj
+Fīrozpur Jhirka
+Ferozepore
+Fīrozābād
+Ferokh
+Fāzilka
+Fatwa
+Fatehpur Sīkri
+Fatehpur
+Fatehpur
+Fatehpur
+Fatehgarh Chūriān
+Fatehganj West
+Fatehābād
+Fatehābād
+Farrukhnagar
+Farrukhābād
+Farīdpur
+Farīdkot
+Farīdābād
+Farakka
+Fālākāta
+Faizpur
+Fyzābād
+Etāwah
+Erraguntla
+Erode
+Erāttupetta
+Erandol
+Emmiganūr
+Ellore
+Elūr
+Ellenabad
+Elamanchili
+Egra
+Dwārka
+Durgapur
+Durgāpur
+Durg
+Dūngarpur
+Ganj Dundwāra
+Dumraon
+Dumra
+Dumka
+Dum Duma
+Dam Dam
+Duliāgaon
+Dugda
+Dubrājpur
+Dornakal
+Dorāha
+Dongargarh
+Dondaicha
+Dombivli
+Dod Ballāpur
+Doda
+Diu
+Dīsa
+Diphu
+Dīnhāta
+Dindori
+Dindigul
+Dīnānagar
+Dimāpur
+Digras
+Dīglūr
+Dighwāra
+Digboi
+Dīg
+Dīdwāna
+Dicholi
+Dibrugarh
+Dibai
+Diamond Harbour
+Dhūri
+Dhupgāri
+Dhuliān
+Dhūlia
+Dhuburi
+Dhrol
+Dhrāngadhra
+Dhorāji
+Dhone
+Dholka
+Dhing
+Dhenkānāl
+Dhekiajuli
+Dhaurahra
+Dhaulpur
+Dhārūr
+Dhāruhera
+Dharmsāla
+Dharmavaram
+Dharmapuri
+Dharmanagar
+Dharmadam
+Dharmābād
+Dhāriwāl
+Dhāri
+Dharapuram
+Dharangaon
+Dharampur
+Dhār
+Dhanera
+Dhandhuka
+Dhanbād
+Dhanaura
+Dhanaula
+Dhamtari
+Dhāmpur
+Dhāmnod
+Dhāka
+Dewas
+Deoli
+Devgarh
+Devgadh Bāriya
+Devarkonda
+Devanhalli
+Devakottai
+Deūlgaon Rāja
+Deshnoke
+Depālpur
+Deori Khās
+Deoria
+Deoraniān
+Deoli
+Deolāli
+Deogarh
+Deoband
+Denkanikota
+Delhi
+Dehri
+Dehra Dūn
+Dausa
+Daund
+Daudnagar
+Dattāpur
+Datia
+Dātāganj
+Dasūya
+Dāsna
+Daryāpur
+Dārwha
+Dārjiling
+Darbhanga
+Dandeli
+Dinapore
+Damoh
+Dāmnagar
+Daman
+Daltonganj
+Dalsingh Sarai
+Dalkola
+Dākor
+Dohad
+Dahegām
+Dāhānu
+Dādri
+Dabwāli
+Dabra
+Daboh
+Dabhoi
+Cuttack
+Curchorem
+Cuncolim
+Cumbum
+Cuddapah
+Cuddalore
+Coondapoor
+Colonelganj
+Colgong
+Calangute
+Coimbatore
+Cochin
+Clement Town
+Chūru
+Churāchāndpur
+Chunār
+Chotila
+Chopda
+Chodavaram
+Rampachodavaram
+Chittūr
+Chittaurgarh
+Chittaranjan
+Chitradurga
+Chītāpur
+Chidawa
+Chīrāla
+Chīpurupalle
+Chiplūn
+Chintāmani
+Chinna Salem
+Chinnamanūr
+Chincholi
+Chillupār
+Chilakalūrupet
+Chikodi
+Chiknāyakanhalli
+Chikmagalūr
+Chikhli
+Chik Ballāpur
+Chidambaram
+Chicholi
+Chhoti Sādri
+Chhota Udepur
+Chhindwāra
+Chhibrāmau
+Chhatarpur
+Chhātāpur
+Chhāta
+Chharra
+Chhaprauli
+Chāpra
+Chhāpar
+Chhala
+Chhabra
+Chettipālaiyam
+Chetput
+Chennimalai
+Chengannūr
+Chengam
+Chengalpattu
+Chāvakkād
+Chaksu
+Chatrapur
+Chatra
+Chās
+Charthāwal
+Charkhi Dādri
+Charkhāri
+Chāpar
+Channarāyapatna
+Channapatna
+Channagiri
+Changanācheri
+Chāndor
+Chāndūr Bāzār
+Chāndūr
+Chāndur
+Chānda
+Chandrakona
+Chāndpur
+Chandigarh
+Chanderi
+Chanduasi
+Chandauli
+Chandannagar
+Chānasma
+Chamrajnagar
+Chāmpa
+Chamba
+Challapalle
+Challakere
+Chālisgaon
+Chalāla
+Chakradharpur
+Chaklāsi
+Chākia
+Chākan
+Chāībāsa
+Canning
+Cannanore
+Kolkata
+Byādgi
+Buxar
+Burla
+Burhar
+Burhānpur
+Būndu
+Būndi
+Buldāna
+Bulandshahr
+Budhlāda
+Budhāna
+Budaun
+Brājarājnagar
+Brahmapur
+Botād
+Borsad
+Borivli
+Bongaigaon
+Mumbai
+Bolpur
+Bokāro
+Bokajān
+Boisar
+Bodināyakkanūr
+Buddh Gaya
+Bodhan
+Bobbili
+Biswān
+Bissāu
+Bishnupur
+Bisauli
+Bīsalpur
+Birūr
+Bīrpur
+Birmitrapur
+Binka
+Bindki
+Etāwa
+Bilthra
+Bilsi
+Bilsanda
+Bilimora
+Bilhaur
+Bilgrām
+Bilgi
+Bīlāspur
+Bilāspur
+Bilāsipāra
+Bilāri
+Bilāra
+Bikramganj
+Bīkaner
+Bijnor
+Bijbiāra
+Bijāwar
+Bijapur
+Bihār
+Bihārīganj
+Bidhūna
+Bīdar
+Biaora
+Bhuvanagiri
+Bhusāval
+Bhūm
+Bhuj
+Bhudgaon
+Bhubaneshwar
+Bhuban
+Bhor
+Bhopal
+Bhongīr
+Bhongaon
+Bhogpur
+Bhiwāni
+Bhiwandi
+Bhitarwār
+Bhīnmāl
+Bhinga
+Bhindār
+Bhind
+Bhīmunipatnam
+Bhīmavaram
+Bhīlwāra
+Bhilai
+Bhīkhi
+Bhikangaon
+Bhāyāvadar
+Bhayandar
+Bhawānipatna
+Bhawānīgarh
+Bhawāniganj
+Bhāvnagar
+Bhavāni
+Bhattiprolu
+Bhātpāra
+Bhatkal
+Bhatinda
+Bhātāpāra
+Bhasāwar
+Bharwāri
+Bharūch
+Bharthana
+Bharatpur
+Bhānvad
+Bhānpurī
+Bhānpura
+Bhanjanagar
+Bhānder
+Bhandāra
+Bhālki
+Bhaisa
+Bhainsdehi
+Bhāgalpur
+Bhadreswar
+Bhadrāvati
+Bhadrakh
+Bhadrāchalam
+Bhādra
+Bhadohi
+Bhadaur
+Bhādāsar
+Bhachāu
+Bhabhua
+Beypore
+Bewar
+Betūl
+Bettiah
+Betamcherla
+Beri Khās
+Berasia
+Beohāri
+Bemetāra
+Belūr
+Belsand
+Belonia
+Bellary
+Belgaum
+Beldānga
+Bela
+Behror
+Behat
+Begusarai
+Begūn
+Begamganj
+Bedi
+Beāwar
+Bāzpur
+Bayāna
+Bawāna
+Bauda
+Batāla
+Baswa
+Bāsudebpur
+Bastī
+Bāsoda
+Basni
+Basmat
+Basi
+Basi
+Basi
+Basavana Bāgevādi
+Basavakalyān
+Barwāni
+Barwāla
+Bāruni
+Bāruipur
+Bārsi
+Barpeta
+Barpāli
+Barnāla
+Bārmer
+Barki Saria
+Barka Kāna
+Barjala
+Bari Sādri
+Bāri
+Barhiya
+Bārh
+Bargi
+Bargarh
+Bareilly
+Bārdoli
+Barddhamān
+Bar Bigha
+Baraut
+Barauli
+Bārāsat
+Bārāsat
+Baranagar
+Bārān
+Bāramūla
+Bārāmati
+Bārākpur
+Bāpatla
+Banūr
+Bantvāl
+Bāntva
+Bānswāra
+Bānswāda
+Bānsi
+Bānsdīh
+Bānsbāria
+Bannūr
+Banmankhi
+Bānkura
+Bānki
+Bānka
+Bāngarmau
+Bangārapet
+Bangaon
+Bangaon
+Banganapalle
+Bengaluru
+Banga
+Bandipura
+Bāndīkūi
+Bānda
+Banda
+Banat
+Bānapur
+Bāmor Kalān
+Bālurghāt
+Bālugaon
+Balrāmpur
+Bālotra
+Baloda Bāzār
+Balod
+Bāli
+Ballālpur
+Bāli
+Balasore
+Balarāmpur
+Bālāpur
+Balāngīr
+Bālāghāt
+Bālāchor
+Bakhtiyārpur
+Baj Baj
+Bairāgnia
+Byndoor
+Bail-Hongal
+Baihar
+Baidyabāti
+Bahraigh
+Bahjoi
+Baheri
+Baharampur
+Bahādurgarh
+Bahādurganj
+Bāh
+Bagulā
+Bāghpat
+Bāghdogra
+Bāgha Purāna
+Bāgepalli
+Bagasra
+Bagar
+Bagalkot
+Bagaha
+Bagaha
+Badvel
+Badūria
+Badnāwar
+Badlapur
+Bādāmi
+Badagara
+Bada Barabīl
+Bachhraon
+Babrāla
+Bābra
+Babīna
+Baberu
+Bābai
+Azamgarh
+Ajodhya
+Ayakudi
+Avanigadda
+Avinashi
+Āvadi
+Ausa
+Aurangābād
+Aurangabad
+Auraiya
+Aurād
+Attur
+Attingal
+Attili
+Atraulī
+Atmakūr
+Adirampattinam
+Athni
+Āthagarh
+Atarra
+Āsind
+Āsika
+Asifābād
+Ashta
+Ashta
+Ashoknagar
+Āsansol
+Āsandh
+Ārvi
+Aruppukkottai
+Arumuganeri
+Arukutti
+Arsikere
+Āron
+Arkalgūd
+Ariyalūr
+Arcot
+Arāria
+Arantāngi
+Ārani
+Ārangaon
+Arang
+Arāmbāgh
+Arakkonam
+Arrah
+Aonla
+Anūpshahr
+Anūppur
+Anūpgarh
+Anta
+Anshing
+Annur
+Annigeri
+Ankleshwar
+Anjār
+Anjangaon
+Anjad
+Angul
+Angamāli
+Anekal
+Andol
+Anthiyur
+Āndippatti
+Anantnag
+Anantapur
+Anandpur
+Ānand
+Anakāpalle
+Anaimalai
+Amudālavalasa
+Āmta
+Amroli
+Amroha
+Amritsar
+Amreli
+Amrāvati
+Amod
+Āmli
+Āmlāgora
+Amla
+Amet
+Ambur
+Ambikāpur
+Ambattūr
+Ambasamudram
+Ambāla
+Ambājogāi
+Ambāh
+Ambad
+Amarpur
+Amarpātan
+Amarnāth
+Amalner
+Amalāpuram
+Aluva
+Alwar
+Alot
+Along
+Alnāvar
+Almora
+Alleppey
+Allahābād
+Alīpur
+Alīgarh
+Alīganj
+Alībāg
+Ālangulam
+Ālangāyam
+Alandur
+Alandi
+Aland
+Akot
+Akola
+Aklera
+Akivīdu
+Akbarpur
+Akbarpur
+Akaltara
+Akalkot
+Ajra
+Ajnāla
+Ajmer
+Aizawl
+Ahraura
+Ahmadpur
+Ahmadnagar
+Ahmedabad
+Āgra
+Agartala
+Agar
+Afzalpur
+Afzalgarh
+Adūr
+Adra
+Ādoni
+Ādilābād
+Addanki
+Achhnera
+Achalpur
+Ābu Road
+Ābu
+Abohar
+Abhayāpuri
+Contai
+Haldia
+Srirāmpur
+Dumjor
+Bankra
+Chakapara
+Mahiari
+Dhulagari
+Pānchla
+Nangi
+Pujali
+Monoharpur
+Nabagrām
+Soyībug
+Singāpur
+Ghatkesar
+Vijayapura
+Ādampur
+Porur
+Madipakkam
+Perungudi
+Madambakkam
+Powai
+Navi Mumbai
+Murudeshwara
+Shivaji Nagar
+Greater Noida
+Mohali
+Pithampur
+Barbil
+Airoli
+Aluva
+Kotkapura
+Muvattupuzha
+Perumbavoor
+Vapi
+Baddi
+Noida
+Bhiwadi
+Mandideep
+Singrauli
+Birpara
+Jaigaon
+Akkarampalle
+Bellampalli
+Chemmumiahpet
+Gaddi Annaram
+Dasnapur
+Kanuru
+Lal Bahadur Nagar
+Malkajgiri
+Mandamarri
+Chinnachowk
+Kyathampalle
+Gajuwaka
+Manuguru
+Kalyandurg
+Ponnur
+Quthbullapur
+Ramanayyapeta
+Palwancha
+Barpeta Road
+Sathupalli
+Yanamalakuduru
+Marigaon
+Naharlagun
+Serilingampalle
+Silapathar
+Lumding Railway Colony
+Aistala
+Ashoknagar Kalyangarh
+Bahula
+Bhawanipur
+Zira
+Ramagundam
+Cherpulassery
+Kirandul
+Shiraguppi
+V.S.K.Valasai (Dindigul-Dist.)
+Neelankarai
+Injambakkam
+Kultali
+Shahbazpur
+Kumbalam
+Aroor
+Kadakkavoor
+Kalavoor
+Kalamassery
+Cherthala
+Zaxo
+Umm Qaşr
+Tozkhurmato
+Tikrīt
+Tallkayf
+Sīnah
+Sāmarrā’
+Nāḩīyat Saddat al Hindīyah
+Ruwāndiz
+Rāwah
+Al-Hamdaniya
+Mandalī
+Koysinceq
+Kifrī
+Kirkuk
+Karbala
+Erbil
+Hīt
+Ḩalabjah
+Ḩadīthah
+Dihok
+Jamjamāl
+Bayjī
+Baqubah
+Baynjiwayn
+Balad
+Baghdad
+Az Zubayr
+Aş Şuwayrah
+As Sulaymānīyah
+As Samawah
+Nāḩiyat ash Shināfīyah
+Ash Shaţrah
+Ash Shāmīyah
+Ar Ruţbah
+Ar Rumaythah
+Ramadi
+‘Aqrah
+An Nāşirīyah
+Najaf
+‘Anat al Qadīmah
+Imam Qasim
+Al Musayyib
+Al Mishkhāb
+Al Miqdādīyah
+Al Mawşil al Jadīdah
+Mosul
+Al Kūt
+Kufa
+Khāliş
+‘Alī al Gharbī
+Al Hindīyah
+Al Ḩillah
+Al Ḩayy
+Al Hārithah
+Nahiyat Ghammas
+Nāḩiyat al Fuhūd
+Al Fāw
+Al Fallūjah
+Basrah
+Al ‘Azīzīyah
+Al ‘Amārah
+‘Afak
+Ad Dujayl
+Ad Dīwānīyah
+Abū Ghurayb
+Al Başrah al Qadīmah
+Sinjār
+Āzādshahr
+Kahrīz
+Nūrābād
+Īstgāh-e Rāh Āhan-e Garmsār
+Qarchak
+Shahre Jadide Andisheh
+Khorramdarreh
+Yasuj
+Āzādshahr
+Zarand
+Zanjān
+Yazd
+Varāmīn
+Torbat-e Ḩeydarīyeh
+Tonekābon
+Tehran
+Hashtpar
+Tākestān
+Takāb
+Taft
+Tabriz
+Tabas
+Sonqor
+Sirjan
+Shūshtar
+Shūsh
+Shīrvān
+Shiraz
+Shahr-e Kord
+Shahr-e Bābak
+Shādegān
+Semnān
+Semīrom
+Sāveh
+Sari
+Saqqez
+Sanandaj
+Salmās
+Shāhīn Dezh
+Sabzevar
+Rūdsar
+Robāţ Karīm
+Rāvar
+Rasht
+Rāmshīr
+Rāmhormoz
+Rafsanjān
+Qūchān
+Qorveh
+Qom
+Qeshm
+Qazvin
+Qarah Ẕīā’ od Dīn
+Farrokh Shahr
+Qā’en
+Sarpol-e Z̄ahāb
+Pīshvā
+Piranshahr
+Pāveh
+Pārsābād
+Oshnavīyeh
+Orūmīyeh
+Omīdīyeh
+Nūrābād
+Nowshahr
+Nīshābūr
+Neyrīz
+Nekā
+Naz̧arābād
+Naqadeh
+Nahāvand
+Mīnāb
+Mīāndoāb
+Meybod
+Mahrīz
+Masjed Soleymān
+Bardsīr
+Mashhad
+Marand
+Malāyer
+Malārd
+Mahābād
+Langarūd
+Kūhdasht
+Kīsh
+Khvoy
+Khvānsār
+Khorramshahr
+Khorramabad
+Khomeyn
+Khalkhāl
+Kermānshāh
+Kerman
+Kāzerūn
+Kāshmar
+Kāshān
+Karaj
+Kangāvar
+Kāmyārān
+Kalāleh
+Jūybār
+Javānrūd
+Īlām
+Harsīn
+Hamadān
+Gorgān
+Gonbad-e Kāvūs
+Gonābād
+Golpāyegān
+Gerāsh
+Bandar-e Ganāveh
+Fūman
+Fīrūzābād
+Fereydūnkenār
+Fasā
+Fārsān
+Esfarāyen
+Shahrud
+Dogonbadan
+Delījān
+Dehlorān
+Dehdasht
+Sūsangerd
+Darreh Shahr
+Dārāb
+Dāmghān
+Damāvand
+Chenārān
+Chālūs
+Bandar-e Būshehr
+Būkān
+Borūjerd
+Borūjen
+Borāzjān
+Bojnūrd
+Bīrjand
+Bījār
+Bonāb
+Behshahr
+Behbahān
+Bāneh
+Bandar-e Lengeh
+Bandar-e Anzalī
+Bandar ‘Abbās
+Bam
+Bahār
+Bāfq
+Bābolsar
+Bābol
+Aznā
+Hashtrūd
+Āstārā
+Āstāneh-ye Ashrafīyeh
+Asadābād
+Ardestān
+Ardakān
+Ardabīl
+Arāk
+Āmol
+Alvand
+Shahrīār
+Alīgūdarz
+Aleshtar
+Akbarābād
+‘Ajab Shīr
+Ahvaz
+Ahar
+Aghajari
+Ābyek
+Abhar
+Ābdānān
+Ābādeh
+Abadan
+Eqbālīyeh
+Shāhreẕā
+Rehnān
+Qahderījān
+Najafābād
+Khomeynī Shahr
+Kelīshād va Sūdarjān
+Falāvarjān
+Isfahan
+Dowlatābād
+Dorcheh Pīāz
+Zābol
+Zahedan
+Torbat-e Jām
+Tāybād
+Sarakhs
+Qaşr-e Qand
+Khāsh
+Īrānshahr
+Chabahar
+Mahdishahr
+Pasragad Branch
+Akureyri
+Reykjavík
+Kópavogur
+Hafnarfjörður
+Vittoria
+Villabate
+Vibo Valentia
+Trapani
+Termini Imerese
+Siracusa
+Sinnai
+Siderno
+Sestu
+Selargius
+Scordia
+Scicli
+Sciacca
+San Giovanni la Punta
+San Giovanni in Fiore
+San Cataldo
+Rossano Stazione
+Rosolini
+Ribera
+Reggio Calabria
+Ragusa
+Quattromiglia
+Quartu Sant'Elena
+Pozzallo
+Porto Empedocle
+Piazza Armerina
+Paternò
+Partinico
+Palmi
+Palma di Montechiaro
+Palermo
+Palagonia
+Pachino
+Oristano
+Noto
+Niscemi
+Nicastro-Sambiase
+Monserrato
+Monreale
+Modica
+Misterbianco
+Misilmeri
+Milazzo
+Messina
+Mazara del Vallo
+Mascalucia
+Marsala
+Licata
+Lentini
+Iglesias
+Gioia Tauro
+Giarre
+Gela
+Floridia
+Favara
+Enna
+Crotone
+Cosenza
+Comiso
+Catanzaro
+Catania
+Castrovillari
+Castelvetrano
+Casarano
+Carini
+Carbonia
+Canicattì
+Caltanissetta
+Caltagirone
+Cagliari
+Bronte
+Biancavilla
+Belpasso
+Barcellona Pozzo di Gotto
+Bagheria
+Avola
+Augusta
+Assemini
+Amato
+Alcamo
+Agrigento
+Adrano
+Acireale
+Aci Catena
+Aci Castello
+Zola Predosa
+Voghera
+Vittorio Veneto
+Viterbo
+Vimodrone
+Vimercate
+Lancenigo-Villorba
+Villaricca
+Villafranca di Verona
+Vignola
+Vigevano
+Vicenza
+Viareggio
+Verona
+Vercelli
+Ventimiglia
+Venice
+Venaria Reale
+Velletri
+Vasto
+Varese
+Valenzano
+Valenza
+Valdagno
+Udine
+Triggiano
+Trieste
+Trezzano sul Naviglio
+Treviso
+Treviglio
+Trentola-Ducenta
+Trento
+Trecate
+Trani
+Tradate
+Tortona
+Torremaggiore
+Torre del Greco
+Torre Annunziata
+Turin
+Tolentino
+Tivoli
+Thiene
+Terzigno
+Terracina
+Terni
+Termoli
+Terlizzi
+Teramo
+Taranto
+Suzzara
+Sulmona
+Spoleto
+Sora
+Sondrio
+Somma Vesuviana
+Siena
+Sezze
+Seveso
+Settimo Torinese
+Sestri Levante
+Sesto San Giovanni
+Sesto Fiorentino
+Seriate
+Seregno
+Senigallia
+Senago
+Segrate
+Schio
+Scandicci
+Scafati
+Savona
+Savigliano
+Sava
+Sassuolo
+Sassari
+Sarzana
+Saronno
+Sarno
+San Vito dei Normanni
+Santeramo in Colle
+Sant'Antonio Abate
+Sant'Antimo
+Sant'Anastasia
+Santa Maria Capua Vetere
+San Severo
+San Sebastiano
+San Salvo
+San Remo
+Sannicandro Garganico
+San Miniato
+San Miniato Basso
+San Mauro Torinese
+San Lazzaro
+San Giuseppe Vesuviano
+San Giuliano Milanese
+San Giovanni Valdarno
+San Giovanni Rotondo
+San Giovanni Lupatoto
+San Giovanni in Persiceto
+San Giorgio a Cremano
+San Donato Milanese
+San Donà di Piave
+San Bonifacio
+San Benedetto del Tronto
+Salsomaggiore Terme
+Salerno
+Sacile
+Ruvo di Puglia
+Rutigliano
+Rozzano
+Rovigo
+Rovereto
+Rosignano Solvay-Castiglioncello
+Roseto degli Abruzzi
+Romano di Lombardia
+Rome
+Rocca di Papa
+Rivoli
+Rimini
+Rieti
+Riccione
+Rho
+Reggio nell'Emilia
+Ravenna
+Rapallo
+Qualiano
+Putignano
+Prato
+Pozzuoli
+Potenza
+Porto Torres
+Porto Sant'Elpidio
+Porto San Giorgio
+Portogruaro
+Civitanova Marche
+Portici
+Pordenone
+Pontedera
+Pompei
+Pomigliano d'Arco
+Pomezia
+Poggiomarino
+Poggibonsi
+Pistoia
+Pisa
+Piossasco
+Piombino
+Pioltello
+Pinerolo
+Pietrasanta
+Piacenza
+Pescara
+Pesaro
+Perugia
+Pavia
+Parma
+Parabiago
+Palo del Colle
+Palazzolo sull'Oglio
+Palagiano
+Pagani
+Padova
+Paderno Dugnano
+Ottaviano
+Ostuni
+Osimo
+Orta Nova
+Orbassano
+Olbia
+Oderzo
+Nuoro
+Novi Ligure
+Novate Milanese
+Novara
+Nova Milanese
+Nola
+Noicattaro
+Noci
+Nocera Superiore
+Nocera Inferiore
+Nichelino
+Nettuno
+Nerviano
+Nardò
+Napoli
+Mugnano di Napoli
+Muggiò
+Monza
+Montichiari
+Montevarchi
+Montesilvano Marina
+Monterotondo
+Montemurlo
+Montecchio Maggiore-Alte Ceccato
+Montecatini-Terme
+Montebelluna
+Monopoli
+Monfalcone
+Mondragone
+Mondovì
+Moncalieri
+Molfetta
+Mola di Bari
+Mogliano Veneto
+Modugno
+Modena
+Mirano
+Mirandola
+Mira Taglio
+Minturno
+Milano
+Mestre
+Mesagne
+Merano
+Mentana
+Melzo
+Melito di Napoli
+Melegnano
+Meda
+Matera
+Massafra
+Massa
+Martina Franca
+Marino
+Marina di Carrara
+Marigliano
+Mariano Comense
+Marcianise
+Marano di Napoli
+Mantova
+Manfredonia
+Manduria
+Malnate
+Magenta
+Maddaloni
+Macerata
+Lugo
+Lucera
+Lucca
+Lodi
+Livorno
+Lissone
+Limbiate
+Lido di Ostia
+Lido
+Legnano
+Legnago
+Lecco
+Lecce
+Latina
+La Spezia
+L'Aquila
+Lanciano
+Lainate
+Ladispoli
+Ivrea
+Isernia
+Ischia Porto
+Ischia
+Pallanza-Intra-Suna
+Imperia
+Imola
+Jesi
+Guidonia
+Grumo Nevano
+Grugliasco
+Grottaglie
+Grottaferrata
+Grosseto
+Gravina in Puglia
+Gragnano
+Gorizia
+Gorgonzola
+Giussano
+Giulianova
+Giugliano in Campania
+Giovinazzo
+Gioia del Colle
+Ginosa
+Ghedi
+Genzano di Roma
+Genoa
+Garbagnate Milanese
+Gallipoli
+Gallarate
+Galatina
+Gaeta
+Frosinone
+Frattaminore
+Frattamaggiore
+Frascati
+Francavilla Fontana
+Francavilla al Mare
+Fossano
+Fornacelle
+Formigine
+Formia
+Forlì
+Forio
+Fondi
+Follonica
+Foligno
+Foggia
+Fiumicino-Isola Sacra
+Florence
+Fiorano
+Fidenza
+Ferrara
+Fermo
+Fasano
+Fano
+Falconara Marittima
+Faenza
+Fabriano
+Ercolano
+Erba
+Empoli
+Eboli
+Domodossola
+Desio
+Desenzano del Garda
+Dalmine
+Cusano Milanino
+Cuneo
+Cremona
+Crema
+Corsico
+Correggio
+Cornaredo
+Cormano
+Cordenons
+Corato
+Copertino
+Conversano
+Conegliano
+Como
+Cologno Monzese
+Collegno
+Colleferro
+Colle di Val d'Elsa
+Civitavecchia
+Città di Castello
+Cisterna di Latina
+Ciriè
+Cinisello Balsamo
+Ciampino
+Chivasso
+Chioggia
+Chieti
+Chieri
+Chiavari
+Chiari
+Cesenatico
+Cesena
+Cesano Maderno
+Cervia
+Cerveteri
+Cernusco sul Naviglio
+Cerignola
+Cercola
+Cento
+Ceglie Messapica
+Cecina
+Cava Dè Tirreni
+Cattolica
+Castiglione delle Stiviere
+Castel Volturno
+Castel Maggiore
+Castellammare di Stabia
+Castelfranco Veneto
+Castelfranco Emilia
+Cassino
+Cassano d'Adda
+Casoria
+Caserta
+Cascina
+Casamassima
+Casalnuovo di Napoli
+Casale Monferrato
+Casalecchio di Reno
+Casal di Principe
+Carrara
+Carpi Centro
+Carmagnola
+Cardito
+Carate Brianza
+Capua
+Capannori
+Cantù
+Canosa di Puglia
+Campobasso
+Campi Bisenzio
+Camaiore
+Caivano
+Busto Arsizio
+Bussolengo
+Brusciano
+Brugherio
+Brindisi
+Bresso
+Bressanone
+Brescia
+Bra
+Bovisio-Masciago
+Boscoreale
+Borgomanero
+Bolzano
+Bologna
+Bollate
+Bitonto
+Bisceglie
+Biella
+Bergamo
+Benevento
+Belluno
+Battipaglia
+Bastia umbra
+Bassano del Grappa
+Barletta
+Bari
+Bareggio
+Bagnoli
+Bacoli
+Avezzano
+Aversa
+Avellino
+Asti
+Ascoli Piceno
+Arzignano
+Arzano
+Ariccia
+Arezzo
+Arese
+Ardea
+Arcore
+Aprilia
+Aosta
+Anzio
+Angri
+Andria
+Ancona
+Altamura
+Alpignano
+Alghero
+Alessandria
+Albignasego
+Albenga
+Albano Laziale
+Alba
+Agropoli
+Afragola
+Adelfia
+Acqui Terme
+Acquaviva delle Fonti
+Acilia-Castel Fusano-Ostia Antica
+Acerra
+Abbiategrasso
+Abano Terme
+Spinea-Orgnano
+Verbania
+Lumezzane
+Guidonia Montecelio
+Lamezia Terme
+Caronno Pertusella
+Cassano Magnago
+San Felice A Cancello
+San Nicola la Strada
+Quarto
+Orta di Atella
+Casavatore
+Volla
+Gravina di Catania
+Cesano Boscone
+Tor Lupara
+Torvaianica
+Bellaria-Igea Marina
+Villanova
+Marina di Ardea-Tor San Lorenzo
+San Paolo
+Monterusciello
+Romano Banco
+Casa Santa
+Arpino
+Paolo VI
+Corigliano Scalo
+Saint Helier
+Spanish Town
+Savanna-la-Mar
+Portmore
+Old Harbour
+New Kingston
+Montego Bay
+May Pen
+Mandeville
+Linstead
+Kingston
+Half Way Tree
+Wādī as Sīr
+Umm as Summāq
+Saḩāb
+Mādabā
+Ma'an
+Kurayyimah
+Judita
+Jarash
+‘Izrā
+Irbid
+Zarqa
+Aydūn
+Aţ Ţafīlah
+As Salţ
+Safi
+Ar Ramthā
+‘Anjarah
+Amman
+Al Quwaysimah
+Mafraq
+Qīr Moāv
+Al Jubayhah
+Aqaba
+‘Ajlūn
+Karak City
+Russeifa
+Shingū
+Atsugi
+Akashi
+Zushi
+Zama
+Yuza
+Gero
+Yukuhashi
+Yūki
+Yugawara
+Yoshikawa
+Yoshii
+Yoshida-kasugachō
+Yorii
+Yono
+Yonago
+Yokosuka
+Yokohama
+Yokkaichi
+Youkaichi
+Yawata
+Yatsushiro
+Yatsuomachi-higashikumisaka
+Yasugichō
+Yashiro
+Yashio-shi
+Yao
+Yanai
+Yanagawa
+Yamazakichō-nakabirose
+Yamaguchi
+Yamaga
+Yaizu
+Yaita
+Wakimachi
+Utsunomiya
+Uto
+Usuki
+Ushibuka
+Ureshinomachi-shimojuku
+Urayasu
+Uozu
+Umi
+Ujiie
+Uji
+Uenohara
+Ueno-ebisumachi
+Ueki
+Ueda
+Ube
+Tsuyama
+Tsushima
+Tsurusaki
+Tsuruoka
+Tsurugi-asahimachi
+Tsuruga
+Tsuma
+Tsukumiura
+Tsukawaki
+Tsubata
+Tsubame
+Tsu
+Toyota
+Toyoshina
+Toyooka
+Toyonaka
+Toyokawa
+Toyohashi
+Toyohama
+Toyama
+Tottori
+Tosu
+Tonoshō
+Tondabayashichō
+Tomioka
+Tomigusuku
+Tokyo
+Tokuyama
+Tokushima
+Tokorozawa
+Tokoname
+Toki
+Tōkamachi
+Togitsu
+Tochio-honchō
+Tochigi
+Toba
+Tenri
+Tennō
+Tawaramoto
+Tatsuno
+Tatsunochō-tominaga
+Tateyama
+Tatebayashi
+Tarumizu
+Tarui
+Tanushimarumachi-toyoki
+Tanuma
+Nishi-Tokyo-shi
+Tanashichō
+Tanabe
+Tanabe
+Tamano
+Tamana
+Tamamura
+Taketoyo
+Takeochō-takeo
+Takehara
+Takefu
+Takedamachi
+Takayama
+Takatsuki
+Takasaki
+Takarazuka
+Takaoka
+Takanabe
+Takamatsu
+Takaishi
+Takahashi
+Takahama
+Bungo-Takada-shi
+Tajimi
+Tahara
+Tagawa
+Tadotsu
+Suzuka
+Suzaka
+Suwa
+Susaki
+Sumoto
+Sukumo
+Suita
+Suibara
+Sugito
+Sueyoshichō-ninokata
+Sōka
+Sōja
+Sobue
+Shōbu
+Shōbara
+Shizuoka
+Shirone
+Shiraoka
+Shirahamachō-usazakiminami
+Shiozawa
+Shiojiri
+Shinshiro
+Shin’ichi
+Shingū
+Shimonoseki
+Shimodate
+Shimoda
+Minato
+Nishishinminato
+Shimada
+Shimabara
+Shiki
+Shido
+Shibushi
+Shibukawa
+Shibata
+Seto
+Setakamachi-takayanagi
+Satsumasendai
+Satte
+Sasebo
+Sasayama
+Sasaguri
+Sano
+Sanjō
+Sandachō
+Sakurai
+Saku
+Sakata
+Sakaiminato
+Sakaidechō
+Sakai-nakajima
+Sakai
+Sakai
+Sakado
+Saiki
+Sagara
+Saga
+Sabae
+Ryūō
+Ryōtsu-minato
+Ōzu
+Oyama
+Ōyama
+Owase
+Ōtsuki
+Ōtsu
+Ōtake
+Ōta
+Osaka
+Onomichi
+Onoda
+Ono
+Ono
+Ōno-hara
+Ōmuta
+Ōmura
+Ōme
+Ōmamachō-ōmama
+Ōmachi
+Ōkuchi-shinohara
+Okegawa
+Okazaki
+Okayama
+Okaya
+Ōkawa
+Ojiya
+Ōita
+Ōiso
+Ōi
+Ogōri-shimogō
+Ogawa
+Ōgaki
+Odawara
+Ōdachō-ōda
+Ōbu
+Obita
+Obama
+Nyūzen
+Numazu
+Numata
+Nonoichi
+Nōgata
+Noda
+Nobeoka
+Nishiwaki
+Nishio
+Nishinoomote
+Nishinomiya-hama
+Nirasaki
+Ninomiya
+Nikkō
+Niitsu-honchō
+Niimi
+Niihama
+Niigata
+Nichinan
+Naze
+Narutochō-mitsuishi
+Nara-shi
+Nanao
+Namerikawa
+Nakatsugawa
+Nakatsu
+Nakanojōmachi
+Nakano
+Nakamura
+Nakama
+Naha
+Nagoya
+Nago
+Nagasaki
+Nagareyama
+Nagaoka
+Nagano
+Nagahama
+Nabari
+Musashino
+Muroto-misakicho
+Muramatsu
+Murakami
+Mukō
+Muikamachi
+Morohongō
+Moriyama
+Moriguchi
+Mori
+Mizunami
+Miyoshi
+Miyazu
+Miyazaki
+Miyakonojō
+Miyata
+Mitsuke
+Mitsukaidō
+Mitake
+Mitaka-shi
+Mishima
+Mino
+Mino
+Minamirinkan
+Minamata
+Minakuchichō-matoba
+Mikuni
+Miki
+Mihara
+Mibu
+Menuma
+Matsutō
+Matsumoto
+Matsue
+Matsudo
+Matsubase
+Matsubara
+Masuda
+Maruoka
+Kamimaruko
+Marugame
+Makurazaki
+Maki
+Maizuru
+Maebashi
+Maebaru-chūō
+Machida
+Kyoto
+Kushikino
+Kusatsu
+Kurume
+Kuroda
+Kurihashi
+Kure
+Kurayoshi
+Kurashiki
+Kumamoto
+Kumagaya
+Kukichūō
+Kudamatsu
+Kozakai-chō
+Koshigaya
+Kosai-shi
+Kōnosu
+Kōnan
+Komoro
+Komono
+Komatsushimachō
+Komatsu
+Komaki
+Kokubunji
+Kokubu-matsuki
+Koga
+Koga
+Kōfu
+Kodamachō-kodamaminami
+Kochi
+Kobe
+Kobayashi
+Kitsuki
+Kitakyushu
+Kitakata
+Kitahama
+Kishiwada
+Kisarazu
+Kisai
+Kiryū
+Kikuchi
+Kazo
+Kawasaki
+Kawasaki
+Kawanishi
+Kawaguchi
+Kawagoe
+Katsuyama
+Kasukabe
+Kasugai
+Kashiwazaki
+Kashiwa
+Kashima
+Kashihara-shi
+Kashihara
+Kaseda-shirakame
+Kasaoka
+Kasamatsuchō
+Kariya
+Karatsu
+Kanzakimachi-kanzaki
+Kanuma
+Kanoya
+Kan’onjichō
+Kannabechō-yahiro
+Kanie
+Kanekomachi
+Kanda
+Kanazawa
+Kanaya
+Kamojimachō-jōgejima
+Kamogatachō-kamogata
+Kamo
+Kamirenjaku
+Kaminokawa
+Kamiichi
+Kameyama
+Kameoka
+Kameda-honchō
+Kamakura
+Kakogawachō-honmachi
+Kakegawa
+Kakamigahara
+Kashima-shi
+Kajiki
+Kaizuka
+Kainan
+Kagoshima
+Kadoma
+Izumo
+Izumiōtsu
+Izumi
+Izumi
+Iwatsuki
+Iwata
+Iwakura
+Iwakuni
+Iwai
+Iwade
+Itsukaichi
+Itoman
+Itoigawa
+Itō
+Itami
+Ishiki
+Ishikawa
+Ishii
+Ishige
+Ishigaki
+Isesaki
+Isehara
+Ise
+Isawa
+Isahaya
+Inuyama
+Ino
+Innoshima
+Inazawa
+Ina
+Imarichō-kō
+Imaichi
+Ikoma
+Ikeda
+Ikedachō
+Ijūin
+Iizuka
+Iiyama
+Iida
+Ichinomiya
+Ibusuki
+Ibaraki
+Ibara
+Hotaka
+Honjō
+Hondo
+Hōfu
+Hitoyoshi
+Hita
+Hisai-motomachi
+Hiroshima
+Hiratsuka
+Hiratachō
+Hirara
+Hirakata
+Hirado
+Hino
+Hino
+Himimachi
+Himeji
+Hikone
+Hiji
+Hekinan
+Hayama
+Hatsukaichi
+Hatogaya-honchō
+Hashimoto
+Hanyū
+Hannō
+Handa
+Hamanoichi
+Hamamatsu
+Hamakita
+Hamada
+Hakui
+Haibara-akanedai
+Hagi
+Katsuren-haebaru
+Hadano
+Hachiōji
+Ōmihachiman
+Gyōda
+Gushikawa
+Gōtsuchō
+Gotenba
+Gosen
+Gose
+Gojō
+Gōdo
+Gobō
+Ginowan
+Gifu-shi
+Gamagōri
+Futtsu
+Honchō
+Fukuyama
+Fukuroi
+Fukura
+Fukuoka
+Fukumitsu
+Nishifukuma
+Fukui-shi
+Fukuechō
+Fukuchiyama
+Fukiage-fujimi
+Fukayachō
+Fujisawa
+Fujioka
+Fujioka
+Fujinomiya
+Fujieda
+Fuji
+Fuchūchō
+Enzan
+Daitōchō
+Chōfugaoka
+Chiryū
+Chino
+Chikushino-shi
+Chigasaki
+Chichibu
+Chatan
+Beppu
+Ayabe
+Atami
+Ashiya
+Ashikaga
+Arai
+Annaka
+Anjō
+Anan
+Amagi
+Amagasaki
+Akune
+Kariya
+Aki
+Aioi
+Ageoshimo
+Okinawa
+Kushima
+Hikari
+Nagato
+Hasuda
+Kamifukuoka
+Sayama
+Fussa
+Asaka
+Wako
+Shimotoda
+Kimitsu
+Miura
+Wakayama
+Iyo
+Uwajima
+Saijō
+Ōzu
+Matsuyama
+Masaki-chō
+Kawanoechō
+Hōjō
+Yuzawa
+Yotsukaidō
+Yonezawa
+Yokotemachi
+Yōkaichiba
+Yanagawamachi-saiwaichō
+Yamoto
+Yamagata
+Yamada
+Yachimata
+Watari
+Wakuya
+Ushiku
+Tsukuba
+Toride
+Tōno
+Tomobe
+Tomiya
+Tōgane
+Tendō
+Takahata
+Takahagi
+Sukagawa
+Shizukuishi
+Shisui
+Shiroishi
+Shiroi
+Shiogama
+Shinjō
+Sendai
+Sawara
+Sakura
+Sagae
+Ryūgasaki
+Rifu
+Ōtsuchi
+Ōtawara
+Ōmiya
+Omigawa
+Ōmagari
+Okunoya
+Ōkawara
+Ōhara
+Ōfunato
+Obanazawa
+Ōarai
+Ōami
+Nihommatsu
+Narutō
+Narita
+Namie
+Naka
+Nagai
+Motomiya
+Motegi
+Moriya
+Morioka
+Mooka
+Mobara
+Mizusawa
+Miyako
+Mito
+Miharu
+Matsushima
+Mashiko
+Marumori
+Makabe
+Kuroiso
+Kōriyama
+Kogota
+Kitakami
+Kitaibaraki
+Kamogawa
+Katsuura
+Katsuta
+Katori-shi
+Kasama
+Karasuyama
+Kaminoyama
+Kamaishi
+Kakuda
+Iwase
+Iwanuma
+Iwaki
+Itako
+Ishioka
+Ishinomaki
+Ishikawa
+Inawashiro
+Ichinoseki
+Ichihara
+Hobaramachi
+Hitachi
+Higashine
+Hasaki
+Hanamaki
+Furukawa
+Funehikimachi-funehiki
+Funaishikawa
+Fukushima
+Fujishiro
+Edosaki
+Daigo
+Chiba
+Asahi
+Ami
+Akita
+Abiko
+Akitashi
+Bihoro
+Wakkanai
+Tomakomai
+Tōbetsu
+Mutsu
+Takikawa
+Takanosu
+Sunagawa
+Shizunai-furukawachō
+Shiraoi
+Shimo-furano
+Shibetsu
+Sapporo
+Rumoi
+Otofuke
+Otaru
+Ōdate
+Obihiro
+Noshiro
+Nemuro
+Nayoro
+Nanae
+Namioka
+Muroran
+Mombetsu
+Misawa
+Yoichi
+Makubetsu
+Kushiro
+Kuroishi
+Shimokizukuri
+Kitami
+Kamiiso
+Iwanai
+Iwamizawa
+Ishikari
+Ichinohe
+Kitahiroshima
+Hirosaki
+Hanawa
+Hakodate
+Hachinohe
+Fukagawa
+Ebetsu
+Date
+Chitose
+Bibai
+Ashibetsu
+Asahikawa
+Aomorishi
+Abashiri
+Goshogawara
+Aso
+Nanto-shi
+Kawage
+Neyagawa
+Hitachi-Naka
+Inashiki
+Ōnojō
+Minokamo
+Gujō
+Jōetsu
+Saitama
+Higashimurayama-shi
+Fujikawaguchiko
+Dazaifu
+Kamigyō-ku
+Buzen
+Sendai
+Webuye
+Wajir
+Voi
+Thika
+Rongai
+Pumwani
+Nyeri
+Nyahururu
+Narok
+Nanyuki
+Nakuru
+Naivasha
+Nairobi
+Mumias
+Muhoroni
+Moyale
+Mombasa
+Molo
+Migori
+Meru
+Mbale
+Marsabit
+Maralal
+Mandera
+Malindi
+Makueni
+Machakos
+Lugulu
+Lodwar
+Lamu
+Kitui
+Kitale
+Kisumu
+Kisii
+Kilifi
+Kiambu
+Keruguya
+Kericho
+Karuri
+Kapenguria
+Kakamega
+Kabarnet
+Isiolo
+Homa Bay
+Garissa
+Embu
+Eldoret
+Busia
+Bungoma
+Athi River
+Siaya
+Ol Kalou
+Suluktu
+Isfana
+Balykchy
+Tokmok
+Tash-Kumyr
+Talas
+Kyzyl-Suu
+Uzgen
+Osh
+Naryn
+Kyzyl-Kyya
+Kara Suu
+Karakol
+Kara-Balta
+Kant
+Jalal-Abad
+Iradan
+Cholpon-Ata
+Bishkek
+Bazar-Korgon
+At-Bashi
+Toktogul
+Osh City
+Phnom Penh
+Ta Khmau
+Takeo
+Svay Rieng
+Stung Treng
+Sisŏphŏn
+Siem Reap
+Prey Veng
+Pursat
+Phumĭ Véal Srê
+Sâmraông
+Tbêng Méanchey
+Paôy Pêt
+Pailin
+Lumphăt
+Koh Kong
+Kratié
+Kampot
+Kampong Thom
+Kampong Speu
+Sihanoukville
+Kampong Chhnang
+Kampong Cham
+Ban Lŭng
+Battambang
+Smach Mean Chey
+Tarawa
+Moutsamoudou
+Moroni
+Basseterre
+Yŏnan-ŭp
+Wŏnsan
+T’ongch’ŏn-ŭp
+Sŭngho 1-tong
+Sunan
+Songnim
+Sil-li
+Sinmak
+Sinanju
+Sariwŏn
+Samho-rodongjagu
+Pyongyang
+P’yŏngsŏng
+Ongjin
+Namp’o
+Kusŏng
+Kujang-ŭp
+Kowŏn-ŭp
+Kosan
+Kangdong-ŭp
+Kaesŏng
+Hwangju-ŭp
+Hŭngnam
+Hŭkkyo-ri
+Hoeyang
+Hamhŭng
+Haeju
+Chunghwa
+Chŏngju
+Changyŏn
+Chaeryŏng-ŭp
+Ayang-ni
+Anju
+Anbyŏn-ŭp
+Anak
+Yuktae-dong
+Ŭiju
+Sŏnbong
+Sinŭiju
+Sakchu-ŭp
+Yŏnggwang-ŭp
+Onsŏng
+Nanam
+Namyang-dong
+Najin
+Musan-ŭp
+Kyŏngsŏng
+Kilju
+Kapsan-ŭp
+Kanggye-si
+Iwŏn-ŭp
+Hyesan-dong
+Hyesan-si
+Hongwŏn
+Hoeryŏng
+Chongjin
+Aoji-ri
+Heung-hai
+Enjitsu
+Neietsu
+Eisen
+Reiko
+Yŏng-dong
+Eisen
+Yeoju
+Yesan
+Yangsan
+Yangp'yŏng
+Yangju
+Yanggu
+Wŏnju
+Wanju
+Waegwan
+Ulsan
+Uijeongbu-si
+Tangjin
+Taesal-li
+Daejeon
+Daegu
+Taisen-ri
+T’aebaek
+Suwon-si
+Suncheon
+Seoul
+Suisan
+Jenzan
+Seonghwan
+Sokcho
+Sangju
+Santyoku
+Fuyo
+Busan
+Bucheon-si
+Puan
+Beolgyo
+Pohang
+Osan
+Asan
+Okcheon
+Kosong
+Nonsan
+Nangen
+Naju
+Munsan
+Mungyeong
+Muan
+Moppo
+Miryang
+Gyeongsan-si
+Kyonju
+Kwangyang
+Gwangju
+Gwangju
+Kurye
+Guri-si
+Kunwi
+Kunsan
+Kinzan
+Gumi
+Goyang-si
+Goseong
+Gongju
+Kyosai
+Koesan
+Koch'ang
+Kimje
+Kimhae
+Gimcheon
+Gijang
+Gapyeong
+Kang-neung
+Ganghwa-gun
+Iksan
+Incheon
+Imsil
+Icheon-si
+Hwasun
+Hwaseong-si
+Hwacheon
+Hongsung
+Hongch’ŏn
+Hayang
+Haenam
+Chuncheon
+Jeonju
+Cheongsong gun
+Cheongju-si
+Cheonan
+Chinju
+Chinch'ŏn
+Jinan-gun
+Jeju City
+Changwon
+Changsu
+Anyang-si
+Anseong
+Ansan-si
+Andong
+Gaigeturi
+Sinhyeon
+Yeosu
+Yŏnmu
+Tonghae
+Pubal
+Seongnam-si
+Hanam
+Hwado
+Namyangju
+Ungsang
+Wabu
+Naesŏ
+Hwawŏn
+Kwangmyŏng
+Sinan
+Seogwipo
+Changnyeong
+Janūb as Surrah
+Ḩawallī
+Bayān
+As Sālimīyah
+Ar Rumaythīyah
+Ar Riqqah
+Al Manqaf
+Al Mahbūlah
+Kuwait City
+Al Jahrā’
+Al Faḩāḩīl
+Al Finţās
+Al Farwānīyah
+Al Aḩmadī
+Ad Dasmah
+Salwá
+Ar Rābiyah
+Şabāḩ as Sālim
+George Town
+Zhanaozen
+Shalqar
+Shalkar
+Oral
+Kandyagash
+Qulsary
+Khromtau
+Karagandy
+Embi
+Balyqshy
+Atyrau
+Aqtöbe
+Aktau
+Aqsay
+Zyryanovsk
+Zhosaly
+Zhezqazghan
+Dzhetygara
+Zhangatas
+Ayteke Bi
+Taraz
+Zaysan
+Yanykurgan
+Vannovka
+Ush-Tyube
+Turkestan
+Temirtau
+Tekeli
+Tasböget
+Talghar
+Taldykorgan
+Taldyqorghan
+Shymkent
+Chu
+Shemonaīkha
+Shchūchīnsk
+Semey
+Saryaghash
+Sarkand
+Sorang
+Rudnyy
+Kyzylorda
+Kostanay
+Karatau
+Kapshagay
+Petropavl
+Pavlodar
+Zharkent
+Ust-Kamenogorsk
+Sarykemer
+Merke
+Makīnsk
+Lisakovsk
+Baykonyr
+Ridder
+Lenger
+Kokshetau
+Kentau
+Esik
+Georgīevka
+Aksu
+Otegen Batyra
+Ekibastuz
+Shīeli
+Shardara
+Burunday
+Aksu
+Balqash
+Ayagoz
+Atbasar
+Arys
+Arkalyk
+Aral
+Astana
+Almaty
+Akkol’
+Abay
+Stepnogorsk
+Kyzyl-Orda
+Vientiane
+Xam Nua
+Savannakhét
+Pakxé
+Muang Xay
+Vangviang
+Muang Phônsavan
+Muang Pakxan
+Thakhèk
+Luang Prabang
+Ban Houakhoua
+Phonsavan
+Zahlé
+Tripoli
+Tyre
+Sidon
+Ra’s Bayrūt
+Djounie
+Jbaïl
+Habboûch
+Bcharré
+Beirut
+Baalbek
+En Nâqoûra
+Nabatîyé et Tahta
+Castries
+Vaduz
+Welisara
+Weligama
+Wattala
+Vavuniya
+Valvedditturai
+Trincomalee
+Ratnapura
+Puttalam
+Point Pedro
+Pita Kotte
+Peliyagoda
+Panadura
+Nuwara Eliya
+Negombo
+Mulleriyawa
+Dehiwala-Mount Lavinia
+Moratuwa
+Matara
+Maharagama
+Kurunegala
+Sri Jayewardenepura Kotte
+Kotikawatta
+Kolonnawa
+Kelaniya
+Katunayaka
+Kandy
+Kandana
+Kalutara
+Kalmunai
+Jaffna
+Ja Ela
+Homagama
+Hendala
+Hatton
+Hanwella Ihala
+Gampola
+Galle
+Galkissa
+Eravur Town
+Dambulla
+Colombo
+Chilaw
+Beruwala
+Bentota
+Batticaloa
+Battaramulla South
+Badulla
+Anuradhapura
+Ampara
+Ambalangoda
+Shanjeev Home
+Mount Lavinia
+Zwedru
+New Yekepa
+Voinjama
+Monrovia
+Kakata
+Harper
+Greenville
+Gbarnga
+Buchanan
+Bensonville
+Quthing
+Qacha’s Nek
+Mohale’s Hoek
+Maseru
+Maputsoe
+Mafeteng
+Leribe
+Butha-Buthe
+Visaginas
+Vilnius
+Utena
+Ukmerge
+Telsiai
+Taurage
+Silute
+Šiauliai
+Rokiškis
+Radviliskis
+Plunge
+Panevėžys
+Palanga
+Fabijoniškės
+Mazeikiai
+Marijampolė
+Kretinga
+Klaipėda
+Kėdainiai
+Kaunas
+Jonava
+Gargždai
+Druskininkai
+Alytus
+Aleksotas
+Dainava (Kaunas)
+Šilainiai
+Eiguliai
+Pašilaičiai
+Pilaitė
+Justiniškės
+Šeškinė
+Lazdynai
+Vilkpėdė
+Naujamiestis
+Luxembourg
+Esch-sur-Alzette
+Dudelange
+Valmiera
+Ventspils
+Vec-Liepāja
+Tukums
+Salaspils
+Riga
+Rēzekne
+Ogre
+Liepāja
+Jūrmala
+Jelgava
+Jēkabpils
+Daugavpils
+Cēsis
+Tobruk
+Sulūq
+Darnah
+Benghazi
+Az Zuwaytīnah
+At Tāj
+Tūkrah
+Al Qubbah
+Al Marj
+Al Jawf
+Al Bayḑā’
+Al Abyār
+Ajdabiya
+Zuwārah
+Zliten
+Zalţan
+Yafran
+Waddān
+Tarhuna
+Tripoli
+Tagiura
+Sirte
+Şurmān
+Şabrātah
+Sabhā
+Nālūt
+Murzuq
+Mizdah
+Mişrātah
+Masallātah
+Hūn
+Zawiya
+Ghat
+Gharyan
+Brak
+Banī Walīd
+Az Zintān
+Az Zāwīyah
+Awbārī
+Al Khums
+Al Jadīd
+Zaïo
+Zagora
+Youssoufia
+Tiznit
+Tirhanimîne
+Tinghir
+Tiflet
+Tétouan
+Taza
+Taroudant
+Taourirt
+Taounate
+Tan-Tan
+Tangier
+Tahla
+Souq Larb’a al Gharb
+Sidi Yahia El Gharb
+Sidi Slimane
+Sidi Qacem
+Sidi Ifni
+Sidi Bennour
+Settat
+Sefrou
+Sale
+Safi
+Rabat
+Oulad Teïma
+Oujda
+Oued Zem
+Ouezzane
+Ouarzazat
+Nador
+Mohammedia
+Midelt
+Meknès
+Mechraa Bel Ksiri
+Martil
+Marrakesh
+Larache
+Ksar El Kebir
+Khouribga
+Khenifra
+Kenitra
+Kasba Tadla
+Jerada
+Imzoûrene
+Guercif
+Guelmim
+Fkih Ben Salah
+Fès al Bali
+Fes
+Essaouira
+El Jadida
+El Hajeb
+El Aïoun
+Chefchaouene
+Casablanca
+Bouznika
+Berkane
+Beni Mellal
+Berrechid
+Azrou
+Azemmour
+Asilah
+Khemisset
+Al Hoceïma
+Ahfir
+Agadir
+Skhirate
+Boujniba
+Dakhla
+Monte-Carlo
+Monaco
+Edineţ
+Ungheni
+Tiraspolul
+Straşeni
+Bilicenii Vechi
+Soroca
+Slobozia
+Rîbniţa
+Orhei
+Hînceşti
+Căuşeni
+Floreşti
+Dubăsari
+Drochia
+Comrat
+Chişinău
+Ceadîr-Lunga
+Cahul
+Bender
+Bălţi
+Podgorica
+Pljevlja
+Nikšić
+Herceg-Novi
+Cetinje
+Budva
+Bijelo Polje
+Bar
+Marigot
+Toamasina
+Vondrozo
+Vohipaho
+Vohibinany
+Vavatenina
+Vangaindrano
+Tsiroanomandidy
+Tsiombe
+Tsaratanana
+Toliara
+Fort Dauphin
+Soavinandriana
+Soanindrariny
+Soanierana Ivongo
+Sitampiky
+Sambava
+Sakaraha
+Sahavato
+Sadabe
+Nosy Varika
+Morondava
+Moramanga
+Miandrivazo
+Miandrarivo
+Marovoay
+Marolambo
+Maroantsetra
+Manjakandriana
+Mananjary
+Mananara
+Manakara
+Maintirano
+Mahanoro
+Mahajanga
+Maevatanana
+Ikongo
+Ikalamavony
+Ihosy
+Ifanadiana
+Fianarantsoa
+Fenoarivo Be
+Fenoarivo Atsinanana
+Faratsiho
+Farafangana
+Fandriana
+Betioky
+Betafo
+Beroroha
+Belo sur Tsiribihina
+Beloha
+Bealanana
+Arivonimamo
+Antsohimbondrona
+Antsohihy
+Antsiranana
+Antsirabe
+Antanifotsy
+Antananarivo
+Antalaha
+Ankazondandy
+Ankazobe
+Ankazoabo
+Anjozorobe
+Hell-Ville
+Andilamena
+Andapa
+Ampasimanolotra
+Amparafaravola
+Ampanihy
+Ampahana
+Ambovombe
+Ambositra
+Ambohitrolomahitsy
+Amboasary
+Amboanjo
+Ambilobe
+Ambatondrazaka
+Ambatolampy
+Ambatofinandrahana
+Ambato Boeny
+Ambarakaraka
+Ambanja
+Ambalavao
+Alarobia
+Majuro
+RMI Capitol
+Желино
+Vinica
+Veles
+Tetovo
+Теарце
+Студеничани
+Strumica
+Struga
+Shtip
+Skopje
+Сарај
+Ресен
+Радовиш
+Prilep
+Ohrid
+Неготино
+Negotino
+Липково
+Kumanovo
+Крива Паланка
+Kochani
+Kičevo
+Kavadarci
+Kamenjane
+Gostivar
+Gevgelija
+Delcevo
+Debar
+Brvenica
+Bogovinje
+Bitola
+Šuto Orizare
+Butel
+Čair
+Ilinden
+Kisela Voda
+Centar Župa
+Yorosso
+Timbuktu
+Sikasso
+Ségou
+San
+Sagalo
+Mopti
+Markala
+Koutiala
+Koulikoro
+Kolokani
+Kayes
+Kati
+Kangaba
+Gao
+Djénné
+Bougouni
+Banamba
+Bamako
+Bafoulabé
+Yenangyaung
+Nyaungdon
+Yamethin
+Wakema
+Twante
+Taungoo
+Thongwa
+Thayetmyo
+Thaton
+Tharyarwady
+Thanatpin
+Thanatpin
+Dawei
+Taunggyi
+Taungdwingyi
+Syriam
+Sittwe
+Shwebo
+Sagaing
+Yangon
+Pyu
+Pyinmana
+Pyay
+Pyapon
+Bago
+Paungde
+Pakokku
+Hpa-an
+Nyaunglebin
+Myitkyina
+Myingyan
+Myawadi
+Myanaung
+Mudon
+Mawlamyinegyunn
+Mawlamyine
+Monywa
+Mogok
+Minbu
+Myeik
+Meiktila
+Pyin Oo Lwin
+Mawlaik
+Maubin
+Martaban
+Mandalay
+Magway
+Loikaw
+Letpandan
+Lashio
+Kyaukse
+Kyaikto
+Kyaiklat
+Kyaikkami
+Kayan
+Kanbe
+Hinthada
+Hakha
+Chauk
+Bogale
+Bhamo
+Pathein
+Myaydo
+Nay Pyi Taw
+Uliastay
+Ulaangom
+Ölgiy
+Khovd
+Altai
+Ulan Bator
+Sühbaatar
+Murun-kuren
+Mandalgovi
+Hovd
+Erdenet
+Dzüünharaa
+Darhan
+Dalandzadgad
+Saynshand
+Bulgan
+Bayanhongor
+Bayanhongor
+Baruun-Urt
+Arvayheer
+Зуунмод
+Macau
+Saipan
+Saint-Joseph
+Sainte-Marie
+Petite Rivière Salée
+Le Robert
+Le Lamentin
+Le François
+La Trinité
+Fort-de-France
+Ducos
+Zouerate
+Tékane
+Sélibaby
+Rosso
+Nouakchott
+Nouâdhibou
+Néma
+Kiffa
+Kaédi
+Atar
+Aleg
+Plymouth
+Brades
+Żabbar
+Valletta
+Qormi
+Mosta
+Birkirkara
+Vacoas
+Triolet
+Saint Pierre
+Quatre Bornes
+Port Louis
+Mahébourg
+Goodlands
+Curepipe
+Centre de Flacq
+Bel Air Rivière Sèche
+Le Hochet
+Male
+Karonga
+Zomba
+Salima
+Rumphi
+Nsanje
+Nkhotakota
+Mzuzu
+Mzimba
+Mulanje
+Mchinji
+Mangochi
+Liwonde
+Lilongwe
+Kasungu
+Dedza
+Blantyre
+Balaka
+Gustavo A. Madero
+San Fernando
+Zumpango
+Zumpango del Río
+Zacualtipán
+Zacatlán
+Zacatepec
+Yecapixtla
+Yautepec
+Xoxocotla
+Xonacatlán
+Xochitepec
+Xochimilco
+Xicotepec de Juárez
+Xico
+San Miguel Xico Viejo
+Álvaro Obregón
+Villahermosa
+Gustavo A. Madero
+Villa Cuauhtémoc Otzolotepec
+Veracruz
+Venustiano Carranza
+Valle Hermoso
+Valladolid
+Uman
+Tuxtla Gutiérrez
+Tuxpan de Rodríguez Cano
+Tultitlán
+Tultepec
+Tulancingo
+Tula de Allende
+Toluca
+Tlazcalancingo
+Tlaquiltenango
+Tlapa de Comonfort
+Tlapacoyan
+Tlalpan
+Tlalnepantla
+Tlahuac
+Tizimín
+Tizayuca
+Tixtla de Guerrero
+Ticul
+Santiago Tíanguistenco
+Tezontepec de Aldama
+Teziutlan
+Texcoco de Mora
+Tequixquiac
+Tequisquiapan
+Cuautitlán Izcalli
+Tepoztlán
+Tepotzotlán
+Tepeji de Ocampo
+Tepeaca
+Tepatlaxco de Hidalgo
+Teoloyucan
+Tenosique de Pino Suárez
+Tenango de Arista
+Temixco
+Temapache
+Teloloapan
+Tecax
+Tehuacán
+Tecamachalco
+Teapa
+Taxco de Alarcón
+Tapachula
+Tantoyuca
+Tampico
+Tamazunchale
+Santo Domingo Tehuantepec
+Santiago Tuxtla
+Santiago Pinotepa Nacional
+Santiago Tulantepec
+Moyotzingo
+Santa María Chimalhuacán
+Santa Cruz Xoxocotlán
+Tecamac de Felipe Villanueva
+Chiautempan
+San Salvador El Seco
+San Salvador Atenco
+San Pablo de las Salinas
+San Pablo Autopan
+San Miguel Zinacantepec
+Coatlinchán
+San Mateo Atenco
+San Martin Texmelucan de Labastida
+Teolocholco
+Teotihuacán de Arista
+San Juan del Río
+Tuxtepec
+San Francisco Acuautla
+Sanctorum
+San Cristóbal de las Casas
+San Andres Tuxtla
+Salina Cruz
+Río Verde
+Río Bravo
+Río Blanco
+Reynosa
+Puerto Escondido
+Puente de Ixtla
+Puebla
+Progreso de Alvaro Obregon
+Progreso de Castro
+Poza Rica de Hidalgo
+Polanco
+Playa del Carmen
+Pijijiapan
+Peto
+Perote
+Paraiso
+Papantla de Olarte
+Pánuco
+Palmarito Tochapán
+Palenque
+Pachuca de Soto
+Ozumba de Alzate
+Oxkutzkab
+Orizaba
+Ometepec
+Ocozocoautla de Espinosa
+Ocoyoacac
+Ocosingo
+Oaxaca de Juárez
+Nuevo Laredo
+Nogales
+Nicolás Romero
+Naucalpan de Juárez
+Naranjos
+Villa Nanchital
+Motul
+Motozintla
+Montemorelos
+Santiago Momoxpan
+Mixquiahuala de Juarez
+Misantla
+Miramar
+Minatitlan
+Milpa Alta
+Miahuatlán de Porfirio Díaz
+Metepec
+Mérida
+Matías Romero
+Heroica Matamoros
+Martínez de la Torre
+Mapastepec
+Malinaltepec
+Magdalena Contreras
+Macuspana
+Reyes Acozac
+Los Reyes La Paz
+Linares
+Lerma de Villada
+Lerdo de Tejada
+Las Margaritas
+Las Choapas
+La Isla
+Kanasín
+Juchitán de Zaragoza
+Jojutla
+Jiutepec
+Jalpa de Méndez
+Xalapa de Enríquez
+Izúcar de Matamoros
+San Jerónimo Ixtepec
+Ixtapan de la Sal
+Ixtapaluca
+Iztapalapa
+Ixtac Zoquitlán
+Iztacalco
+Ixmiquilpan
+Iguala de la Independencia
+Hunucmá
+Huixtla
+Huitzuco de los Figueroa
+Huimanguillo
+Huejutla de Reyes
+Huejotzingo
+Huauchinango
+Huatusco de Chicuellar
+Ciudad de Huajuapan de León
+Frontera Comalapa
+Frontera
+Fortín de las Flores
+Felipe Carrillo Puerto
+Escárcega
+Emiliano Zapata
+Emiliano Zapata
+Ciudad Mante
+Ecatepec
+Cunduacán
+Cuernavaca
+Cuautlancingo
+Cuautla Morelos
+Cuautitlán
+Cuautepec de Hinojosa
+Cuajimalpa
+San Miguel de Cozumel
+Coyotepec
+Coyoacán
+Cosoleacaque
+Cosamaloapan de Carpio
+Córdoba
+San Bernardino Contla
+Comitán
+Comalcalco
+Coatzintla
+Coatzacoalcos
+Coatepec
+Coacalco
+Ciudad Victoria
+Ciudad Valles
+Ciudad Serdán
+Ciudad Sahagun
+Ciudad Nezahualcoyotl
+Ciudad Miguel Alemán
+Ciudad Mendoza
+Ciudad Madero
+Ciudad Fernández
+Mexico City
+Ciudad del Carmen
+Cintalapa de Figueroa
+Cholula
+Chilpancingo de los Bravos
+Chilapa de Alvarez
+Chignahuapan
+Chiconcuac
+San Vicente Chicoloapan
+Chichén-Itzá
+Chiautla
+Chiapa de Corzo
+Chetumal
+Champotón
+Chalco de Díaz Covarrubias
+Cerro Azul
+Catemaco
+Carlos A. Carrillo
+Cardenas
+Cárdenas
+Capulhuac
+Cancún
+Campeche
+Calpulalpan
+Cadereyta
+Berriozábal
+Banderilla
+Azcapotzalco
+Axochiapan
+Atlixco
+Atlacomulco
+Ciudad López Mateos
+Apizaco
+Apan
+Amozoc de Mota
+Amecameca
+Heroica Alvarado
+Altotonga
+Altepexi
+Altamira
+Allende
+Álamo
+Ajalpan
+Agua Dulce
+Actopan
+Acayucan
+Acatzingo de Hidalgo
+Acatlán de Osorio
+Acapulco de Juárez
+Acajete
+San Antonio de la Cal
+Hidalgo
+Río de Teapa
+Huamantla
+Zacatelco
+Tlaxcala de Xicohtencatl
+Papalotla
+Vicente Guerrero
+Tonalá
+Arriaga
+San Andrés Cholula
+Tampico
+Alto Lucero
+San Mateo Otzacatipan
+Santa María Totoltepec
+San Lorenzo Acopilco
+Benito Juarez
+Venustiano Carranza
+Miguel Hidalgo
+Cuauhtémoc
+Huixquilucan
+Melchor Ocampo
+Huilango
+Santiago Teyahualco
+Ojo de Agua
+Buenavista
+Miguel Alemán (La Doce)
+Leyva Solano
+Cihuatlán
+Guadalupe Victoria
+Ixtapa-Zihuatanejo
+Zapotlanejo
+Zapotiltic
+Zapopan
+Zamora
+Zacoalco de Torres
+Zacatecas
+Zacapú
+Yuriria
+Yurécuaro
+Villagrán
+Ciudad Frontera
+García
+Ciudad de Villa de Álvarez
+Valle de Santiago
+Valle de Bravo
+Uruapan
+Uriangato
+Tuxpan
+Torreon
+Tonalá
+Tlaquepaque
+Tlajomulco de Zúñiga
+Tijuana
+Tesistán
+Tequila
+Tepic
+Tepatitlán de Morelos
+Tepalcatepec
+Teocaltiche
+Tejupilco de Hidalgo
+Tecoman
+Tecate
+Tangancícuaro de Arista
+Tamazula de Gordiano
+Tala
+Tacámbaro de Codallos
+Sombrerete
+Soledad Díez Gutiérrez
+Silao
+Sayula
+Santiago Papasquiaro
+Santiago Ixcuintla
+Santiago
+Santa Rosa Jauregui
+Santa Catarina
+Santa Anita
+San Sebastián el Grande
+San Pedro
+San Nicolás de los Garza
+San Miguel el Alto
+San Miguel de Papasquiaro
+San Miguel de Allende
+San Luis Río Colorado
+San Luis Potosí
+San Luis de la Paz
+San Luis de la Paz
+Cabo San Lucas
+San Juan de los Lagos
+San José Iturbide
+San José del Cabo
+San Francisco del Rincón
+San Felipe
+San Felipe
+San Buenaventura
+Nicolás R Casillas
+Salvatierra
+Saltillo
+Salamanca
+Sahuayo de Morelos
+Sabinas Hidalgo
+Ciudad Sabinas
+Rosarito
+Romita
+Río Grande
+Rincón de Romos
+Ramos Arizpe
+Santiago de Querétaro
+Puruándiro
+Puerto Vallarta
+Puerto Peñasco
+Piedras Negras
+Petatlán
+Pénjamo
+Pátzcuaro
+Parras de la Fuente
+Paracho de Verduzco
+Palau
+Ojinaga
+Ocotlán
+Nuevo México
+Nuevo Casas Grandes
+Nueva Rosita
+Nueva Italia de Ruiz
+Nochistlán
+Navolato
+Navojoa
+Nava
+Moroleón
+Morelia
+Monterrey
+Monclova
+Mexicali
+Pedro Meoqui
+Melchor Múzquiz
+Medina
+Mazatlán
+Matehuala
+Matamoros
+Marfil
+Maravatío
+Manzanillo
+Rodolfo Sánchez Taboada
+Magdalena de Kino
+San Pedro Madera
+Los Mochis
+Loreto
+León
+Las Pintas de Arriba
+La Piedad Cavadas
+La Paz
+La Orilla
+Lagos de Moreno
+La Cruz
+La Barca
+Santa Cruz de Juventino Rosas
+Jocotepec
+Jiquílpan de Juárez
+Jiménez
+Jesús María
+Jerez de García Salinas
+Jaral del Progreso
+Jamay
+Jalostotitlán
+Ixtlán del Río
+Ixtapa
+Irapuato
+Huetamo de Núñez
+Huatabampo
+Hidalgo del Parral
+Heróica Zitácuaro
+Nogales
+Heroica Caborca
+Hermosillo
+Heroica Guaymas
+Guasave
+Guanajuato
+Guamúchil
+Guadalupe
+Guadalupe
+Guadalajara
+Gomez Palacio
+Juan Jose Rios
+General Escobedo
+Garza García
+Fresnillo
+Escuinapa de Hidalgo
+Ensenada
+Encarnación de Díaz
+Empalme
+Pueblo Nuevo
+El Salto
+El Pueblito
+El Grullo
+Victoria de Durango
+Culiacán
+Cuauhtémoc
+Villa de Costa Rica
+Cortazar
+Compostela
+Comonfort
+Colima
+Ciudad Obregón
+Ciudad Lerdo
+Ciudad Juárez
+Ciudad Hidalgo
+Ciudad Guzmán
+Ciudad Delicias
+Ciudad Constitución
+Ciudad Camargo
+Ciudad Anáhuac
+Ciudad Altamirano
+Ciudad Acuña
+Chihuahua
+Chapala
+Celaya
+Castaños
+Cananea
+Villa Juárez
+Calvillo
+Víctor Rosales
+Autlán de Navarro
+Atoyac de Álvarez
+Atotonilco el Alto
+Armeria
+Arcelia
+Arandas
+Apodaca
+Apatzingán
+Apaseo el Grande
+Apaseo el Alto
+Ameca
+Allende
+Allende
+Aguascalientes
+Agua Prieta
+Acaponeta
+Acámbaro
+Abasolo
+Anáhuac
+Dolores Hidalgo Cuna de la Independencia Nacional
+Guacamayas
+Ciudad Lázaro Cárdenas
+Colonia del Valle
+Colonia Lindavista
+Colonia Nativitas
+Las Delicias
+San Pedro Garza Garcia
+Soledad de Graciano Sánchez
+Manzanillo
+Naucalpan de Juárez
+Hacienda Santa Fe
+Fuentes del Valle
+San Salvador Tizatlalli
+Jardines de la Silla (Jardines)
+San Buenaventura
+Colonia Santa Teresa
+San Jerónimo Cuatro Vientos
+San Martín Azcatepec
+Fraccionamiento Real Palmas
+Pórticos de San Antonio
+San Isidro
+Centro Familiar la Soledad
+San José Guadalupe Otzacatipan
+Las Pintitas
+Emiliano Zapata
+San Antonio Tecómitl
+Licenciado Benito Juárez (Campo Gobierno)
+Teotihuacán de Arista
+Jesús del Monte
+San Jorge Pueblo Nuevo
+Manuel Ojinaga
+Terrazas del Valle
+La Ermita
+Lomas del Sur
+Parque Industrial Ciudad Mitras
+Mitras Poniente
+Villa del Prado 2da Sección
+Tres de Mayo
+Don Antonio
+Heroica Ciudad de Tlaxiaco
+Ciudad de Huitzuco
+Casa Blanca
+La Providencia Siglo XXI
+Ampliación San Mateo (Colonia Solidaridad)
+Fraccionamiento Ciudad Olmeca
+San Rafael Tlanalapan
+Tecámac de Felipe Villanueva
+Venceremos
+Alborada Jaltenco
+Crucecita
+Padang Mat Sirat
+Kuah
+Jerantut
+Raub
+Batu Pahat
+Parit Raja
+Pekan Nenas
+Pontian Kechil
+Kampung Pasir Gudang Baru
+Kota Tinggi
+Taman Senai
+Kulai
+Skudai
+Johor Bahru
+Kluang
+Yong Peng
+Mersing
+Segamat
+Tangkak
+Muar
+Bakri
+Labis
+Kuala Selangor
+Batang Berjuntai
+Batu Arang
+Shah Alam
+Klang
+Cukai
+Kuala Lipis
+Papar
+Kota Kinabalu
+Donggongon
+Putatan
+Kinarut
+Ranau
+Semporna
+Victoria
+Beaufort
+Lahad Datu
+Sandakan
+Keningau
+Tawau
+Paka
+Kertih
+Kulim
+Bagan Serai
+Bedong
+Simpang Empat
+Taiping
+Kuala Kangsar
+Ipoh
+Gua Musang
+Kuala Terengganu
+Marang
+Tampin
+Alor Gajah
+Kampung Ayer Keroh
+Sungai Udang
+Malacca
+Banting
+Jenjarum
+Semenyih
+Seremban
+Port Dickson
+Sepang
+Bahau
+Kuala Pilah
+Pekan
+Mentekab
+Temerluh
+Butterworth
+Perai
+Bukit Mertajam
+Nibong Tebal
+Parit Buntar
+Tasek Glugor
+George Town
+Serendah
+Rawang
+Petaling Jaya
+Kuala Lumpur
+Sabak Bernam
+Sungai Besar
+Kuantan
+Batu Gajah
+Kampar
+Tapah Road
+Bidur
+Lumut
+Teluk Intan
+Gurun
+Sungai Petani
+Kepala Batas
+Tanah Merah
+Kuching
+Simanggang
+Sarikei
+Sibu
+Kangar
+Jitra
+Kuala Kedah
+Alor Setar
+Pasir Mas
+Kota Bharu
+Kudat
+Kapit
+Bintulu
+Limbang
+Miri
+Ulu Tiram
+Tanjung Tokong
+Tanjung Sepat
+Permatang Kuching
+Peringat
+Ladang Seri Kundang
+Pantai Remis
+Kuang
+Klebang Besar
+Kampung Tanjung Karang
+Kampung Sungai Ara
+Kampung Simpang Renggam
+Kampong Pangkal Kalong
+Kampong Masjid Tanah
+Kampong Kadok
+Kampong Dungun
+Kampung Bukit Baharu
+Kampung Baru Subang
+Kampung Baharu Nilai
+Kampong Baharu Balakong
+Kampung Ayer Molek
+Bukit Rambai
+Bentong Town
+Batu Berendam
+Putrajaya
+Bandar Labuan
+Subang Jaya
+Putra Heights
+Pantai Cenang
+Xai-Xai
+Dondo
+Macia
+Tete
+Ressano Garcia
+Quelimane
+Pemba
+Nampula
+Nacala
+Montepuez
+Mocímboa
+Ilha de Moçambique
+Maxixe
+Matola
+Maputo
+Manjacaze
+Lichinga
+Inhambane
+Cuamba
+Chokwé
+Chimoio
+Chibuto
+Beira
+António Enes
+Mutuáli
+Katima Mulilo
+Windhoek
+Swakopmund
+Rundu
+Rehoboth
+Otjiwarongo
+Oshakati
+Okahandja
+Lüderitz
+Keetmanshoop
+Grootfontein
+Gobabis
+Walvis Bay
+Nouméa
+Mont-Dore
+Dumbéa
+Birni N Konni
+Zinder
+Tillabéri
+Tibiri
+Tessaoua
+Téra
+Tanout
+Tahoua
+Niamey
+Nguigmi
+Mirriah
+Mayahi
+Matamey
+Maradi
+Magaria
+Madaoua
+Illéla
+Gaya
+Dosso
+Dogondoutchi
+Diffa
+Dakoro
+Ayorou
+Alaghsas
+Agadez
+Kingston
+Zuru
+Zungeru
+Zaria
+Yola
+Yenagoa
+Wukari
+Wudil
+Warri
+Wamba
+Uyo
+Uromi
+Umuahia
+Ughelli
+Ugep
+Uga
+Ubiaja
+Tegina
+Tambuwal
+Talata Mafara
+Takum
+Suleja
+Sokoto
+Soba
+Saki
+Shagamu
+Sapele
+Rijau
+Rano
+Potiskum
+Port Harcourt
+Pindiga
+Patigi
+Pankshin
+Ozubulu
+Oyo
+Oyan
+Owo
+Owerri
+Otukpa
+Otan Ayegbaju
+Osogbo
+Orita Eruwa
+Onitsha
+Ondo
+Olupona
+Okuta
+Okrika
+Okigwe
+Okene
+Oke Mesi
+Oke Ila
+Ohafia-Ifigh
+Ogwashi-Uku
+Oguta
+Ogoja
+Ogaminana
+Offa
+Ode
+Obudu
+Obonoma
+Numan
+Nsukka
+Nnewi
+Nkwerre
+Nkpor
+Nguru
+Nasarawa
+Nafada
+Mubi
+Moriki
+Monguno
+Mokwa
+Modakeke
+Minna
+Marte
+Malumfashi
+Makurdi
+Makoko
+Maiduguri
+Magumeri
+Lokoja
+Lere
+Lapai
+Lalupon
+Lagos
+Lafiagi
+Lafia
+Kwale
+Kumo
+Kumagunnam
+Kukawa
+Kuje
+Kontagora
+Kiyawa
+Kisi
+Keffi
+Kaura Namoda
+Katsina-Ala
+Katsina
+Kari
+Kano
+Kamba
+Kaiama
+Kagoro
+Kafanchan
+Kaduna
+Kachia
+Kabba
+Jos
+Jimeta
+Jega
+Jebba
+Jalingo
+Iwo
+Itu
+Isieke
+Ise-Ekiti
+Isanlu-Itedoijowa
+Ipoti
+Iperu
+Inisa
+Ilorin
+Ilobu
+Illela
+Ilesa
+Ilaro
+Ila Orangun
+Ikot Ekpene
+Ikom
+Ikirun
+Ikire
+Ikere-Ekiti
+Ikeja
+Ijero-Ekiti
+Ijebu-Ode
+Ijebu-Jesa
+Ijebu-Igbo
+Ihiala
+Igede-Ekiti
+Igbo-Ukwu
+Igbor
+Igbo-Ora
+Igboho
+Igbeti
+Igbara-Odo
+Ifo
+Idanre
+Idah
+Ibi
+Ibeto
+Ibadan
+Hadejia
+Gwoza
+Gwarzo
+Gwaram
+Gwadabawa
+Gusau
+Gummi
+Gumel
+Gombi
+Gombe
+Gembu
+Geidam
+Gbongan
+Gaya
+Gashua
+Garko
+Ganye
+Gamboru
+Funtua
+Fiditi
+Ezza-Ohu
+Esuk Oron
+Epe
+Enugu-Ukwu
+Enugu-Ezike
+Enugu
+Emure-Ekiti
+Elele
+Ekpoma
+Eket
+Ejigbo
+Eha Amufu
+Egbe
+Effon Alaiye
+Effium
+Ebute Ikorodu
+Dutsen Wai
+Dutse
+Dukku
+Doma
+Dikwa
+Deba
+Daura
+Daura
+Darazo
+Damboa
+Damaturu
+Calabar
+Burutu
+Bukuru
+Buguma
+Bonny
+Bode Saadu
+Biu
+Birnin Kudu
+Birnin Kebbi
+Sofo-Birnin-Gwari
+Billiri
+Bida
+Benin City
+Bende
+Beli
+Bauchi
+Baro
+Bama
+Badagry
+Babana
+Azare
+Awka
+Awgu
+Auchi
+Asaba
+Argungu
+Aramoko-Ekiti
+Apomu
+Anchau
+Amaigbo
+Akwanga
+Akure
+Aku
+Ajaokuta
+Agulu
+Agbor
+Afikpo
+Ado Odo
+Ado-Ekiti
+Abuja
+Abeokuta
+Abakaliki
+Aba
+Degema Hulk
+Tipitapa
+Somoto
+Somotillo
+Siuna
+San Rafael del Sur
+San Marcos
+Rivas
+Río Blanco
+Rama
+Puerto Cabezas
+Ocotal
+Nueva Guinea
+Nandaime
+Nagarote
+Matagalpa
+Masaya
+Masatepe
+Managua
+León
+La Paz Centro
+Juigalpa
+Jinotepe
+Jinotega
+Jalapa
+Granada
+Estelí
+El Viejo
+El Crucero
+Diriamba
+Corinto
+Chinandega
+Chichigalpa
+Camoapa
+Boaco
+Bluefields
+Ciudad Sandino
+Zwolle
+Zwijndrecht
+Zutphen
+Zundert
+Zoetermeer
+Zevenaar
+Zeist
+Zeewolde
+Zandvoort
+Zaltbommel
+Zaanstad
+Zaandam
+Wolvega
+Woerden
+Woensdrecht
+Wisch
+Winterswijk
+Winschoten
+Wijk bij Duurstede
+Wijchen
+Wierden
+Westervoort
+Werkendam
+Weesp
+Weert
+Wassenaar
+Wageningen
+Waddinxveen
+Waalwijk
+Waalre
+Vught
+Voorst
+Voorschoten
+Voorhout
+Voorburg
+Volendam
+Vlissingen
+Vlagtwedde
+Vlaardingen
+Vianen
+Venray
+Venlo
+Velsen-Zuid
+Velp
+Veldhoven
+Veghel
+Veere
+Veenendaal
+Veendam
+Valkenswaard
+Utrecht
+Urk
+Uithoorn
+Uden
+Tubbergen
+Tongelre
+Tilburg
+Tiel
+Terneuzen
+Tegelen
+Steenwijk
+Steenbergen
+Staphorst
+Stadskanaal
+Spijkenisse
+Someren
+Soest
+Sneek
+Sliedrecht
+Sittard
+Sint-Oedenrode
+'s-Hertogenbosch
+'s-Gravenzande
+The Hague
+Schijndel
+Schiedam
+Scheveningen
+Schagen
+Rucphen
+Rotterdam
+Roosendaal
+Roermond
+Rijswijk
+Ridderkerk
+Rhoon
+Rhenen
+Raalte
+Putten
+Purmerend
+Pijnacker
+Papendrecht
+Oud-Beijerland
+Oss
+Oosterhout
+Oldenzaal
+Oldebroek
+Oisterwijk
+Oegstgeest
+Nuth
+Nunspeet
+Nuenen
+Noordwijkerhout
+Noordwijk-Binnen
+Nijmegen
+Nijkerk
+Nieuwegein
+Nederweert
+Naarden
+Naaldwijk
+Mijdrecht
+Middelharnis
+Middelburg
+Meppel
+Meerssen
+Medemblik
+Maastricht
+Maassluis
+Maarssen
+Losser
+Loon op Zand
+Lisse
+Lindenholt
+Lichtenvoorde
+Leusden
+Lelystad
+Leiderdorp
+Leiden
+Leeuwarden
+Leerdam
+Leek
+Krimpen aan den IJssel
+Korrewegwijk
+Kerkrade
+Katwijk aan Zee
+Kampen
+IJsselstein
+Huizen
+Houten
+Horst
+Hoorn
+Hoogezand
+Hoogeveen
+Hoofddorp
+Hoge Vucht
+Hoensbroek
+Hilversum
+Hilvarenbeek
+Hillegom
+Heusden
+Hengelo
+Hendrik-Ido-Ambacht
+Helmond
+Hellevoetsluis
+Heiloo
+Heesch
+Heerlen
+Heerhugowaard
+Heerenveen
+Heerde
+Heemstede
+Heemskerk
+Harlingen
+Harenkarspel
+Haren
+Harderwijk
+Hardenberg
+Haarlem
+Haaksbergen
+Groningen
+Groesbeek
+Gouda
+Gorinchem
+Goirle
+Goes
+Gennep
+Gendringen
+Geldrop
+Geldermalsen
+Geertruidenberg
+Ermelo
+Epe
+Enschede
+Enkhuizen
+Emmen
+Emmeloord
+Elst
+Elburg
+Eindhoven
+Eibergen
+Eersel
+Ede
+Duiven
+Druten
+Dronten
+Drimmelen
+Driebergen-Rijsenburg
+Drachten
+Dordrecht
+Dongen
+Doetinchem
+Diemen
+Deventer
+Den Helder
+Delfzijl
+Delft
+Delfshaven
+De Bilt
+Dalfsen
+Culemborg
+Cuijk
+Cranendonck
+Castricum
+Capelle aan den IJssel
+Bussum
+Bunschoten
+Brunssum
+Brummen
+Broek op Langedijk
+Broek in Waterland
+Breda
+Boxtel
+Boskoop
+Borssele
+Borne
+Born
+Borger
+Bodegraven
+Bloemendaal
+Bladel
+Beverwijk
+Beuningen
+Best
+Bergschenhoek
+Bergeijk
+Bergen op Zoom
+Benthuizen
+Beek
+Barneveld
+Barendrecht
+Baarn
+Asten
+Assen
+Arnhem
+Apeldoorn
+Anloo
+Amsterdam
+Amstelveen
+Amersfoort
+Alphen aan den Rijn
+Almere Stad
+Almelo
+Alkmaar
+Alblasserdam
+Aalten
+Aalsmeer
+Amsterdam-Zuidoost
+Berkel en Rodenrijs
+Ypenburg
+Trondheim
+Tromsø
+Tønsberg
+Steinkjer
+Stavanger
+Skien
+Sarpsborg
+Sandnes
+Sandefjord
+Porsgrunn
+Oslo
+Moss
+Molde
+Mo i Rana
+Lillehammer
+Larvik
+Kristiansund
+Kristiansand
+Kongsberg
+Horten
+Haugesund
+Harstad
+Hamar
+Halden
+Gjøvik
+Fredrikstad
+Drammen
+Bodø
+Bergen
+Arendal
+Ålesund
+Askøy
+Ytrebygda
+Wāling
+Tulsīpur
+Tīkāpur
+Tānsen
+Sirāhā
+Rājbirāj
+Pokhara
+Pātan
+Panauti̇̄
+Malangwa
+Mahendranagar
+Lahān
+Kirtipur
+Khāndbāri
+Kathmandu
+Janakpur
+Jaleswar
+Ithari
+Ilām
+Hetauda
+Gulariyā
+Gaur
+Dharān Bāzār
+Dhankutā
+Dhangarhi
+Dārchulā
+Dailekh
+Dadeldhurā
+Butwāl
+Bīrganj
+Birātnagar
+Bharatpur
+Bhairāhawā
+Bhadrapur
+Banepā
+Bāglung
+Birendranagar
+Dipayal
+Nepalgunj
+Yaren
+Alofi
+Wellington
+Wanganui
+Timaru
+Taupo
+Pukekohe East
+Porirua
+Paraparaumu
+Palmerston North
+North Shore
+New Plymouth
+Nelson
+Napier
+Manukau City
+Mangere
+Lower Hutt
+Invercargill
+Hastings
+Hamilton
+Dunedin
+Christchurch
+Auckland
+Levin
+Gisborne
+Masterton
+Tauranga
+Papakura
+Whakatane
+Ashburton
+Whangarei
+Cambridge
+Rotorua
+Blenheim
+Upper Hutt
+Taradale
+Waitakere
+Sur
+Sohar
+Sufālat Samā’il
+Shināş
+Şalālah
+Şaḩam
+Nizwá
+Muscat
+Khasab
+Izkī
+‘Ibrī
+Ibrā’
+Bidbid
+Bawshar
+Barkā’
+Bahlā’
+Badīyah
+As Suwayq
+Seeb
+Rustaq
+Al Liwā’
+Al Khābūrah
+Al Buraymī
+Ādam
+Yanqul
+Vista Alegre
+Veracruz
+Tocumen
+Santiago de Veraguas
+San Miguelito
+Puerto Armuelles
+Pedregal
+Panamá
+Pacora
+Nuevo Arraiján
+Las Cumbres
+La Concepción
+La Chorrera
+La Cabima
+David
+Colón
+Chitré
+Chilibre
+Chepo
+Changuinola
+Cativá
+Arraiján
+Alcalde Díaz
+Aguadulce
+Yurimaguas
+Virú
+Uchiza
+Tumbes
+Trujillo
+Tocache
+Tingo María
+Tambo Grande
+Talara
+Sullana
+Sechura
+Santiago de Cao
+San Pedro de Lloc
+Saña
+Rioja
+Querecotillo
+Pucallpa
+Piura
+Pimentel
+Picsi
+Paita
+Paiján
+Pacasmayo
+Moyobamba
+Monsefú
+Moche
+Marcavelica
+La Unión
+Laredo
+La Peca
+Lambayeque
+Juanjuí
+Jaén
+Iquitos
+Huaraz
+Huánuco
+Huamachuco
+Guadalupe
+Ferreñafe
+Coishco
+Chulucanas
+Chongoyape
+Chocope
+Chimbote
+Chiclayo
+Chepén
+Chachapoyas
+Catacaos
+Cajamarca
+Bellavista
+Bagua Grande
+La Breita
+Zarumilla
+Yunguyo
+Yanacancha
+Tarma
+Tambopata
+Tacna
+Santiago de Surco
+Sicuani
+Satipo
+San Vicente de Cañete
+Santa Ana
+San Isidro
+San Clemente
+Puno
+Puerto Maldonado
+Pisco
+Paramonga
+Nuevo Imperial
+Nazca
+Moquegua
+Mollendo
+Minas de Marcona
+Mala
+Lima
+La Oroya
+Junín
+Juliaca
+Jauja
+Imperial
+Ilo
+Ilave
+Ica
+Huaura
+Huarmey
+Huaral
+Huanta
+Huancayo
+Huancavelica
+Hualmay
+Huacho
+Cusco
+Chosica
+Chincha Alta
+Chaupimarca
+Chancay
+Cerro de Pasco
+Camaná
+Callao
+Barranca
+Ayaviri
+Ayacucho
+Arequipa
+Andahuaylas
+Abancay
+La Rinconada
+Punaauia
+Papeete
+Faaa
+Wewak
+Port Moresby
+Popondetta
+Mount Hagen
+Mendi
+Madang
+Lae
+Kokopo
+Kimbe
+Goroka
+Daru
+Bulolo
+Arawa
+Zamboanga
+Wao
+Virac
+Vigan
+Victorias
+Victoria
+Veruela
+Valencia
+Urdaneta
+Ualog
+Tupi
+Tuguegarao City
+Trento
+Toledo
+Tiwi
+Ternate
+Teresa
+Telabastagan
+Taytay
+Tayabas
+Tarlac City
+Tanza
+Tanjay
+Tangub
+Tandag
+Tanay
+Tanauan
+Tanauan
+Taloc
+Talisay
+Talisay
+Talisay
+Talavera
+Talacogon
+Tagum
+Taguig
+Tagudin
+Tagoloan
+Tagbilaran City
+Tagas
+Tacurong
+Tabuk
+Tabaco
+Taal
+Surigao
+Surallah
+Subic
+Suay
+Sorsogon
+Solano
+Solana
+Sitangkai
+Sipalay
+Silang
+Sibulan
+Sexmoan
+Sebu
+Sariaya
+San Vicente
+Santo Tomas
+Santol
+Santiago
+Santa Rosa
+Santa Maria
+Santa Maria
+Santa Cruz
+Santa Cruz
+Santa Cruz
+Santa Catalina
+Santa Barbara
+Santa Ana
+San Simon
+San Pedro
+San Pascual
+San Pablo
+San Nicolas
+San Narciso
+San Miguel
+San Miguel
+San Mateo
+San Mateo
+San Mariano
+San Marcelino
+San Luis
+San Leonardo
+San Juan
+San Jose del Monte
+San Jose
+San Jose
+San Ildefonso
+San Francisco
+Aurora
+San Francisco
+San Fernando
+San Fernando
+San Fernando
+San Antonio
+San Antonio
+San Antonio
+Sampaloc
+Samal
+Samal
+Sagay
+Sablayan
+Roxas
+Roxas City
+Roxas
+Romblon
+Rizal
+Recodo
+Ramos
+Ramon
+Quiapo
+Quezon City
+Quezon
+Quezon
+Pulupandan
+Pulong Santa Cruz
+Pulilan
+Puerto Princesa
+Port Area
+Porac
+Polomolok
+Polangui
+Plaridel
+Pio
+Pinamungahan
+Pinamalayan
+Pililla
+Pilar
+Pila
+Peñaranda
+Patuto
+Passi
+Parang
+Paraiso
+Papaya
+Paombong
+Pantubig
+Paniqui
+Pangil
+Pandi
+Pandacaqui
+Panalanoy
+Panabo
+Palo
+Palayan City
+Pagbilao
+Pagaluñgan
+Pagadian
+Paete
+Pacol
+Ozamiz City
+Oroquieta
+Ormoc
+Orion
+Orani
+Olongapo
+Obando
+Noveleta
+Norzagaray
+New Corella
+Nasugbu
+Narra
+Naic
+Nagcarlan
+Naga
+Naga
+Nabunturan
+Nabua
+Muricay
+Murcia
+Muñoz
+Morong
+Morong
+Rodriguez
+Monkayo
+Molave
+Minglanilla
+Midsayap
+Meycauayan
+Mexico
+Mercedes
+Mendez-Nuñez
+Mauban
+Mati
+Masinloc
+Masbate
+Masantol
+Mariveles
+Marilao
+Mariano
+Marawi City
+Maramag
+Maragondon
+Mantampay
+Mansilingan
+Mansalay
+Manolo Fortich
+Manila
+Manibaug Pasig
+Mangaldan
+Mandaue City
+Mandaluyong City
+Mankayan
+Manay
+Manapla
+Manaoag
+Mamburao
+Mamatid
+Malvar
+Maluso
+Maluñgun
+Malolos
+Malita
+Malilipot
+Malaybalay
+Malapatan
+Malanday
+Malabanban Norte
+Makati City
+Mahayag
+Magsaysay
+Magarao
+Maganoy
+Magalang
+Mabalacat City
+Maasin
+Maao
+Lupon
+Lumbang
+Lucena
+Lucban
+Lubao
+Los Baños
+Lopez
+Loma de Gato
+Loboc
+Lipa City
+Lingayen
+Limay
+Liloan
+Lilio
+Libon
+Libertad
+Legaspi
+Laur
+La Trinidad
+Lapu-Lapu City
+La Paz
+Laoang
+Laoag
+Lala
+Laguilayan
+La Castellana
+La Carlota
+Labo
+Koronadal
+Kidapawan
+Kawit
+Kalibo (poblacion)
+Kabankalan
+Kabacan
+Jose Pañganiban
+Jolo
+Jasaan
+Jalajala
+Jagna
+Jaen
+Itogon
+Isulan
+Isabela
+City of Isabela
+Irosin
+Iriga City
+Ipil
+Indang
+Imus
+Iloilo
+Iligan City
+Ilagan
+Iba
+Hinigaran
+Himamaylan
+Hermosa
+Hagonoy
+Guyong
+Gumaca
+Guiset East
+Guimba
+Guihulñgan
+Guiguinto
+Goa
+Glan
+Gerona
+General Trias
+General Tinio
+General Santos
+General Mamerto Natividad
+Gapan
+Escalante
+Saravia
+Dumaguete
+Don Carlos
+Domalanoan
+Dologon
+Dipolog
+Dinalupihan
+Digos
+Diadi
+Del Pilar
+Davao
+Dasmariñas
+Dapitan
+Danao
+Danao
+Daet
+Cuenca
+Cotabato
+Cordova
+Consolacion
+Concepcion
+Concepcion Ibaba
+Compostela
+Compostela
+Cebu City
+Cavite City
+Catbalogan
+Catarman
+Catanauan
+Castillejos
+Carmona
+Cogan
+Carigara
+Cardona
+Carcar
+Capas
+Canlaon
+Candelaria
+Candaba
+Camiling
+Calumpit
+Calumpang
+Calbayog City
+Calauan
+Calauag
+Calatagan
+Calasiao
+Calapan
+Calamba
+Calaca
+Calabanga
+Cainta
+Cagayan de Oro
+Cadiz
+Cabiao
+Cabayangan
+Cabanatuan City
+Cabagan
+Cabadbaran
+Butuan
+Bustos
+Boroon
+Burgos
+Bunawan
+Buluan
+Bulaon
+Bulan
+Bulacan
+Buhi
+Bugo
+Buenavista
+Budta
+Botolan
+Borongan
+Bongao
+Bongabon
+Bogo
+Bocaue
+Bislig
+Binonga
+Binmaley
+Binangonan
+Binalbagan
+Bignay Uno
+Bayugan
+Bayombong
+Baybay
+Bayawan
+Bayambang
+Bay
+Bauang
+Bauan
+Bato
+Batangas
+Batac City
+Baras
+Bantayan
+Bansalan
+Bañga
+Banaybanay
+Bambang
+Baliuag
+Balayan
+Balanga
+Balamban
+Balagtas
+Bais
+Bah-Bah
+Baguio
+Bago City
+Baggabag B
+Bacoor
+Bacolod City
+Babo-Pangulo
+Baao
+Atimonan
+Asia
+Aringay
+Arayat
+Aparri
+Apalit
+Antipolo
+Angono
+Angeles City
+Angat
+Amadeo
+Alicia
+Aliaga
+Alaminos
+Alabel
+Agoo
+Abuyog
+Abucay
+Bagong Pagasa
+Malingao
+Pasig City
+Pandan
+Apas
+Chuhar Jamāli
+Rāwala Kot
+Pīr jo Goth
+Khairpur
+Zhob
+Zaida
+Zāhir Pīr
+Zafarwāl
+Yazman
+Wazīrābād
+Warburton
+Wārāh
+Vihāri
+Utmānzai
+Uthal
+Usta Muhammad
+Umarkot
+Ubauro
+Turbat
+Topi
+Toba Tek Singh
+Thul
+Thatta
+Thāru Shāh
+Taunsa
+Tānk
+Tangi
+Tando Muhammad Khān
+Tando Jām
+Tando Allāhyār
+Tando Ādam
+Tāndliānwāla
+Talhār
+Talamba
+Talagang
+Tāl
+Swābi
+Surkhpur
+Sukkur
+Sukheke Mandi
+Sodhra
+Sīta Road
+Sinjhoro
+Sillānwāli
+Sibi
+Sialkot
+Shujāābād
+Shorko
+Shikārpur
+Sheikhupura
+Sharqpur
+Shakargarr
+Shahr Sultān
+Shāhpur Chākar
+Shahkot
+Shāhdādpur
+Shāhdādkot
+Shabqadar
+Sehwān
+Sargodha
+Sarāi Sidhu
+Sarāi Naurang
+Sarāi Ālamgīr
+Sangla Hill
+Sānghar
+Sambriāl
+Sakrand
+Sāhīwāl
+Sahiwal
+Sādiqābād
+Rohri
+Renāla Khurd
+Rawalpindi
+Ratodero
+Rānīpur
+Rājanpur
+Rāja Jang
+Rāiwind
+Rādhan
+Rabwāh
+Quetta
+Kambar
+Qādirpur Rān
+Pishin
+Pīr Mahal
+Pindi Gheb
+Pindi Bhattiān
+Pind Dādan Khān
+Phālia
+Peshawar
+Pattoki
+Pasrūr
+Pasni
+Pāno Āqil
+Pākpattan
+Pahārpur
+Pad Īdan
+Pabbi
+Okāra
+Nushki
+Nawābshāh
+Naushahro Fīroz
+Naushahra Virkān
+Naudero
+Nasīrābād
+Nārowāl
+Nārang
+Naukot
+Nankāna Sāhib
+Muzaffargarh
+Muzaffarābād
+Mustafābād
+Murree
+Murīdke
+Multān
+Moro
+Mithi
+Mitha Tiwāna
+Mīrpur Māthelo
+Mirpur Khas
+Mingora
+Minchinābād
+Miānwāli
+Miān Channūn
+Mehrābpur
+Mehar
+Mātli
+Matiāri
+Mastung
+Mardan
+Mānsehra
+Mangla
+Mandi Bahāuddīn
+Mānānwāla
+Māmu Kānjan
+Malir Cantonment
+Malakwāl
+Mailsi
+Mach
+Loralai
+Lodhrān
+Layyah
+Lārkāna
+Lāliān
+Lāla Mūsa
+Lakki Marwat
+Lahore
+Ladhewāla Warāich
+Lāchi
+Kunri
+Kunjāh
+Kundiān
+Kulāchi
+Kot Samāba
+Kotri
+Kot Rādha Kishan
+Kot Mūmin
+Kot Malik
+Kotli Lohārān
+Kotli
+Kot Ghulām Muhammad
+Kot Diji
+Kot Addu
+Kohāt
+Khushāb
+Khurriānwāla
+Khewra
+Khāriān
+Khārān
+Khānpur
+Khānpur
+Khāngarh
+Khāngāh Dogrān
+Khalābat
+Khairpur Nathan Shāh
+Khairpur
+Khairpur
+Kasūr
+Kashmor
+Karor
+Karachi
+Kanganpur
+Kandiāro
+Kandhkot
+Kāmra
+Kamoke
+Kamīr
+Kamar Mushāni
+Kamālia
+Kalūr Kot
+Kallar Kahār
+Kāleke Mandi
+Kalāt
+Kālābāgh
+Kahūta
+Kohror Pakka
+Kāhna
+Kabīrwāla
+Johi
+Jīwani
+Jhumra
+Jhol
+Jhelum
+Jhawāriān
+Jhang Sadr
+Jauharābād
+Jatoi Shimāli
+Jarānwāla
+Jand
+Jāmpur
+Jalālpur Pīrwāla
+Jalālpur
+Jahāniān Shāh
+Jacobābād
+Islamabad
+Hyderabad
+Hujra
+Hingorja
+Hazro
+Haveliān
+Haveli
+Hāsilpur
+Hasan Abdāl
+Haru Zbad
+Harnoli
+Harīpur
+Hangu
+Hāla
+Hāfizābād
+Hadāli
+Gwadar
+Gujrāt
+Gujrānwāla
+Gūjar Khān
+Gojra
+Ghotki
+Ghauspur
+Ghāro
+Garh Mahārāja
+Gambat
+Fort Abbās
+Fazalpur
+Chak Two Hundred Forty-Nine TDA
+Faruka
+Faqīrwāli
+Faisalābād
+Eminābād
+Dunyāpur
+Dunga Bunga
+Dullewāla
+Dīr
+Dīpālpur
+Dinga
+Dijkot
+Digri
+Dhoro Naro
+Dhanot
+Dera Ismāīl Khān
+Dera Ghazi Khan
+Dera Bugti
+Daur
+Dāūd Khel
+Daska
+Darya Khān
+Dājal
+Dadu
+Dādhar
+Chūniān
+Chūhar Kāna
+Chor
+Choa Saidān Shāh
+Chishtiān Mandi
+Chiniot
+Chīchāwatni
+Chawinda
+Charsadda
+Chaman
+Chakwāl
+Chak Āzam Saffo
+Būrewāla
+Bhopālwāla
+Bhit Shāh
+Bhimbar
+Bhera
+Bhawāna
+Bhān
+Bhalwāl
+Bhakkar
+Bhāi Pheru
+Bela
+Bat Khela
+Basīrpur
+Bannu
+Bahāwalpur
+Bahāwalnagar
+Badīn
+Baddomalhi
+Attock City
+Ārifwāla
+Amangarh
+Alīpur
+Akora
+Ahmadpur East
+Abbottābād
+Bahāwalnagar
+Nowshera Cantonment
+Ahmadpur Siāl
+New Bādāh
+Tando Ghulām Ali
+Sethārja Old
+Risālpur
+Malakwal City
+Żyrardów
+Żoliborz
+Zielonka
+Zamość
+Zambrów
+Ząbki
+Wyszków
+Wołomin
+Wola
+Włochy
+Wieliczka
+Wesoła
+Wawer
+Warsaw
+Ursus
+Tomaszów Mazowiecki
+Tomaszów Lubelski
+Tarnów
+Tarnobrzeg
+Targówek
+Szczytno
+Świdnik
+Suwałki
+Sulejówek
+Staszów
+Starachowice
+Stalowa Wola
+Śródmieście
+Sokołów Podlaski
+Sokółka
+Sochaczew
+Skierniewice
+Skarżysko-Kamienna
+Siemiatycze
+Siedlce
+Sanok
+Sandomierz
+Rzeszów
+Ropczyce
+Rembertów
+Rawa Mazowiecka
+Radzyń Podlaski
+Radom
+Pułtusk
+Puławy
+Przeworsk
+Przemyśl
+Przasnysz
+Pruszków
+Płońsk
+Pisz
+Pionki
+Piastów
+Piaseczno
+Otwock
+Ostrów Mazowiecka
+Ostrowiec Świętokrzyski
+Ostrołęka
+Opoczno
+Olsztyn
+Olecko
+Ochota
+Nowy Targ
+Nowy Sącz
+Nowy Dwór Mazowiecki
+Nisko
+Mrągowo
+Mokotów
+Mława
+Mińsk Mazowiecki
+Milanówek
+Mielec
+Międzyrzec Podlaski
+Marki
+Łuków
+Lublin
+Lubartów
+Łomża
+Łomianki
+Lidzbark Warmiński
+Legionowo
+Łęczna
+Łapy
+Łańcut
+Krosno
+Krasnystaw
+Kraśnik
+Kozienice
+Konstancin-Jeziorna
+Końskie
+Kobyłka
+Kielce
+Kętrzyn
+Kabaty
+Józefów
+Jędrzejów
+Jasło
+Jarosław
+Hrubieszów
+Hajnówka
+Grodzisk Mazowiecki
+Grajewo
+Gorlice
+Giżycko
+Gierłoż
+Garwolin
+Ełk
+Działdowo
+Dęblin
+Dębica
+Ciechanów
+Chełm
+Busko-Zdrój
+Brzesko
+Bochnia
+Biłgoraj
+Bielsk Podlaski
+Bielany
+Białystok
+Białołeka
+Biała Podlaska
+Bemowo
+Bartoszyce
+Augustów
+Żywiec
+Żory
+Złotów
+Złotoryja
+Zielona Góra
+Zgorzelec
+Zgierz
+Zduńska Wola
+Zawiercie
+Żary
+Zakopane
+Żagań
+Zabrze
+Ząbkowice Śląskie
+Września
+Wrocław
+Wodzisław Śląski
+Włocławek
+Wieluń
+Wejherowo
+Wałcz
+Wałbrzych
+Wągrowiec
+Wadowice
+Ustroń
+Ustka
+Tychy
+Turek
+Trzebinia
+Trzcianka
+Toruń
+Tczew
+Tarnowskie Góry
+Szczecinek
+Szczecin
+Szamotuły
+Świnoujście
+Świętochłowice
+Świebodzin
+Świecie
+Świebodzice
+Świdwin
+Świdnica
+Swarzędz
+Sulechów
+Strzelce Opolskie
+Strzegom
+Starogard Gdański
+Stargard Szczeciński
+Środa Wielkopolska
+Śrem
+Sosnowiec
+Sopot
+Solec Kujawski
+Słupsk
+Słubice
+Skawina
+Sierpc
+Sieradz
+Siemianowice Śląskie
+Rypin
+Rydułtowy
+Rybnik
+Rumia
+Ruda Śląska
+Reda
+Rawicz
+Radzionków
+Radomsko
+Radlin
+Racibórz
+Pyskowice
+Pszczyna
+Pruszcz Gdański
+Prudnik
+Poznań
+Polkowice
+Police
+Płock
+Pleszew
+Piotrków Trybunalski
+Piła
+Piekary Śląskie
+Pabianice
+Ozorków
+Oświęcim
+Ostrów Wielkopolski
+Ostróda
+Orzesze
+Opole
+Olkusz
+Oleśnica
+Oława
+Oborniki
+Nysa
+Nowy Tomyśl
+Nowogard
+Nowa Sól
+Nowa Ruda
+Namysłów
+Nakło nad Notecią
+Myszków
+Mysłowice
+Myślenice
+Mikołów
+Międzyrzecz
+Malbork
+Luboń
+Lubliniec
+Lubin
+Lubań
+Łowicz
+Łódź
+Libiąż
+Leszno
+Legnica
+Lędziny
+Łęczyca
+Lębork
+Łaziska Górne
+Łask
+Kwidzyn
+Kutno
+Krotoszyn
+Krapkowice
+Kraków
+Koszalin
+Kostrzyn nad Odrą
+Kościerzyna
+Kościan
+Konstantynów Łódzki
+Konin
+Kołobrzeg
+Koło
+Knurów
+Kluczbork
+Kłodzko
+Kęty
+Kędzierzyn-Koźle
+Katowice
+Kartuzy
+Kamienna Góra
+Kalisz
+Jelenia Góra
+Jelcz
+Jaworzno
+Jawor
+Jastrzębie Zdrój
+Jarocin
+Inowrocław
+Iława
+Gubin
+Gryfino
+Gryfice
+Grudziądz
+Gostynin
+Gostyń
+Gorzów Wielkopolski
+Goleniów
+Gniezno
+Głuchołazy
+Głowno
+Głogów
+Gliwice
+Gdynia
+Gdańsk
+Fordon
+Elbląg
+Dzierżoniów
+Dąbrowa Górnicza
+Częstochowa
+Czerwionka-Leszczyny
+Czeladź
+Czechowice-Dziedzice
+Cieszyn
+Chrzanów
+Choszczno
+Chorzów
+Chojnice
+Chodzież
+Chełmża
+Chełmno
+Bytów
+Bytom
+Bydgoszcz
+Brzeg
+Brodnica
+Braniewo
+Bolesławiec
+Boguszów-Gorce
+Bogatynia
+Bieruń
+Bielsko-Biala
+Bielawa
+Białogard
+Bełchatów
+Będzin
+Andrychów
+Aleksandrów Łódzki
+Ursynów
+Praga Północ
+Praga Południe
+Jelcz Laskowice
+Saint-Pierre
+Adamstown
+Aguadilla
+Arecibo
+Barceloneta
+Bayamón
+Caguas
+Candelaria
+Carolina
+Cataño
+Cayey
+Fajardo
+Guayama
+Guaynabo
+Humacao
+Levittown
+Manatí
+Mayagüez
+Ponce
+San Juan
+Trujillo Alto
+Vega Baja
+Yauco
+Rafaḩ
+An Nuşayrāt
+Khān Yūnis
+Jabālyā
+Gaza
+Dayr al Balaḩ
+Bayt Lāhyā
+Bayt Ḩānūn
+Banī Suhaylā
+Al Burayj
+‘Abasān al Kabīrah
+Yuta
+Ţūlkarm
+Ţūbās
+Sa‘īr
+Ramallah
+Qalqīlyah
+Qabāţīyah
+Nablus
+Janīn
+Idhnā
+Ḩalḩūl
+Dūrā
+Bethlehem
+Bayt Jālā
+Banī Na‘īm
+Balāţah
+Az̧ Z̧āhirīyah
+As Samū‘
+Ar Rām wa Ḑāḩiyat al Barīd
+Jericho
+Al Yāmūn
+Hebron
+Al Bīrah
+Al ‘Ayzarīyah
+Old City
+Al Qarārah
+Az Zuwāydah
+East Jerusalem
+Vila Franca de Xira
+Vialonga
+Torres Vedras
+Tomar
+Sintra
+Sesimbra
+Setúbal
+São João da Talha
+São Domingos de Rana
+Santarém
+Santa Iria da Azóia
+Sacavém
+Rio de Mouro
+Ramada
+Queluz
+Quarteira
+Póvoa de Santa Iria
+Portimão
+Portalegre
+Pontinha
+Pombal
+Pinhal Novo
+Piedade
+Peniche
+Parede
+Palmela
+Paço de Arcos
+Olhão
+Odivelas
+Montijo
+Monte Estoril
+Monsanto
+Moita
+Marinha Grande
+Loures
+Loulé
+Lisbon
+Linda-a-Velha
+Leiria
+Laranjeiro
+Lagos
+Funchal
+Faro
+Évora
+Estoril
+Entroncamento
+Corroios
+Charneca
+Castelo Branco
+Cascais
+Carnaxide
+Carcavelos
+Caparica
+Camarate
+Câmara de Lobos
+Caldas da Rainha
+Cacém
+Belas
+Beja
+Barreiro
+Arrentela
+Amora
+Amadora
+Almada
+Algés
+Alcabideche
+Albufeira
+Viseu
+Vila Real
+Vilar de Andorinho
+Vila Nova de Gaia
+Vila do Conde
+Viana do Castelo
+Valongo
+Sequeira
+Senhora da Hora
+São Pedro da Cova
+São Mamede de Infesta
+São João da Madeira
+Rio Tinto
+Póvoa de Varzim
+Porto
+Ponte de Lima
+Pedroso
+Ovar
+Oliveira do Douro
+Monção
+Matosinhos
+Maia
+Leça do Bailio
+Leça da Palmeira
+Ílhavo
+Guimarães
+Guarda
+Gondomar
+Feira
+Fânzeres
+Fafe
+Esposende
+Esposende
+Ermesinde
+Custoias
+Covilhã
+Coimbra
+Canidelo
+Bragança
+Braga
+Bougado
+Barcelos
+Baguim do Monte
+Aveiro
+Águas Santas
+Ponta Delgada
+Melekeok
+Villarrica
+Villa Hayes
+Villa Elisa
+San Lorenzo
+San Juan Bautista
+San Antonio
+Presidente Franco
+Pilar
+Pedro Juan Caballero
+Nemby
+Limpio
+Lambaré
+Itauguá
+Itá
+Fernando de la Mora
+Encarnación
+Coronel Oviedo
+Concepción
+Colonia Mariano Roque Alonso
+Ciudad del Este
+Capiatá
+Caazapá
+Caaguazú
+Caacupé
+Asunción
+Umm Şalāl Muḩammad
+Ar Rayyān
+Al Wakrah
+Al Khawr
+Doha
+Saint-Pierre
+Saint-Paul
+Saint-Louis
+Saint-Leu
+Saint-Joseph
+Sainte-Suzanne
+Sainte-Marie
+Saint-Denis
+Saint-Benoît
+Saint-André
+Le Tampon
+Le Port
+La Possession
+Piton Saint-Leu
+Zimnicea
+Zărnești
+Zalău
+Vulcan
+Voluntari
+Vişeu de Sus
+Vatra Dornei
+Vaslui
+Urziceni
+Turnu Măgurele
+Turda
+Tulcea
+Târnăveni
+Târgu Secuiesc
+Târgu Neamţ
+Târgu-Mureş
+Târgu Jiu
+Târgovişte
+Timişoara
+Tecuci
+Suceava
+Slatina
+Şimleu Silvaniei
+Sighetu Marmaţiei
+Sibiu
+Sfântu-Gheorghe
+Sebeş
+Satu Mare
+Salonta
+Săcele
+Roșiorii de Vede
+Roman
+Râşnov
+Râmnicu Vâlcea
+Râmnicu Sărat
+Reşiţa
+Reghin-Sat
+Rădăuți
+Popeşti-Leordeni
+Ploieşti
+Piteşti
+Piatra Neamţ
+Petroşani
+Petrila
+Pantelimon
+Orăştie
+Oradea
+Olteniţa
+Odorheiu Secuiesc
+Ocna Mureş
+Năvodari
+Motru
+Moreni
+Moineşti
+Mizil
+Miercurea-Ciuc
+Mediaş
+Medgidia
+Mangalia
+Lupeni
+Lugoj
+Luduş
+Iaşi
+Huşi
+Hunedoara
+Gura Humorului
+Giurgiu
+Gherla
+Gheorgheni
+Galaţi
+Găeşti
+Focșani
+Filiaşi
+Fetești-Gară
+Feteşti
+Fălticeni
+Făgăraș
+Drobeta-Turnu Severin
+Drăgăşani
+Dorohoi
+Deva
+Dej
+Curtea de Argeş
+Cugir
+Craiova
+Corabia
+Constanţa
+Comăneşti
+Codlea
+Cluj-Napoca
+Cisnădie
+Câmpulung Moldovenesc
+Câmpina
+Câmpia Turzii
+Cernavodă
+Carei
+Caransebeş
+Caracal
+Calafat
+Buzău
+Buhuşi
+Buftea
+Bucharest
+Breaza
+Braşov
+Brăila
+Brad
+Botoşani
+Borşa
+Bocşa
+Blaj
+Bistriţa
+Bârlad
+Balş
+Băileşti
+Băicoi
+Baia Sprie
+Baia Mare
+Bacău
+Arad
+Alexandria
+Alba Iulia
+Aiud
+Adjud
+Baia Mare
+Paşcani
+Mioveni
+Sighișoara
+Slobozia
+Sector 1
+Sector 2
+Sector 3
+Sector 4
+Sector 5
+Sector 6
+Zrenjanin
+Zemun
+Zaječar
+Vršac
+Vranje
+Trstenik
+Stara Pazova
+Sremčica
+Smederevska Palanka
+Smederevo
+Senta
+Prokuplje
+Požarevac
+Pirot
+Pančevo
+Obrenovac
+Novi Pazar
+Nova Pazova
+Niš
+Negotin
+Leskovac
+Lazarevac
+Kruševac
+Kraljevo
+Kragujevac
+Kikinda
+Jagodina
+Inđija
+Gornji Milanovac
+Ćuprija
+Čačak
+Bor
+Belgrade
+Bečej
+Aranđelovac
+Vrbas
+Valjevo
+Užice
+Subotica
+Sremska Mitrovica
+Sombor
+Šabac
+Ruma
+Novi Sad
+Bačka Topola
+Bačka Palanka
+Apatin
+Knjazevac
+Udomlya
+Sosnovka
+Sasovo
+Zyuzino
+Zyablikovo
+Zverevo
+Zvenigorod
+Zlatoust
+Zimovniki
+Zhulebino
+Zhukovskiy
+Zhukovka
+Zhirnovsk
+Zhigulevsk
+Zherdevka
+Zheleznovodsk
+Zheleznogorsk
+Zheleznodorozhnyy
+Zernograd
+Zelenokumsk
+Zelenograd
+Zelenodolsk
+Zelenchukskaya
+Zavolzh’ye
+Zarechnyy
+Zaraysk
+Zapolyarnyy
+Zamoskvorech’ye
+Zainsk
+Yur’yev-Pol’skiy
+Yoshkar-Ola
+Yeysk
+Yessentukskaya
+Yessentuki
+Yershov
+Yemva
+Yelizavetinskaya
+Yelets
+Yelan’
+Yelabuga
+Yegor’yevsk
+Yegorlykskaya
+Yefremov
+Yasnyy
+Yasnogorsk
+Yasenevo
+Yartsevo
+Yaroslavl
+Yaransk
+Yanaul
+Yagry
+Yablonovskiy
+Vyshniy Volochëk
+Vyselki
+Vyksa
+Vykhino-Zhulebino
+Vyborg
+Vyazniki
+Vyaz’ma
+Vyatskiye Polyany
+Vsevolozhsk
+Votkinsk
+Vostryakovo
+Vostryakovo
+Voskresensk
+Voronezh
+Altuf’yevskiy
+Vorob’yovo
+Volzhskiy
+Volzhsk
+Vol’sk
+Volokolamsk
+Vologda
+Volkhov
+Nagornyy
+Volgorechensk
+Volgograd
+Volgodonsk
+Vnukovo
+Novovladykino
+Vladimir
+Vladikavkaz
+Vidnoye
+Vichuga
+Veshnyaki
+Vereshchagino
+Venëv
+Vel’sk
+Velikiy Ustyug
+Velikiye Luki
+Vatutino
+Valuyki
+Valday
+Vagonoremont
+Uzlovaya
+Uvarovo
+Uva
+Ust’-Labinsk
+Ust’-Katav
+Ust’-Dzheguta
+Usman’
+Uryupinsk
+Urus-Martan
+Uritsk
+Unecha
+Ulyanovsk
+Ukhta
+Uglich
+Ufa
+Uchkeken
+Uchaly
+Uchaly
+Tyrnyauz
+Tver
+Tuymazy
+Tutayev
+Tula
+Tuchkovo
+Tuapse
+Tsimlyansk
+Trubchevsk
+Troparëvo
+Troitskaya
+Troitsk
+Tosno
+Torzhok
+Tomilino
+Tol’yatti
+Timashëvsk
+Tikhvin
+Tikhoretsk
+Teykovo
+Terek
+Tyoply Stan
+Temryuk
+Tekstil’shchiki
+Tbilisskaya
+Tambov
+Agidel’
+Taganrog
+Taganskiy
+Syzran’
+Syktyvkar
+Svobody
+Sviblovo
+Svetogorsk
+Svetlyy
+Svetlograd
+Suvorovskaya
+Suvorov
+Surovikino
+Surkhakhi
+Sukhinichi
+Stupino
+Strunino
+Stroitel’
+Strogino
+Sterlitamak
+Stavropol’
+Staryy Oskol
+Staroshcherbinovskaya
+Starominskaya
+Starodub
+Staraya Russa
+Staraya Kupavna
+Staraya Derevnya
+Sovetsk
+Sovetsk
+Sosnovyy Bor
+Sosnovaya Polyana
+Sosnogorsk
+Sortavala
+Sorochinsk
+Solntsevo
+Solnechnogorsk
+Sol’-Iletsk
+Solikamsk
+Sokol’niki
+Sokol
+Sokol
+Sofrino
+Sochi
+Sobinka
+Smolensk
+Slobodskoy
+Slobodka
+Slavyansk-na-Kubani
+Slantsy
+Skopin
+Skhodnya
+Sim
+Sibay
+Shuya
+Shushary
+Shumerlya
+Mikhaylovsk
+Shilovo
+Sheksna
+Shebekino
+Shchukino
+Shchigry
+Shcherbinka
+Shchelkovo
+Shchëkino
+Shatura
+Shar’ya
+Shali
+Shakhun’ya
+Shakhty
+Severskaya
+Severo-Zadonsk
+Severoural’sk
+Severomorsk
+Severodvinsk
+Severnyy
+Setun’
+Sestroretsk
+Sertolovo
+Serpukhov
+Sergiyev Posad
+Sergach
+Serdobsk
+Semiluki
+Semikarakorsk
+Semënovskoye
+Semënov
+Sel’tso
+Segezha
+Satka
+Sarov
+Saratov
+Sarapul
+Saransk
+Saraktash
+Saint Petersburg
+Samara
+Sal’sk
+Salavat
+Safonovo
+Rzhev
+Rybnoye
+Rybinsk
+Rybatskoye
+Ryazhsk
+Ryazan’
+Ruzayevka
+Rublëvo
+Rtishchevo
+Rostov-na-Donu
+Rostov
+Rostokino
+Rossosh’
+Rossosh’
+Roslavl’
+Roshal’
+Rodniki
+Revda
+Reutov
+Razumnoye
+Rayevskiy
+Rasskazovo
+Ramenki
+Pyatigorsk
+Pushkino
+Pushkin
+Pushchino
+Pugachev
+Pskov
+Protvino
+Proletarsk
+Prokhladnyy
+Priyutovo
+Privolzhskiy
+Privolzhsk
+Priozërsk
+Primorsko-Akhtarsk
+Pridonskoy
+Povorino
+Kotlovka
+Annino
+Polyarnyye Zori
+Polyarnyy
+Pokrovskoye-Streshnëvo
+Pokrov
+Pokhvistnevo
+Podporozh’ye
+Podol’sk
+Pochep
+Ryazanskiy
+Plavsk
+Pikalëvo
+Petushki
+Petrozavodsk
+Petrovskaya
+Petrovsk
+Petrodvorets
+Peterhof
+Pestovo
+Pervoural’sk
+Perovo
+Perm
+Pereslavl’-Zalesskiy
+Novo-Peredelkino
+Penza
+Pechora
+Pavlovskiy Posad
+Pavlovskaya
+Pavlovsk
+Pavlovsk
+Pashkovskiy
+Pallasovka
+Ozëry
+Ozerki
+Otradnyy
+Otradnoye
+Otradnoye
+Otradnaya
+Ostrov
+Ostrogozhsk
+Ostashkov
+Ostankinskiy
+Osa
+Orsk
+Orlovskiy
+Orenburg
+Orël
+Orekhovo-Zuyevo
+Orekhovo-Borisovo Severnoye
+Ordzhonikidzevskaya
+Onega
+Omutninsk
+Olenegorsk
+Tsotsin-Yurt
+Oktyabr’skiy
+Odintsovo
+Ochër
+Ochakovo-Matveyevskoye
+Obninsk
+Nytva
+Nyandoma
+Nurlat
+Novyy Oskol
+Novyye Kuz’minki
+Novyye Cherëmushki
+Novozybkov
+Novovoronezh
+Novouzensk
+Novoul’yanovsk
+Novotroitsk
+Novotitarovskaya
+Novoshakhtinsk
+Novorossiysk
+Novopokrovskaya
+Novopavlovsk
+Novomoskovsk
+Novomichurinsk
+Novokuz’minki
+Novokuybyshevsk
+Novokubansk
+Novokhovrino
+Novogireyevo
+Novodvinsk
+Novocherkassk
+Novocheboksarsk
+Novoanninskiy
+Novoaleksandrovsk
+Velikiy Novgorod
+Novaya Usman’
+Novaya Derevnya
+Noginsk
+Nizhnyaya Tura
+Nizhniy Tagil
+Nizhniy Novgorod
+Nizhniy Lomov
+Nizhnekamsk
+Nikulino
+Nikol’skoye
+Nikol’skoye
+Nikol’sk
+Nikolayevsk
+Nikel’
+Nezlobnaya
+Nevinnomyssk
+Nevel’
+Nesterovskaya
+Nerekhta
+Nelidovo
+Neftekamsk
+Neftegorsk
+Nazran’
+Navashino
+Nar'yan-Mar
+Nartkala
+Naro-Fominsk
+Nal’chik
+Nakhabino
+Naberezhnyye Chelny
+Mytishchi
+Murom
+Murmansk
+Mtsensk
+Mozhga
+Mozhaysk
+Mozdok
+Mostovskoy
+Moscow
+Morshansk
+Morozovsk
+Monino
+Monchegorsk
+Mirnyy
+Mineralnye Vody
+Millerovo
+Mikhaylovka
+Mikhalkovo
+Michurinsk
+Metallostroy
+Menzelinsk
+Mendeleyevsk
+Meleuz
+Melenki
+Medvezh’yegorsk
+Medvedovskaya
+Medvedevo
+Mednogorsk
+Maykop
+Matveyevskoye
+Marks
+Mar’ino
+Mar’ina Roshcha
+Manturovo
+Yaroslavskiy
+Maloyaroslavets
+Malgobek
+Malakhovka
+Makhachkala
+Magnitogorsk
+Lyudinovo
+Lyublino
+Lyubertsy
+Lytkarino
+Lys’va
+Lyskovo
+Luzhniki
+Lukhovitsy
+Luga
+Losino-Petrovskiy
+Lomonosov
+Lodeynoye Pole
+Lobnya
+Livny
+Liski
+Lipetsk
+Likino-Dulevo
+Likhobory
+Lianozovo
+L’govskiy
+Levoberezhnaya
+Komendantsky aerodrom
+Lermontov
+Leonovo
+Leninskiye Gory
+Leninsk
+Leninogorsk
+Tsaritsyno
+Leningradskaya
+Yubileyny
+Lefortovo
+Lebedyan’
+Lazarevskoye
+Lakinsk
+Labinsk
+Dugulubgey
+Kuznetsk
+Kuz’minki
+Kuvandyk
+Kuskovo
+Kushva
+Kushchëvskaya
+Kusa
+Kur’yanovo
+Kursk
+Kurovskoye
+Kurganinsk
+Kurchatov
+Kurchaloy
+Kupchino
+Kungur
+Kumertau
+Kulebaki
+Kukmor
+Kudymkar
+Kudepsta
+Kubinka
+Kstovo
+Krymsk
+Kropotkin
+Kronshtadt
+Krasnyy Sulin
+Biryulëvo Zapadnoye
+Krasnoye Selo
+Krasnovishersk
+Krasnoufimsk
+Krasnokamsk
+Krasnogvardeyskoye
+Krasnogorsk
+Krasnodar
+Krasnoarmeyskaya
+Krasnoarmeysk
+Krasnoarmeysk
+Presnenskiy
+Koz’modem’yansk
+Kozhukhovo
+Kozeyevo
+Kozel’sk
+Kovylkino
+Kovrov
+Kovdor
+Kotovsk
+Kotovo
+Kotlas
+Kotel’nikovo
+Kotel’niki
+Kotel’nich
+Kostroma
+Kostomuksha
+Kosaya Gora
+Koryazhma
+Korenovsk
+Konstantinovsk
+Kondrovo
+Kondopoga
+Konakovo
+Kommunar
+Kolpino
+Kolomyagi
+Kolomna
+Kolomenskoye
+Kol’chugino
+Kokhma
+Klintsy
+Klin
+Klimovsk
+Kizlyar
+Kizilyurt
+Kizel
+Kislovodsk
+Kirzhach
+Kirsanov
+Kirovsk
+Kirovsk
+Kirovo-Chepetsk
+Kirov
+Kirov
+Kirishi
+Kireyevsk
+Kingisepp
+Kineshma
+Kinel’-Cherkassy
+Kinel’
+Kimry
+Kimovsk
+Khot'kovo
+Khosta
+Khoroshëvo-Mnevniki
+Kholmskiy
+Khimki
+Khasavyurt
+Kharabali
+Khadyzhensk
+Kazan
+Katav-Ivanovsk
+Kastanayevo
+Kaspiysk
+Kasimov
+Kashira
+Kashin
+Karachev
+Karachayevsk
+Karabulak
+Karabanovo
+Kapotnya
+Kantyshevo
+Kanevskaya
+Kandalaksha
+Kanash
+Kamyzyak
+Kamyshin
+Kamensk-Shakhtinskiy
+Kaluga
+Kalininsk
+Korolev
+Kaliningrad
+Kalach-na-Donu
+Kalach
+Kachkanar
+Kabanovo
+Izobil’nyy
+Izmaylovo
+Izhevsk
+Izberbash
+Ivanteyevka
+Ivanovskoye
+Ivanovo
+Istra
+Ishimbay
+Ipatovo
+Inza
+Inozemtsevo
+Il’skiy
+Igra
+Gus’-Khrustal’nyy
+Gusev
+Gul’kevichi
+Gukovo
+Gudermes
+Gubkin
+Gubakha
+Gryazovets
+Gryazi
+Groznyy
+Gribanovskiy
+Grazhdanka
+Goryachiy Klyuch
+Goryachevodskiy
+Gorodishche
+Gorodets
+Gorelovo
+Gol’yanovo
+Golitsyno
+Glazov
+Giaginskaya
+Georgiyevsk
+Gelendzhik
+Gay
+Gavrilov-Yam
+Gatchina
+Galich
+Gagarin
+Furmanov
+Fryazino
+Fryazevo
+Frolovo
+Fili
+Ezhva
+Engel’s
+Enem
+Elista
+Elektrougli
+Elektrostal’
+Elektrogorsk
+Ekazhevo
+Dzerzhinskiy
+Dzerzhinsk
+Dyurtyuli
+Dyat’kovo
+Dubovka
+Dubna
+Dorogomilovo
+Donskoye
+Donskoy
+Donetsk
+Domodedovo
+Dolgoprudnyy
+Dobryanka
+Dmitrov
+Divnoye
+Dinskaya
+Dimitrovgrad
+Desnogorsk
+Derbent
+Zapadnoye Degunino
+Dedovsk
+Davydkovo
+Davlekanovo
+Dankov
+Danilov
+Dagestanskiye Ogni
+Dachnoye
+Chusovoy
+Chudovo
+Chistopol’
+Chishmy
+Chernyanka
+Chernyakhovsk
+Chernushka
+Chernogolovka
+Cherkessk
+Cherepovets
+Cherëmushki
+Chekhov
+Chegem
+Cheboksary
+Chaykovskiy
+Chapayevsk
+Buzuluk
+Buynaksk
+Buy
+Buturlinovka
+Businovo
+Buinsk
+Buguruslan
+Bugul’ma
+Budënnovsk
+Bryukhovetskaya
+Bryansk
+Bronnitsy
+Brateyevo
+Borovichi
+Borisoglebsk
+Bor
+Bol’shaya Setun’
+Bologoye
+Boksitogorsk
+Boguchar
+Bogorodskoye
+Bogorodsk
+Bogoroditsk
+Bobrov
+Blagoveshchensk
+Blagodarnyy
+Biryulëvo
+Birsk
+Bibirevo
+Bezhetsk
+Bezenchuk
+Beslan
+Berezniki
+Beloretsk
+Belorechensk
+Beloozërskiy
+Belgorod
+Belëv
+Belebey
+Belaya Kalitva
+Belaya Glina
+Baymak
+Bavly
+Bataysk
+Barysh
+Balezino
+Balashov
+Balashikha
+Balakovo
+Novaya Balakhna
+Balabanovo
+Baksan
+Bakal
+Bagayevskaya
+Babushkin
+Azov
+Avtury
+Avtovo
+Atkarsk
+Astrakhan
+Asha
+Arzgir
+Arzamas
+Arsk
+Armavir
+Arkhangel’sk
+Argun
+Ardon
+Apsheronsk
+Aprelevka
+Apatity
+Anna
+Andreyevskoye
+Anapa
+Amin’yevo
+Al’met’yevsk
+Aleksin
+Alekseyevka
+Alekseyevka
+Aleksandrovskoye
+Aleksandrovsk
+Aleksandrov
+Alatyr’
+Levoberezhnyy
+Aksay
+Akhtyrskiy
+Akhtubinsk
+Agryz
+Afipskiy
+Adler
+Achkhoy-Martan
+Abinsk
+Abdulino
+Vasil’yevo
+Ryl’sk
+Neftekumsk
+Alagir
+Persianovka
+Annino
+Dagomys
+Pavlovo
+Belidzhi
+Lesnoy
+Trëkhgornyy
+Mirnyy
+Znamensk
+Zarechnyy
+Kochubeyevskoye
+Vnukovo
+Moskovskiy
+Usinsk
+Obukhovo
+Staryy Malgobek
+Zavodoukovsk
+Zarinsk
+Zarechnyy
+Yuzhnyy
+Yuzhnoural’sk
+Yurga
+Yeniseysk
+Yemanzhelinsk
+Yekaterinburg
+Yashkino
+Yarovoye
+Yalutorovsk
+Vorkuta
+Vorgashor
+Verkhnyaya Salda
+Verkhnyaya Pyshma
+Verkhniy Ufaley
+Uzhur
+Zelenogorsk
+Uray
+Tyumen
+Turinsk
+Troitsk
+Topki
+Tomsk
+Toguchin
+Tobol’sk
+Tayshet
+Tayga
+Tavda
+Tatarsk
+Tashtagol
+Tarko-Sale
+Tara
+Talnakh
+Tal’menka
+Talitsa
+Talitsa
+Sysert’
+Suzun
+Surgut
+Sukhoy Log
+Strezhevoy
+Sredneuralsk
+Sovetskiy
+Sosnovoborsk
+Slavgorod
+Shushenskoye
+Shumikha
+Sharypovo
+Shadrinsk
+Serov
+Sayanogorsk
+Salekhard
+Rubtsovsk
+Rezh
+Reftinskiy
+Promyshlennaya
+Prokop’yevsk
+Poykovskiy
+Polysayevo
+Polevskoy
+Plast
+Osinniki
+Omsk
+Ob’
+Nyagan
+Noyabrsk
+Novyy Urengoy
+Novosilikatnyy
+Novosibirsk
+Novokuznetsk
+Novoaltaysk
+Norilsk
+Nizhnyaya Salda
+Nizhnevartovsk
+Nizhneudinsk
+Nev’yansk
+Nefteyugansk
+Nazarovo
+Nadym
+Myski
+Minusinsk
+Miass
+Mezhdurechensk
+Megion
+Mayma
+Mariinsk
+Linëvo
+Lesosibirsk
+Leninsk-Kuznetsky
+Labytnangi
+Kyzyl
+Kyshtym
+Kuybyshev
+Kurtamysh
+Kurgan
+Kupino
+Kulunda
+Krasnoyarsk
+Krasnoural’sk
+Krasnotur’insk
+Krasnoobsk
+Korkino
+Kopeysk
+Yugorsk
+Kolpashevo
+Kodinsk
+Kochenëvo
+Kiselëvsk
+Kirovgrad
+Khanty-Mansiysk
+Kemerovo
+Kedrovka
+Kayyerkan
+Kataysk
+Kasli
+Kartaly
+Karpinsk
+Karasuk
+Karabash
+Kansk
+Kamyshlov
+Kamensk-Ural’skiy
+Kamen’-na-Obi
+Kaltan
+Kalachinsk
+Ivdel’
+Iskitim
+Ishim
+Irbit
+Ilanskiy
+Gur’yevsk
+Gornyak
+Gorno-Altaysk
+Dudinka
+Divnogorsk
+Degtyarsk
+Chunskiy
+Chernogorsk
+Cherepanovo
+Chelyabinsk
+Chebarkul’
+Borovskiy
+Borodino
+Bolotnoye
+Bogotol
+Bogdanovich
+Biysk
+Beryozovsky
+Berëzovskiy
+Berëzovka
+Berdsk
+Beloyarskiy
+Belovo
+Barnaul
+Barabinsk
+Asino
+Asbest
+Artëmovskiy
+Aramil
+Anzhero-Sudzhensk
+Aleysk
+Alapayevsk
+Akademgorodok
+Achinsk
+Abaza
+Abakan
+Snezhinsk
+Ozersk
+Zheleznogorsk
+Novoural’sk
+Seversk
+Gubkinskiy
+Raduzhny
+Muravlenko
+Lyantor
+Zima
+Zheleznogorsk-Ilimskiy
+Zeya
+Yakutsk
+Vyazemskiy
+Vrangel’
+Vladivostok
+Vikhorevka
+Ust’-Kut
+Ust’-Ilimsk
+Ussuriysk
+Usol’ye-Sibirskoye
+Ulan-Ude
+Udachny
+Tynda
+Tulun
+Trudovoye
+Fokino
+Svobodnyy
+Spassk-Dal’niy
+Slyudyanka
+Shimanovsk
+Shelekhov
+Severobaykal’sk
+Raychikhinsk
+Petrovsk-Zabaykal’skiy
+Partizansk
+Neryungri
+Nerchinsk
+Nakhodka
+Mirny
+Luchegorsk
+Lesozavodsk
+Lensk
+Kyakhta
+Krasnokamensk
+Komsomolsk-on-Amur
+Khabarovsk
+Kavalerovo
+Irkutsk
+Gusinoozyorsk
+Dal’nerechensk
+Chita
+Cheremkhovo
+Borzya
+Bol’shoy Kamen’
+Bodaybo
+Blagoveshchensk
+Birobidzhan
+Bikin
+Belogorsk
+Baykal’sk
+Aykhal
+Artëm
+Arsen’yev
+Angarsk
+Amursk
+Aldan
+Dal'negorsk
+Bratsk
+Sayansk
+Khabarovsk Vtoroy
+Markova
+Vilyuchinsk
+Yuzhno-Sakhalinsk
+Yelizovo
+Vanino
+Sovetskaya Gavan’
+Poronaysk
+Petropavlovsk-Kamchatsky
+Okha
+Nikolayevsk-on-Amure
+Nevel’sk
+Magadan
+Korsakov
+Kholmsk
+Baltiysk
+Isakogorka
+Krasnoznamensk
+Chertanovo Yuzhnoye
+Zagor’ye
+Orekhovo-Borisovo
+Metrogorodok
+Kogalym
+Pyt-Yakh
+Langepas
+Lesnoy
+Zarya
+Raduzhnyy
+Nizhnesortymskiy
+Pokachi
+Izluchinsk
+Kurortnyy
+Chernaya Rechka
+Untolovo
+Petrogradka
+Vasyl'evsky Ostrov
+Parnas
+Kalininskiy
+Krasnogvargeisky
+Admiralteisky
+Krestovskiy ostrov
+Akademicheskoe
+Finlyandskiy
+Centralniy
+Svetlanovskiy
+Sampsonievskiy
+Vostochnoe Degunino
+Rwamagana
+Musanze
+Nzega
+Kigali
+Kibuye
+Kibungo
+Gitarama
+Cyangugu
+Gisenyi
+Byumba
+Butare
+Yanbu
+Umm Lajj
+Ţurayf
+Turabah
+Tārūt
+Tabuk
+Ţubarjal
+Sulţānah
+Sayhāt
+Şāmitah
+Sakakah
+Şafwá
+Şabyā
+Raḩīmah
+Rābigh
+Qal‘at Bīshah
+Najrān
+Mecca
+Khamis Mushait
+Jizan
+Jeddah
+Ha'il
+Duba
+Buraydah
+Abqaiq
+Badr Ḩunayn
+Az Zulfi
+Dhahran
+Aţ Ţaraf
+Ta’if
+As Sulayyil
+Riyadh
+Ar Rass
+‘Ar‘ar
+An Nimāş
+Qurayyat
+Al Wajh
+Al ‘Ulá
+Al Qayşūmah
+Al Qaţīf
+Al Munayzilah
+Al Mubarraz
+Al Mithnab
+Medina
+Khobar
+Al Khafjī
+Al Jumūm
+Al Jubayl
+Al Hufūf
+Al Bukayrīyah
+Al Baţţālīyah
+Al Bāḩah
+‘Afīf
+Ad Dilam
+Ad Dawādimī
+Dammam
+Abū ‘Arīsh
+Abha
+Ash Shafā
+Unaizah
+Honiara
+Victoria
+Zalingei
+Wad Medani
+Umm Ruwaba
+Omdurman
+Tokār
+Tandaltī
+Singa
+Shendi
+Sawākin
+Sinnar
+Rabak
+Maiurno
+Kosti
+Kuraymah
+Kināna
+Kassala
+Kadugli
+Doka
+Dilling
+Port Sudan
+Berber
+Bārah
+Atbara
+As Sūkī
+Ar Ruseris
+Ar Rahad
+An Nuhūd
+El Obeid
+Al Qiţena
+Al Qadarif
+Al Mijlad
+Al Manāqil
+Khartoum
+Geneina
+Al Hilāliyya
+Al Ḩawātah
+Al Hasaheisa
+El Fasher
+El Bauga
+Ad Douiem
+El Daein
+Ad Dindar
+Ed Damer
+Ad-Damazin
+Abū Zabad
+Abu Jibeha
+Umeå
+Skellefteå
+Piteå
+Luleå
+Kiruna
+Boden
+Ystad
+Visby
+Växjö
+Västervik
+Västerås
+Värnamo
+Varberg
+Vänersborg
+Vallentuna
+Uppsala
+Upplands Väsby
+Uddevalla
+Tumba
+Tullinge
+Trollhättan
+Trelleborg
+Täby
+Sundsvall
+Sundbyberg
+Stockholm
+Solna
+Sollentuna
+Södertälje
+Skövde
+Skara
+Sandviken
+Råsunda
+Partille
+Östersund
+Östermalm
+Oskarshamn
+Örnsköldsvik
+Örebro
+Nyköping
+Norrtälje
+Norrköping
+Nässjö
+Nacka
+Motala
+Mölndal
+Märsta
+Malmö
+Lund
+Linköping
+Lidköping
+Lidingö
+Lerum
+Landskrona
+Kungsbacka
+Kungälv
+Kristinehamn
+Kristianstad
+Köping
+Katrineholm
+Karlstad
+Karlskrona
+Karlskoga
+Karlshamn
+Kalmar
+Jönköping
+Jakobsberg
+Huskvarna
+Huddinge
+Helsingborg
+Hässleholm
+Härnösand
+Haninge
+Halmstad
+Göteborg
+Gävle
+Gamla Uppsala
+Falun
+Falköping
+Falkenberg
+Eslöv
+Eskilstuna
+Enköping
+Bromma
+Borlänge
+Borås
+Boo
+Årsta
+Ängelholm
+Alingsås
+Åkersberga
+Majorna
+Singapore
+Jamestown
+Trbovlje
+Velenje
+Ptuj
+Novo Mesto
+Maribor
+Ljubljana
+Kranj
+Koper
+Celje
+Longyearbyen
+Vranov nad Topľou
+Trebišov
+Stará Ľubovňa
+Spišská Nová Ves
+Snina
+Rožňava
+Rimavská Sobota
+Prešov
+Poprad
+Michalovce
+Košice
+Kežmarok
+Humenné
+Bardejov
+Zvolen
+Zlaté Moravce
+Žilina
+Žiar nad Hronom
+Trnava
+Trenčín
+Skalica
+Senica
+Sellye
+Ružomberok
+Púchov
+Prievidza
+Považská Bystrica
+Piešťany
+Pezinok
+Partizánske
+Nové Zámky
+Nové Mesto nad Váhom
+Nitra
+Martin
+Malacky
+Lučenec
+Liptovský Mikuláš
+Levice
+Kysucké Nové Mesto
+Komárno
+Hlohovec
+Handlová
+Galanta
+Dunajská Streda
+Dubnica nad Váhom
+Dolný Kubín
+Detva
+Čadca
+Brezno
+Bratislava
+Banská Bystrica
+Bánovce nad Bebravou
+Waterloo
+Segbwema
+Port Loko
+Makeni
+Lunsar
+Koidu
+Kenema
+Kabala
+Freetown
+Bo
+San Marino
+Ziguinchor
+Vélingara
+Touba
+Tiébo
+Thiès Nones
+Tambacounda
+Sédhiou
+Saint-Louis
+Richard-Toll
+Pout
+Pourham
+Pikine
+Nioro du Rip
+Nguékhokh
+Ndibène Dahra
+Mékhé
+Mbaké
+Matam
+Louga
+Kolda
+Kédougou
+Kayar
+Kaolack
+Kaffrine
+Joal-Fadiout
+Guinguinéo
+Dara
+Dakar
+Bignona
+Wanlaweyn
+Qoryooley
+Qandala
+Mogadishu
+Marka
+Luuq
+Kismayo
+Jilib
+Jawhar
+Jamaame
+Hargeysa
+Garoowe
+Gaalkacyo
+Eyl
+Ceerigaabo
+Ceeldheer
+Buurhakaba
+Buulobarde
+Burao
+Bosaso
+Berbera
+Beledweyne
+Baidoa
+Baardheere
+Afgooye
+Laascaanood
+Baki
+Paramaribo
+Lelydorp
+Yei
+Yambio
+Wau
+Aweil
+Torit
+Tonj
+Rumbek
+Malakal
+Juba
+Gogrial
+Pajok
+Bor
+São Tomé
+Zacatecoluca
+Usulután
+Soyapango
+Sonzacate
+Sonsonate
+Sensuntepeque
+San Vicente
+Santiago de María
+Santa Ana
+San Salvador
+San Rafael Oriente
+San Miguel
+San Martín
+San Marcos
+San Francisco
+Quezaltepeque
+Puerto El Triunfo
+Santa Tecla
+Metapán
+Mejicanos
+La Unión
+La Libertad
+Izalco
+Ilopango
+Delgado
+Cuscatancingo
+Cojutepeque
+Chalchuapa
+Chalatenango
+Ayutuxtepeque
+Apopa
+Antiguo Cuscatlán
+Ahuachapán
+Aguilares
+Acajutla
+Philipsburg
+Yabrūd
+Ţayyibat al Imām
+Tartouss
+Tall Rif‘at
+Tallkalakh
+Tallbīsah
+Ţafas
+Tadmur
+Tādif
+Souran
+Subaykhān
+Ash Shaykh Miskīn
+Sarāqib
+Salqīn
+As Salamīyah
+Satita
+Qaţanā
+Jāsim
+Qārah
+Nubl
+Maşyāf
+Manbij
+Ma‘arratmişrīn
+Khān Shaykhūn
+Kafr Zaytā
+Kafr Takhārīm
+Kafr Nubl
+Kafr Lāhā
+Jisr ash Shughūr
+Jayrūd
+Jarābulus
+Jablah
+‘Irbīn
+Inkhil
+Idlib
+Homs
+Ḩarastā
+Ḩamāh
+Ḩalfāyā
+Aleppo
+Douma
+Damascus
+Dayr Ḩāfir
+Deir ez-Zor
+Ad Darbāsīyah
+Dārayyā
+Dar‘ā
+Binnish
+Bāniyās
+Az Zabadānī
+I‘zāz
+‘Ayn al ‘Arab
+At Tall
+Ath Thawrah
+As Suwaydā’
+Aş Şanamayn
+As Safīrah
+Ar Rastan
+Ar Raqqah
+An Nabk
+Al Quţayfah
+Al Quşayr
+Al Qunayţirah
+Al Qaryatayn
+Al Mayādīn
+Latakia
+Al Kiswah
+Al Ḩasakah
+Al Ḩarāk
+Al Bāb
+‘Afrīn
+Ad Dānā
+Ālbū Kamāl
+Hajīn
+Mbabane
+Manzini
+Lobamba
+Cockburn Town
+Fada
+Am Timan
+Abéché
+Sagh
+Pala
+Oum Hadjer
+N'Djamena
+Moussoro
+Moundou
+Mongo
+Mboursou Léré
+Massakory
+Massaguet
+Mao
+Laï
+Kyabé
+Koumra
+Kelo
+Dourbali
+Doba
+Bongor
+Bitkine
+Benoy
+Ati
+Port-aux-Français
+Vogan
+Tsévié
+Tchamba
+Sotouboua
+Sokodé
+Notsé
+Niamtougou
+Sansanné-Mango
+Lomé
+Kpalimé
+Kara
+Dapaong
+Bassar
+Bafilo
+Badou
+Atakpamé
+Aného
+Ban Talat Yai
+Ban Talat Nua
+Sam Roi Yot
+Phetchaburi
+Trang
+Thung Song
+Thoen
+Thap Than
+Tha Muang
+Tha Maka
+Tak
+Surat Thani
+Sukhothai
+Si Satchanalai
+Sawankhalok
+San Pa Tong
+San Kamphaeng
+Ron Phibun
+Ratchaburi
+Ranong
+Pran Buri
+Prachuap Khiri Khan
+Phunphin
+Phuket
+Photharam
+Phayao
+Pa Sang
+Nakhon Si Thammarat
+Mae Sot
+Mae Sai
+Mae Ramat
+Mae Chan
+Lat Yao
+Lang Suan
+Lamphun
+Lampang
+Kui Buri
+Krabi
+Khao Yoi
+Khanu Woralaksaburi
+Kathu
+Kanchanaburi
+Kamphaeng Phet
+Huai Yot
+Hua Hin
+Hang Dong
+Dok Kham Tai
+Damnoen Saduak
+Chumphon
+Chom Bueng
+Chiang Rai
+Chiang Mai
+Cha-am
+Bo Phloi
+Ban Tak
+Ko Samui
+Ban Pong
+Ban Na San
+Ban Na
+Bang Saphan
+Bang Phae
+Nong Kung Si
+Ban Nong Wua So
+Ban Mai
+Ban Huai Thalaeng
+Ban Khlong Bang Sao Thong
+Na Klang
+Yasothon
+Yaring
+Yala
+Wiset Chaichan
+Wichian Buri
+Warin Chamrap
+Wang Saphung
+Wang Noi
+Wang Nam Yen
+Uttaradit
+Uthai Thani
+Udon Thani
+Ubon Ratchathani
+Trat
+Tha Yang
+Tha Ruea
+Thap Khlo
+Tha Mai
+Tha Bo
+Taphan Hin
+Tak Bai
+Surin
+Suphan Buri
+Su-ngai Kolok
+Songkhla
+Si Sa Ket
+Si Racha
+Sing Buri
+Seka
+Sawang Daen Din
+Satun
+Sattahip
+Saraburi
+Samut Songkhram
+Samut Sakhon
+Samut Prakan
+Sam Phran
+Sakon Nakhon
+Sa Kaeo
+Sadao
+Roi Et
+Rayong
+Ranot
+Ra-ngae
+Prakhon Chai
+Prachin Buri
+Phu Kradueng
+Phu Khiao
+Phra Pradaeng
+Phra Phutthabat
+Phra Nakhon Si Ayutthaya
+Phrae
+Phon Charoen
+Phitsanulok
+Phichit
+Phibun Mangsahan
+Phetchabun
+Phatthalung
+Phan Thong
+Phanom Sarakham
+Phanat Nikhom
+Phak Hai
+Pattani
+Pathum Thani
+Pak Phanang
+Pak Kret
+Pak Chong
+Mueang Nonthaburi
+Non Sung
+Nong Phai
+Nong Khai
+Nong Khae
+Nong Bua Lamphu
+Narathiwat
+Nang Rong
+Nan
+Nam Som
+Nakhon Sawan
+Nakhon Ratchasima
+Nakhon Phanom
+Nakhon Pathom
+Nakhon Nayok
+Nakhon Luang
+Mukdahan
+Maha Sarakham
+Lop Buri
+Lom Sak
+Loei
+Laem Sing
+Kut Chap
+Kuchinarai
+Bangkok
+Krathum Baen
+Klaeng
+Khon Kaen
+Khon Buri
+Khlong Luang
+Khao Wong
+Kaset Wisai
+Kaset Sombun
+Kantharalak
+Kamalasai
+Kalasin
+Kaeng Khoi
+Kaeng Khro
+Kabin Buri
+Hat Yai
+Det Udom
+Den Chai
+Dan Khun Thot
+Chum Phae
+Chon Daen
+Chon Buri
+Chok Chai
+Chanthaburi
+Chaiyaphum
+Chai Nat
+Chai Badan
+Chachoengsao
+Buriram
+Bua Yai
+Betong
+Ban Selaphum
+Ban Rangsit
+Phatthaya
+Ban Phan Don
+Ban Phai
+Ban Phaeo
+Ban Mo
+Ban Lam Luk Ka
+Bang Rakam
+Bang Racham
+Bang Pakong
+Bang Pa-in
+Bang Mun Nak
+Bang Len
+Bang Lamung
+Bang Kruai
+Bang Krathum
+Bang Bua Thong
+Bang Ban
+Ban Dung
+Ban Chang
+Ban Bueng
+Ban Talat Bueng
+Ban Bang Kadi Pathum Thani
+Bang Bo District
+Aranyaprathet
+Amnat Charoen
+Amphoe Sikhiu
+Wichit
+Ban Chalong
+Ban Ratsada
+Yovon
+Vose’
+Vakhsh
+Istaravshan
+Tursunzoda
+Qŭrghonteppa
+Panjakent
+Farkhor
+Vahdat
+Norak
+Kŭlob
+Kolkhozobod
+Khorugh
+Ishqoshim
+Hisor
+Dushanbe
+Danghara
+Chubek
+Boshkengash
+Proletar
+Khŭjand
+Konibodom
+Isfara
+Chkalov
+Moskovskiy
+Suai
+Maubara
+Maliana
+Liquica
+Dili
+Baucau
+Aileu
+Same
+Lospalos
+Venilale
+Balkanabat
+Kaka
+Gumdag
+Gazanjyk
+Abadan
+Baharly
+Ashgabat
+Annau
+Yylanly
+Tagta
+Türkmenbaşy
+Köneürgench
+Boldumsaz
+Daşoguz
+Yolöten
+Tejen
+Seydi
+Saýat
+Mary
+Atamyrat
+Gowurdak
+Türkmenabat
+Bayramaly
+Gazojak
+Zaghouan
+Oued Lill
+Tunis
+Tozeur
+Tataouine
+Thala
+Takelsa
+Tajerouine
+Sousse
+Siliana
+Sidi Bouzid
+Skanes
+Sfax
+La Sebala du Mornag
+Radès
+Ksour Essaf
+Korba
+Kélibia
+Kebili
+Ksar Hellal
+Carthage
+El Fahs
+Galaat el Andeless
+Gafsa
+Gabès
+Nefta
+Nabeul
+Midoun
+Mateur
+Msaken
+Menzel Jemil
+Mennzel Bou Zelfa
+Menzel Bourguiba
+Menzel Abderhaman
+Manouba
+Medjez el Bab
+Medenine
+Jendouba
+Zarzis
+Djemmal
+Houmt Souk
+Hammam Sousse
+Hammam-Lif
+La Goulette
+Douz
+Douar Tindja
+Dar Chabanne
+Ben Arous
+Bizerte
+Beni Khiar
+Béja
+Zouila
+Chebba
+Ariana
+Ar Rudayyif
+Ouardenine
+Kairouan
+Kasserine
+Gremda
+Monastir
+La Mohammedia
+Metlaoui
+Al Marsá
+Mahdia
+El Kef
+El Jem
+Hammamet
+El Hamma
+Bekalta
+El Alia
+Akouda
+Douane
+Nuku‘alofa
+Yüksekova
+Yozgat
+Yeşilli
+Erzin
+Yerköy
+Didim
+Yatağan
+Yalvaç
+Yahyalı
+Viranşehir
+Varto
+Van
+Cimin
+Uşak
+Urla
+Ürgüp
+Şanlıurfa
+Turgutlu
+Tunceli
+Torbalı
+Tire
+Tekirova
+Tavşanlı
+Tatvan
+Tarsus
+Talas
+Susurluk
+Suruç
+Sorgun
+Soma
+Solhan
+Söke
+Siverek
+Sivas
+Şırnak
+Simav
+Silvan
+Silopi
+Silifke
+Siirt
+Seydişehir
+Serinyol
+Serik
+Şereflikoçhisar
+Senirkent
+Şemdinli
+Selçuk
+Seferhisar
+Şarkışla
+Şarkîkaraağaç
+Sarayköy
+Sandıklı
+Salihli
+Reyhanlı
+Polatlı
+Pazarcık
+Patnos
+Pasinler
+Osmaniye
+Ortaköy
+Ortaca
+Ödemiş
+Nusaybin
+Nizip
+Niğde
+Nevşehir
+Nazilli
+Mut
+Muş
+Muğla
+Mucur
+Milas
+Midyat
+Mercin
+Menemen
+Marmaris
+Mardin
+Manisa
+Manavgat
+Malazgirt
+Malatya
+Mahmutlar
+Lice
+Kütahya
+Kuşadası
+Kurtalan
+Beykonak
+Kulu
+Kulp
+Kula
+Kozluk
+Kozan
+Kovancılar
+Korkuteli
+Konya
+Kızıltepe
+Serinhisar
+Kırşehir
+Kırkağaç
+Kırıkkale
+Kırıkhan
+Kilis
+Keskin
+Kemer
+Kemalpaşa
+Kayseri
+Karapınar
+Karaman
+Ağrı
+Karakoçan
+Karaçoban
+Kaman
+Kâhta
+Kahramanmaraş
+Kadirli
+Kadınhanı
+İzmir
+Isparta
+İdil
+Hizan
+Hınıs
+Hilvan
+Hadim
+Hacılar
+Güroymak
+Gölbaşı
+Göksun
+Genç
+Gemerek
+Gediz
+Gazipaşa
+Gaziantep
+Foça
+Fethiye
+Ezine
+Eskişehir
+Erzurum
+Erzincan
+Ermenek
+Ergani
+Ereğli
+Erdemli
+Erciş
+Emirdağ
+Emet
+Elmalı
+Elmadağ
+Eleşkirt
+Elbistan
+Elazığ
+Eğirdir
+Edremit
+Dursunbey
+Dörtyol
+Doğubayazıt
+Diyarbakır
+Diyadin
+Dinar
+Develi
+Denizli
+Demirci
+Dargeçit
+Darende
+Çumra
+Menderes
+Hakkari
+Cizre
+Çine
+Ceylanpınar
+Ceyhan
+Çeşme
+Çermik
+Çay
+Çağlayancerit
+Burhaniye
+Burdur
+Bulanık
+Bucak
+Bozyazı
+Bozüyük
+Bozova
+Bor
+Bolvadin
+Bodrum
+Bitlis
+Bismil
+Birecik
+Bingöl
+Bigadiç
+Beyşehir
+Besni
+Bergama
+Belen
+Belek
+Bayındır
+Batman
+Baskil
+Banaz
+Balıkesir
+Bahçe
+Ayvalık
+Aydın
+Aşkale
+Antalya
+Antakya
+Ankara
+Anamur
+Aliağa
+Alaşehir
+Alanya
+Akşehir
+Aksaray
+Akhisar
+Akdağmadeni
+Akçakale
+Ahlat
+Afyonkarahisar
+Afşin
+Adıyaman
+Adilcevaz
+Adana
+Denizciler
+Batikent
+Dalaman
+Zonguldak
+Zile
+Zeytinburnu
+Yomra
+Yenişehir
+Körfez
+Yalova
+Yakuplu
+Vezirköprü
+Vakfıkebir
+Uzunköprü
+Üsküdar
+Ünye
+Umraniye
+Turhal
+Trabzon
+Tosya
+Tokat
+Tirebolu
+Terme
+Tepecik
+Tekkeköy
+Tekirdağ
+Taşova
+Taşköprü
+Suşehri
+Sürmene
+Sungurlu
+Suluova
+Şişli
+Sinop
+Silivri
+Şebin Karahisar
+Sarıkamış
+Sapanca
+Samsun
+Safranbolu
+Rize
+Osmaneli
+Osmancık
+Orhangazi
+Ordu
+Oltu
+Of
+Niksar
+Nallıhan
+Mustafakemalpaşa
+Mudanya
+Mimarsinan
+Merzifon
+Maltepe
+Malkara
+Lüleburgaz
+Kumru
+Korgan
+Kocaali
+Kızılcahamam
+Kırklareli
+Kestel
+Keşan
+Kelkit
+Kazan
+Kavaklı
+Kastamonu
+Kars
+Karasu
+Karamürsel
+Karacabey
+Karabük
+Kağızman
+İznik
+İzmit
+İstanbul
+İskilip
+İnegol
+Horasan
+Hopa
+Hendek
+Hayrabolu
+Havza
+Gürsu
+Gürpınar
+Gürgentepe
+Gumushkhane
+Görele
+Gönen
+Gölcük
+Giresun
+Geyve
+Gerede
+Gemlik
+Gelibolu
+Gebze
+Ferizli
+Fatsa
+Esenyurt
+Esenler
+Ereğli
+Erdek
+Erbaa
+Eminönü
+Edirne
+Düzce
+Devrek
+Çubuk
+Çorum
+Çorlu
+Çerkezköy
+Çerkeş
+Çayeli
+Çaycuma
+Çatalca
+Çarşamba
+Khanjarah
+Çanakkale
+Çan
+Bursa
+Bulancak
+Boyabat
+Bolu
+Bilecik
+Biga
+Beypazarı
+Beşikdüzü
+Bayburt
+Bartın
+Bandırma
+Bağcılar
+Bafra
+Babaeski
+Artvin
+Arsin
+Arhavi
+Ardeşen
+Ardahan
+Araklı
+Amasya
+Alaplı
+Alaca
+Akyazı
+Akçakoca
+Akçaabat
+Adapazarı
+Espiye
+merter keresteciler
+güngören merter
+Turgutreis
+Sarigerme
+Ataşehir
+Başakşehir
+Beylikdüzü
+Büyükçekmece
+Çankaya
+Bahçelievler
+Sultangazi
+Sultanbeyli
+Sancaktepe
+Karabağlar
+Muratpaşa
+Tunapuna
+Scarborough
+Sangre Grande
+San Fernando
+Rio Claro
+Port of Spain
+Point Fortin
+Paradise
+Mon Repos
+Marabella
+Laventille
+Chaguanas
+Arima
+Funafuti
+Douliu
+Yujing
+Taipei
+Tainan
+Taichung
+Daxi
+Banqiao
+Puli
+Nantou
+Magong
+Lugu
+Kaohsiung
+Yilan
+Hualien City
+Hsinchu
+Hengchun
+Jincheng
+Keelung
+Taoyuan City
+Taitung City
+Zhongxing New Village
+Zanzibar
+Wete
+Vwawa
+Vikindu
+Uyovu
+Uvinza
+Ushirombo
+Usevia
+Usagara
+Usa River
+Urambo
+Tunduma
+Tumbi
+Tukuyu
+Tinde
+Tarime
+Tanga
+Tabora
+Sumbawanga
+Songwa
+Somanda
+Sokoni
+Sirari
+Singida
+Sikonge
+Shinyanga
+Shelui
+Sepuka
+Same
+Rulenge
+Rujewa
+Puma
+Old Shinyanga
+Nzega
+Nyamuswa
+Nyalikungu
+Nyakabindi
+Nsunga
+Nshamba
+Njombe
+Nguruka
+Ngudu
+Ngerengere
+Ngara
+Nangwa
+Namanyere
+Mwanza
+Mwadui
+Mvomero
+Musoma
+Muriti
+Mungaa
+Muheza
+Mugumu
+Mtwango
+Mto wa Mbu
+Mtinko
+Msowero
+Mpwapwa
+Mpanda
+Moshi
+Morogoro
+Mlowo
+Mlimba
+Mlangali
+Mlandizi
+Mlalo
+Mkuranga
+Mwandiga
+Misungwi
+Mikumi
+Mhango
+Mgandu
+Mbuguni
+Mbeya
+Mazinde
+Matui
+Matai
+Maswa
+Masumbwe
+Maramba
+Malinyi
+Malampaka
+Makuyuni
+Makumbako
+Mahanje
+Kihangara
+Magugu
+Magomeni
+Magole
+Mafinga
+Mabama
+Lushoto
+Lugoba
+Liwale
+Lembeni
+Lalago
+Laela
+Kyela
+Kondoa
+Kiwira
+Kishapu
+Kisesa
+Kirando
+Kiomboi
+Kingori
+Kilosa
+Kigoma
+Kidodi
+Kidatu
+Kibondo
+Kibiti
+Kibara
+Kibakwe
+Kibaha
+Katumba
+Katoro
+Katerero
+Kasulu
+Kasamwa
+Kiratu
+Kamachumu
+Kakonko
+Kahama
+Kabanga
+Izazi
+Itigi
+Isaka
+Iringa
+Ipinda
+Ilula
+Ilongero
+Ilembula
+Ikungi
+Igurusi
+Igunga
+Igugunu
+Ifakara
+Hedaru
+Geita
+Geiro
+Galappo
+Dongobesh
+Dodoma
+Dar es Salaam
+Dareda
+Chimala
+Chato
+Chanika
+Chalinze
+Chala
+Chake Chake
+Butiama
+Buseresere
+Bungu
+Bunda
+Bukoba
+Bugarama
+Biharamulo
+Basotu
+Bashanet
+Bariadi
+Bagamoyo
+Babati
+Arusha
+Tingi
+Tandahimba
+Songea
+Nyangao
+Newala Kisimani
+Nanyamba
+Nangomba
+Nanganga
+Nachingwea
+Mtwara
+Mbinga
+Matiri
+Masasi
+Maposeni
+Lukuledi
+Luchingu
+Lindi
+Kitama
+Kigonsera
+Merelani
+Lebedyn
+Druzhkivka
+Vasylivka
+Zvenyhorodka
+Zuhres
+Zolotonosha
+Zolochiv
+Znomenka
+Zmiyiv
+Zhytomyr
+Zhmerynka
+Zhovti Vody
+Zhashkiv
+Zdolbuniv
+Zaporizhzhya
+Yuzhne
+Yevpatoriya
+Yenakiyeve
+Yasynuvata
+Yalta
+Yahotyn
+Vyshhorod
+Vynohradiv
+Voznesensk
+Volnovakha
+Vovchans’k
+Volodymyr-Volyns’kyy
+Vyshneve
+Vinnytsya
+Vatutine
+Vasylkiv
+Uzhhorod
+Uman’
+Tul’chyn
+Tsyurupyns’k
+Truskavets
+Torez
+Tokmak
+Ternopil’
+Tal’ne
+Syevyerodonets’k
+Svitlovods’k
+Sverdlovs’k
+Svatove
+Svalyava
+Sumy
+Stryi
+Stebnyk
+Starokostyantyniv
+Starobil’s’k
+Stakhanov
+Sokal’
+Snizhne
+Smila
+Sloviansk
+Slavuta
+Skvyra
+Skadovs’k
+Synel’nykove
+Simferopol
+Shpola
+Shostka
+Shepetivka
+Shakhtars’k
+Sevastopol
+Selydove
+Sarny
+Sambir
+Saky
+Rubizhne
+Rozdil’na
+Roven’ky
+Romny
+Rivne
+Reni
+Radomyshl’
+Piatykhatky
+Putyvl’
+Pryluky
+Popasna
+Poltava
+Polonne
+Polohy
+Pidhorodne
+Pyryatyn
+Pervomays’k
+Pervomays’k
+Pereyaslav-Khmel’nyts’kyy
+Pereval’s’k
+Pavlohrad
+Ovruch
+Orikhiv
+Oleksandriya
+Odessa
+Ochakiv
+Obukhiv
+Novyy Buh
+Novovolyns’k
+Novoukrayinka
+Novomoskovs’k
+Novohrad-Volyns’kyy
+Nova Kakhovka
+Nosivka
+Nizhyn
+Nyzhn’ohirs’kyy
+Nikopol’
+Netishyn
+Nadvirna
+Mykolayiv
+Mukacheve
+Molodohvardiys’k
+Mohyliv-Podil’s’kyy
+Miskhor
+Myrhorod
+Merefa
+Melitopol’
+Mariupol
+Marhanets’
+Malyn
+Makiyivka
+Lyubotyn
+Lviv
+Lutuhyne
+Luts’k
+Luhansk
+Lubny
+Lozova
+Lysychans’k
+Ladyzhyn
+Kiev
+Kuznetsovs’k
+Kurakhovo
+Kupjansk
+Kryvyi Rih
+Krolevets’
+Kreminna
+Kremenets’
+Kremenchuk
+Krasnyy Luch
+Krasnyy Lyman
+Krasnoperekops’k
+Krasnohrad
+Krasnodon
+Krasnoarmiys’k
+Krasyliv
+Kramators’k
+Kivsharivka
+Kovel’
+Kotovs’k
+Kostopil’
+Korsun’-Shevchenkivs’kyy
+Korostyshiv
+Korosten’
+Kostyantynivka
+Konotop
+Komsomol’s’ke
+Kolomyya
+Kivertsi
+Kirovs’k
+Kirovohrad
+Kiliya
+Khust
+Khmel’nyts’kyy
+Khmil’nyk
+Kherson
+Khartsyz’k
+Kharkiv
+Kerch
+Kozyatyn
+Karlivka
+Kaniv
+Kamieniec Podolski
+Kalush
+Kalynivka
+Kakhovka
+Izyum
+Izyaslav
+Izmayil
+Ivano-Frankivs’k
+Irpin
+Ilovays’k
+Illichivs’k
+Horodok
+Horlivka
+Hlukhiv
+Hulyaypole
+Horodok
+Horodyshche
+Hola Prystan’
+Heniches’k
+Hayvoron
+Haysyn
+Hadyach
+Feodosiya
+Fastiv
+Energodar
+Dzhankoy
+Dzerzhyns’k
+Dunaivtsi
+Dubno
+Drohobych
+Donetsk
+Dolyna
+Dolyns'ka
+Dokuchayevs’k
+Dobropillya
+Dnipropetrovsk
+Dniprodzerzhyns’k
+Dniprorudne
+Dymytrov
+Derhachi
+Debal’tseve
+Chuhuyiv
+Chortkiv
+Chervonopartyzans’k
+Chervonohrad
+Chernivtsi
+Chernihiv
+Cherkasy
+Bucha
+Bryanka
+Brovary
+Brody
+Boyarka
+Boryspil’
+Boryslav
+Bolhrad
+Bohuslav
+Bohodukhiv
+Bilhorod-Dnistrovs’kyy
+Bila Tserkva
+Бережани
+Berehove
+Berdychiv
+Berdyans’k
+Bilopillya
+Bilohirs’k
+Bar
+Balta
+Balakliya
+Balaklava
+Bakhmach
+Bakhchysaray
+Avdiyivka
+Artsyz
+Artemivs’k
+Armyans’k
+Apostolove
+Antratsyt
+Amvrosiyivka
+Alushta
+Alchevs’k
+Okhtyrka
+Komsomolsk
+Славутич
+Yuzhnoukrains'k
+Novoyavorivs'k
+Yumbe
+Wobulenzi
+Wakiso
+Tororo
+Soroti
+Pallisa
+Paidha
+Nyachera
+Ntungamo
+Ntungamo
+Njeru
+Nebbi
+Namasuba
+Mukono
+Mubende
+Moyo
+Mityana
+Mbarara
+Mbale
+Masindi
+Masaka
+Luwero
+Lugazi
+Lira
+Kyenjojo
+Kotido
+Kitgum
+Kireka
+Kayunga
+Kasese
+Kamwenge
+Kampala
+Kabale
+Jinja
+Iganga
+Hoima
+Gulu
+Fort Portal
+Entebbe
+Bwizibwera
+Buwenge
+Busia
+Busembatia
+Bundibugyo
+Bugiri
+Arua
+Adjumani
+Fort Hunt
+Bessemer
+Paducah
+Birmingham
+Center Point
+Daphne
+Decatur
+Dothan
+East Florence
+Enterprise
+Fairhope
+Florence
+Gadsden
+Helena
+Homewood
+Hoover
+Hueytown
+Huntsville
+Madison
+Mobile
+Montgomery
+Mountain Brook
+Northport
+Opelika
+Oxford
+Pelham
+Phenix City
+Prattville
+Prichard
+Selma
+Talladega
+Tillmans Corner
+Troy
+Trussville
+Tuscaloosa
+Vestavia Hills
+Bella Vista
+Benton
+Bentonville
+Blytheville
+Bryant
+Cabot
+Conway
+El Dorado
+Fayetteville
+Forrest City
+Fort Smith
+Hot Springs
+Jacksonville
+Jonesboro
+Little Rock
+Maumelle
+North Little Rock
+Paragould
+Pine Bluff
+Rogers
+Russellville
+Searcy
+Siloam Springs
+Springdale
+Texarkana
+Van Buren
+West Memphis
+"Washington
+Bear
+Dover
+Middletown
+Newark
+Wilmington
+Allapattah
+Altamonte Springs
+Apopka
+Aventura
+Bartow
+Bayonet Point
+Bayshore Gardens
+Belle Glade
+Bellview
+Bloomingdale
+Boca Del Mar
+Boca Raton
+Bonita Springs
+Boynton Beach
+Bradenton
+Brandon
+Brent
+Brownsville
+Buenaventura Lakes
+Cantonment
+Cape Coral
+Carol City
+Carrollwood
+Carrollwood Village
+Casselberry
+Citrus Park
+Clearwater
+Clermont
+Cocoa
+Coconut Creek
+Coconut Grove
+Cooper City
+Coral Gables
+Coral Springs
+Coral Terrace
+Country Walk
+Country Club
+Crestview
+Cutler
+Cutler Ridge
+Dania Beach
+Davie
+Daytona Beach
+DeLand
+DeBary
+Deerfield Beach
+Delray Beach
+Deltona
+Doral
+Dunedin
+East Lake
+East Pensacola Heights
+Edgewater
+Egypt Lake-Leto
+Ensley
+Estero
+Eustis
+Ferry Pass
+Flagami
+Florida Ridge
+Fort Lauderdale
+Fort Myers
+Fort Pierce
+Fort Walton Beach
+Fountainebleau
+Fruit Cove
+Gainesville
+Glenvar Heights
+Golden Gate
+Golden Glades
+Greenacres City
+Haines City
+Hallandale Beach
+Hialeah
+Hialeah Gardens
+Holiday
+Hollywood
+Homestead
+Immokalee
+Iona
+Ives Estates
+Jacksonville
+Jacksonville Beach
+Jasmine Estates
+Jupiter
+Kendale Lakes
+Kendall
+Key West
+Keystone
+Kissimmee
+Lake Butler
+Lake Magdalene
+Lake Worth
+Lake Worth Corridor
+Lakeland
+Lakeside
+Land O' Lakes
+Largo
+Lauderdale Lakes
+Lauderhill
+Lealman
+Leesburg
+Lehigh Acres
+Leisure City
+Lutz
+Lynn Haven
+Maitland
+Margate
+Meadow Woods
+Melbourne
+Merritt Island
+Miami
+Miami Beach
+Miami Gardens
+Miami Lakes
+Miramar
+Myrtle Grove
+Naples
+Navarre
+New Smyrna Beach
+Norland
+North Fort Myers
+North Lauderdale
+North Miami
+North Miami Beach
+North Port
+Oak Ridge
+Oakland Park
+Ocala
+Ocoee
+Ojus
+Opa-locka
+Orlando
+Ormond Beach
+Oviedo
+Pace
+Palm Bay
+Palm Beach Gardens
+Palm City
+Palm Coast
+Palm Harbor
+Palm Springs
+Palm Valley
+Palmetto Bay
+Panama City
+Parkland
+Pembroke Pines
+Pensacola
+Pine Hills
+Pinecrest
+Pinellas Park
+Pinewood
+Plant City
+Plantation
+Poinciana
+Pompano Beach
+Ponte Vedra Beach
+Port Charlotte
+Port Orange
+Port Saint Lucie
+Princeton
+Punta Gorda
+Punta Gorda Isles
+Richmond West
+Riverview
+Riviera Beach
+Rockledge
+Royal Palm Beach
+Ruskin
+Safety Harbor
+Saint Cloud
+Saint Petersburg
+San Carlos Park
+Sanford
+Sarasota
+Sebastian
+Seminole
+South Bradenton
+South Miami Heights
+Southchase
+Spring Hill
+Stuart
+Sun City Center
+Sunny Isles Beach
+Sunrise
+Sunset
+Tallahassee
+Tamarac
+Tamiami
+Tampa
+Tarpon Springs
+Temple Terrace
+The Crossings
+The Hammocks
+The Villages
+Three Lakes
+Titusville
+Town 'n' Country
+University Park
+Valrico
+Venice
+Vero Beach
+Wekiwa Springs
+Wellington
+Wesley Chapel
+Westchase
+West Little River
+West Melbourne
+West Palm Beach
+West Pensacola
+West and East Lealman
+Westchester
+Weston
+Winter Garden
+Winter Haven
+Winter Park
+Winter Springs
+Wright
+Acworth
+Albany
+Alpharetta
+Americus
+Athens
+Atlanta
+Augusta
+Belvedere Park
+Brookhaven
+Brunswick
+Calhoun
+Canton
+Carrollton
+Cartersville
+Columbus
+Conyers
+Dalton
+Decatur
+Douglasville
+Dublin
+Duluth
+Dunwoody
+East Point
+Evans
+Fayetteville
+Forest Park
+Gainesville
+Griffin
+Hinesville
+Kennesaw
+Kingsland
+La Grange
+Lawrenceville
+Lithia Springs
+Mableton
+Macon
+Marietta
+Martinez
+McDonough
+Milledgeville
+Newnan
+North Decatur
+North Druid Hills
+Peachtree City
+Pooler
+Redan
+Riverdale
+Rome
+Roswell
+St. Marys
+Sandy Springs
+Savannah
+Smyrna
+Snellville
+Statesboro
+Stockbridge
+Sugar Hill
+Suwanee
+Thomasville
+Tifton
+Tucker
+Union City
+Valdosta
+Warner Robins
+Wilmington Island
+Woodstock
+Alton
+Belleville
+Cahokia
+Carbondale
+Charleston
+Collinsville
+Decatur
+East Saint Louis
+Edwardsville
+Fairview Heights
+Godfrey
+Granite City
+Jacksonville
+Marion
+Mattoon
+Mount Vernon
+O'Fallon
+Quincy
+Springfield
+Upper Alton
+Bloomington
+Broad Ripple
+Brownsburg
+Carmel
+Clarksville
+Columbus
+Evansville
+Fishers
+Greenfield
+Greenwood
+Indianapolis
+Jasper
+Jeffersonville
+Lawrence
+New Albany
+New Castle
+Plainfield
+Richmond
+Seymour
+Shelbyville
+Terre Haute
+Vincennes
+Derby
+Emporia
+Gardner
+Great Bend
+Hays
+Hutchinson
+Junction City
+Kansas City
+Lawrence
+Leavenworth
+Leawood
+Lenexa
+Manhattan
+Newton
+Olathe
+Overland Park
+Pittsburg
+Prairie Village
+Salina
+Shawnee
+Topeka
+Wichita
+Ashland
+Bowling Green
+Burlington
+Covington
+Danville
+Elizabethtown
+Erlanger
+Fern Creek
+Florence
+Fort Thomas
+Frankfort
+Georgetown
+Henderson
+Highview
+Hopkinsville
+Independence
+Ironville
+Jeffersontown
+Lexington
+Lexington-Fayette
+Louisville
+Madisonville
+Meads
+Murray
+Newburg
+Newport
+Nicholasville
+Okolona
+Owensboro
+Pleasure Ridge Park
+Radcliff
+Richmond
+Saint Matthews
+Shively
+Valley Station
+Winchester
+Alexandria
+Baton Rouge
+Bayou Cane
+Bossier City
+Central
+Chalmette
+Estelle
+Gretna
+Hammond
+Harvey
+Houma
+Kenner
+Lafayette
+Lake Charles
+Laplace
+Marrero
+Metairie
+Metairie Terrace
+Monroe
+Natchitoches
+New Iberia
+New Orleans
+Opelousas
+Prairieville
+Ruston
+Shenandoah
+Shreveport
+Slidell
+Sulphur
+Terrytown
+Adelphi
+Annapolis
+Arbutus
+Arnold
+Aspen Hill
+Baltimore
+Ballenger Creek
+Beltsville
+Bethesda
+Bowie
+Calverton
+Camp Springs
+Carney
+Catonsville
+Chillum
+Cloverly
+Clinton
+Cockeysville
+College Park
+Columbia
+Crofton
+Cumberland
+Damascus
+Dundalk
+East Riverdale
+Easton
+Edgewood
+Eldersburg
+Elkton
+Elkridge
+Ellicott City
+Essex
+Fairland
+Ferndale
+Fort Washington
+Frederick
+Gaithersburg
+Germantown
+Glassmanor
+Glen Burnie
+Green Haven
+Greenbelt
+Hagerstown
+Hanover
+Hillcrest Heights
+Hunt Valley
+Hyattsville
+Ilchester
+Lake Shore
+Landover
+Langley Park
+Laurel
+Lochearn
+Maryland City
+Middle River
+Milford Mill
+Montgomery Village
+North Bel Air
+North Bethesda
+North Potomac
+Odenton
+Olney
+Owings Mills
+Oxon Hill
+Parkville
+Parole
+Pasadena
+Perry Hall
+Pikesville
+Potomac
+Randallstown
+Redland
+Reisterstown
+Rockville
+Rosedale
+Rossville
+Saint Charles
+Salisbury
+Seabrook
+Severn
+Severna Park
+Silver Spring
+South Bel Air
+South Gate
+South Laurel
+Suitland
+Takoma Park
+Towson
+Waldorf
+West Elkridge
+Westminster
+Wheaton
+White Oak
+Woodlawn
+Affton
+Arnold
+Ballwin
+Belton
+Blue Springs
+Cape Girardeau
+Chesterfield
+Clayton
+Columbia
+Concord
+Creve Coeur
+East Independence
+Farmington
+Ferguson
+Florissant
+Gladstone
+Grandview
+Hannibal
+Hazelwood
+Independence
+Jefferson City
+Joplin
+Kansas City
+Kirkwood
+Lee's Summit
+Lemay
+Liberty
+Manchester
+Maryland Heights
+Mehlville
+Nixa
+O'Fallon
+Oakville
+Overland
+Ozark
+Poplar Bluff
+Raymore
+Raytown
+Rolla
+Saint Charles
+Saint Joseph
+St. Louis
+Saint Peters
+Sedalia
+Sikeston
+Spanish Lake
+Springfield
+University City
+Warrensburg
+Webster Groves
+Wentzville
+Wildwood
+Biloxi
+Brandon
+Clarksdale
+Clinton
+Columbus
+Gautier
+Greenville
+Greenwood
+Gulfport
+Hattiesburg
+Horn Lake
+Jackson
+Laurel
+Madison
+Meridian
+Natchez
+Ocean Springs
+Olive Branch
+Oxford
+Pascagoula
+Pearl
+Ridgeland
+Southaven
+Starkville
+Tupelo
+Vicksburg
+West Gulfport
+Albemarle
+Apex
+Asheboro
+Asheville
+Boone
+Burlington
+Carrboro
+Cary
+Chapel Hill
+Charlotte
+Clayton
+Clemmons
+Concord
+Cornelius
+Durham
+Eden
+Elizabeth City
+Fayetteville
+Fuquay-Varina
+Garner
+Gastonia
+Goldsboro
+Greensboro
+Greenville
+Havelock
+Henderson
+Hickory
+High Point
+Holly Springs
+Hope Mills
+Huntersville
+Indian Trail
+Jacksonville
+Kannapolis
+Kernersville
+Kinston
+Laurinburg
+Lenoir
+Lexington
+Lumberton
+Matthews
+Mint Hill
+Monroe
+Mooresville
+Morganton
+Morrisville
+New Bern
+Raleigh
+Roanoke Rapids
+Rocky Mount
+Salisbury
+Sanford
+Shelby
+Statesville
+Thomasville
+Wake Forest
+West Raleigh
+Wilmington
+Wilson
+Winston-Salem
+Atlantic City
+Bridgeton
+Camden
+Cherry Hill
+Glassboro
+Jackson
+Lindenwold
+Maple Shade
+Millville
+Mount Laurel
+Ocean Acres
+Pennsauken
+Pleasantville
+Sicklerville
+South Vineland
+Toms River
+Vineland
+Williamstown
+Athens
+Beavercreek
+Centerville
+Cincinnati
+Columbus
+Dayton
+Fairborn
+Fairfield
+Forest Park
+Grove City
+Hamilton
+Huber Heights
+Kettering
+Lancaster
+Lebanon
+Mason
+Miamisburg
+Middletown
+Norwood
+Oxford
+Pickerington
+Portsmouth
+Reynoldsburg
+Riverside
+Springboro
+Springfield
+Trotwood
+Upper Arlington
+Vandalia
+White Oak
+Whitehall
+Xenia
+Zanesville
+Ada
+Altus
+Ardmore
+Bartlesville
+Bethany
+Bixby
+Broken Arrow
+Chickasha
+Claremore
+Del City
+Duncan
+Durant
+Edmond
+El Reno
+Enid
+Jenks
+Lawton
+McAlester
+Midwest City
+Moore
+Muskogee
+Mustang
+Norman
+Oklahoma City
+Owasso
+Ponca City
+Sand Springs
+Sapulpa
+Shawnee
+Stillwater
+Tahlequah
+Tulsa
+Yukon
+Chambersburg
+Chester
+Drexel Hill
+Hanover
+Philadelphia
+Springfield
+West Chester
+York
+Aiken
+Anderson
+Charleston
+Columbia
+Conway
+Easley
+Florence
+Goose Creek
+Greenville
+Greenwood
+Greer
+Hanahan
+Hilton Head Island
+Lexington
+Mauldin
+Mount Pleasant
+Myrtle Beach
+North Augusta
+North Charleston
+Rock Hill
+Saint Andrews
+Seven Oaks
+Simpsonville
+Socastee
+Spartanburg
+Summerville
+Sumter
+Taylors
+Wade Hampton
+Bartlett
+Brentwood
+Brentwood Estates
+Bristol
+Chattanooga
+Clarksville
+Cleveland
+Collierville
+Columbia
+Cookeville
+Dyersburg
+East Brainerd
+East Chattanooga
+East Ridge
+Farragut
+Franklin
+Gallatin
+Germantown
+Goodlettsville
+Greeneville
+Hendersonville
+Jackson
+Johnson City
+Kingsport
+Knoxville
+La Vergne
+Lebanon
+Maryville
+Memphis
+Morristown
+Mount Juliet
+Murfreesboro
+Nashville
+New South Memphis
+Oak Ridge
+Shelbyville
+Smyrna
+Spring Hill
+Springfield
+Tullahoma
+Abilene
+Alamo
+Aldine
+Alice
+Allen
+Alvin
+Angleton
+Arlington
+Atascocita
+Austin
+Balch Springs
+Baytown
+Beaumont
+Bedford
+Bellaire
+Belton
+Benbrook
+Brenham
+Brownsville
+Brownwood
+Brushy Creek
+Bryan
+Burleson
+Canyon Lake
+Carrollton
+Cedar Hill
+Cedar Park
+Channelview
+Cibolo
+Cinco Ranch
+Cleburne
+Cloverleaf
+College Station
+Colleyville
+Conroe
+Converse
+Coppell
+Copperas Cove
+Corinth
+Corpus Christi
+Corsicana
+Cypress
+Dallas
+DeSoto
+Deer Park
+Denison
+Denton
+Dickinson
+Donna
+Duncanville
+Edinburg
+Ennis
+Euless
+Farmers Branch
+Flower Mound
+Fort Worth
+Fresno
+Friendswood
+Frisco
+Gainesville
+Galveston
+Garland
+Gatesville
+Georgetown
+Grand Prairie
+Grapevine
+Greenville
+Groves
+Haltom City
+Harker Heights
+Harlingen
+Highland Village
+Houston
+Humble
+Huntsville
+Hurst
+Irving
+West Hartford
+West Haven
+West Torrington
+Westport
+Wethersfield
+Willimantic
+Wilton
+Windham
+Windsor
+Wolcott
+Ames
+Ankeny
+Bettendorf
+Burlington
+Cedar Falls
+Cedar Rapids
+Clinton
+Clive
+Coralville
+Council Bluffs
+Davenport
+Des Moines
+Dubuque
+Fort Dodge
+Iowa City
+Johnston
+Marion
+Marshalltown
+Mason City
+Muscatine
+Newton
+Ottumwa
+Sioux City
+Urbandale
+Waterloo
+West Des Moines
+Addison
+Algonquin
+Alsip
+Arlington Heights
+Aurora
+Bartlett
+Batavia
+Bellwood
+Belvidere
+Bensenville
+Berwyn
+Bloomingdale
+Bloomington
+Blue Island
+Bolingbrook
+Bourbonnais
+Bradley
+Bridgeview
+Brookfield
+Buffalo Grove
+Burbank
+Calumet City
+Carol Stream
+Carpentersville
+Cary
+Champaign
+Chicago
+Chicago Heights
+Cicero
+Country Club Hills
+Crest Hill
+Crystal Lake
+Danville
+Darien
+DeKalb
+Deerfield
+Des Plaines
+Dixon
+Dolton
+Downers Grove
+East Moline
+East Peoria
+Elgin
+Elk Grove Village
+Elmhurst
+Elmwood Park
+Evanston
+Evergreen Park
+Frankfort
+Franklin Park
+Freeport
+Galesburg
+Geneva
+Glen Ellyn
+Glenview
+Goodings Grove
+Grayslake
+Gurnee
+Hanover Park
+Harvey
+Highland Park
+Hinsdale
+Hoffman Estates
+Homer Glen
+Homewood
+Huntley
+Joliet
+Kankakee
+La Grange
+Lake Forest
+Lake Zurich
+Lake in the Hills
+Lansing
+Lemont
+Libertyville
+Lisle
+Lockport
+Lombard
+Loves Park
+Machesney Park
+Macomb
+Matteson
+Maywood
+McHenry
+Melrose Park
+Mokena
+Moline
+Montgomery
+Morton
+Morton Grove
+Mount Prospect
+Mundelein
+Naperville
+New Lenox
+Niles
+Normal
+North Aurora
+North Chicago
+North Peoria
+Northbrook
+Oak Forest
+Oak Lawn
+Oak Park
+Orland Park
+Oswego
+Ottawa
+Palatine
+Palos Hills
+Park Forest
+Park Ridge
+Pekin
+Peoria
+Plainfield
+Prospect Heights
+Rock Island
+Rockford
+Rolling Meadows
+Romeoville
+Roselle
+Round Lake
+Round Lake Beach
+Saint Charles
+Schaumburg
+Shorewood
+Skokie
+South Elgin
+South Holland
+Sterling
+Streamwood
+Sycamore
+Tinley Park
+Urbana
+Vernon Hills
+Villa Park
+Wasco
+Washington
+Waukegan
+West Chicago
+Westchester
+Westmont
+Wheaton
+Wheeling
+Wilmette
+Woodridge
+Woodstock
+Yorkville
+Zion
+Anderson
+Crawfordsville
+Crown Point
+Dyer
+East Chicago
+Elkhart
+Fort Wayne
+Frankfort
+Gary
+Goshen
+Granger
+Griffith
+Hammond
+Highland
+Hobart
+Huntington
+Kokomo
+LaPorte
+Lafayette
+Lebanon
+Logansport
+Marion
+Merrillville
+Michigan City
+Mishawaka
+Muncie
+Munster
+Noblesville
+Portage
+Schererville
+South Bend
+Valparaiso
+West Lafayette
+Westfield
+Abington
+Acton
+Agawam
+Amesbury
+Amherst Center
+Arlington
+Ashland
+Attleboro
+Auburn
+Barnstable
+Belmont
+Beverly
+Beverly Cove
+Billerica
+Boston
+Braintree
+Brockton
+Brookline
+Burlington
+Cambridge
+Canton
+Chelmsford
+Chelsea
+Chicopee
+Concord
+Danvers
+Dedham
+Dracut
+East Longmeadow
+Easthampton
+Easton
+Everett
+Fairhaven
+Fall River
+Fitchburg
+Framingham
+Framingham Center
+Franklin
+Gardner
+Gloucester
+Grafton
+Greenfield
+Hanover
+Haverhill
+Holden
+Holyoke
+Jamaica Plain
+Lawrence
+Leominster
+Lexington
+Longmeadow
+Lowell
+Ludlow
+Lynn
+Malden
+Mansfield
+Marblehead
+Marlborough
+Medford
+Melrose
+Methuen
+Milford
+Milton
+Natick
+Needham
+New Bedford
+Newburyport
+Newton
+North Chicopee
+Northampton
+Norton
+Norwood
+Palmer
+Peabody
+Pittsfield
+Quincy
+Randolph
+Reading
+Rockland
+Salem
+Saugus
+Shrewsbury
+Somerset
+Somerville
+South Boston
+South Hadley
+South Peabody
+Southbridge
+Springfield
+Stoneham
+Stoughton
+Sudbury
+Swansea
+Taunton
+Tewksbury
+Wakefield
+Waltham
+Watertown
+Wellesley
+West Springfield
+Westfield
+Westford
+Weymouth
+Wilmington
+Winchester
+Winthrop
+Woburn
+Worcester
+Yarmouth
+Auburn
+Augusta
+Bangor
+Biddeford
+Brunswick
+Lewiston
+Portland
+Saco
+South Portland
+South Portland Gardens
+Waterville
+West Scarborough
+Westbrook
+Adrian
+Allen Park
+Allendale
+Ann Arbor
+Auburn Hills
+Battle Creek
+Bay City
+Birmingham
+Burton
+Canton
+Clinton
+Dearborn
+Dearborn Heights
+Detroit
+East Lansing
+Eastpointe
+Farmington Hills
+Ferndale
+Flint
+Forest Hills
+Garden City
+Grand Rapids
+Grandville
+Grosse Pointe Woods
+Hamtramck
+Haslett
+Hazel Park
+Holland
+Holt
+Iron River
+Jackson
+Jenison
+Kalamazoo
+Kentwood
+Lansing
+Lincoln Park
+Livonia
+Madison Heights
+Marquette
+Midland
+Monroe
+Mount Clemens
+Mount Pleasant
+Muskegon
+Norton Shores
+Novi
+Oak Park
+Okemos
+Owosso
+Pontiac
+Port Huron
+Portage
+Redford
+Rochester Hills
+Romulus
+Roseville
+Royal Oak
+Saginaw
+Shelby
+Southfield
+Southgate
+Saint Clair Shores
+Sterling Heights
+Taylor
+Trenton
+Troy
+Walker
+Warren
+Waterford
+Waverly
+Wayne
+Westland
+Wyandotte
+Wyoming
+Ypsilanti
+Albert Lea
+Andover
+Anoka
+Apple Valley
+Austin
+Blaine
+Bloomington
+Brooklyn Center
+Brooklyn Park
+Buffalo
+Burnsville
+Champlin
+Chanhassen
+Chaska
+Columbia Heights
+Coon Rapids
+Cottage Grove
+Crystal
+Duluth
+Eagan
+Eden Prairie
+Edina
+Elk River
+Faribault
+Farmington
+Forest Lake
+Fridley
+Golden Valley
+Ham Lake
+Hastings
+Hibbing
+Hopkins
+Inver Grove Heights
+Lakeville
+Lino Lakes
+Mankato
+Maple Grove
+Maplewood
+Minneapolis
+Minnetonka
+Minnetonka Mills
+Moorhead
+New Brighton
+New Hope
+Northfield
+Oakdale
+Owatonna
+Plymouth
+Prior Lake
+Ramsey
+Red Wing
+Richfield
+Rochester
+Rosemount
+Roseville
+Saint Cloud
+Saint Louis Park
+Saint Michael
+Saint Paul
+Sartell
+Savage
+Shakopee
+Shoreview
+South Saint Paul
+Stillwater
+West Coon Rapids
+West Saint Paul
+White Bear Lake
+Willmar
+Winona
+Woodbury
+Kirksville
+Fargo
+Grand Forks
+Jamestown
+West Fargo
+Bellevue
+Columbus
+Fremont
+Grand Island
+Hastings
+Kearney
+La Vista
+Lincoln
+Norfolk
+Omaha
+Papillion
+Bedford
+Concord
+Derry
+Derry Village
+Dover
+East Concord
+Keene
+Laconia
+Manchester
+Merrimack
+Nashua
+Portsmouth
+Rochester
+Salem
+Asbury Park
+Avenel
+Bayonne
+Belleville
+Bergenfield
+Bloomfield
+Carteret
+Cliffside Park
+Clifton
+Colonia
+Cranford
+Dover
+Dumont
+East Brunswick
+East Orange
+Edison
+Elizabeth
+Elmwood Park
+Englewood
+Ewing
+Fair Lawn
+Fords
+Fort Lee
+Garfield
+Hackensack
+Hawthorne
+Hillside
+Hoboken
+Hopatcong
+Hopatcong Hills
+Irvington
+Iselin
+Jersey City
+Kearny
+Lakewood
+Linden
+Livingston
+Lodi
+Long Branch
+Lyndhurst
+Madison
+Mahwah
+Maplewood
+Marlboro
+Montclair
+Morristown
+New Brunswick
+New Milford
+Newark
+North Arlington
+North Bergen
+North Plainfield
+Nutley
+Old Bridge
+Orange
+Palisades Park
+Paramus
+Parsippany
+Passaic
+Paterson
+Perth Amboy
+Piscataway
+Plainfield
+Point Pleasant
+Rahway
+Ridgewood
+Roselle
+Rutherford
+Sayreville
+Sayreville Junction
+Scotch Plains
+Secaucus
+Somerset
+South Old Bridge
+South Orange
+South Plainfield
+South River
+Summit
+Teaneck
+Tinton Falls
+Trenton
+Union
+Union City
+Wayne
+West Milford
+West New York
+West Orange
+Westfield
+Willingboro
+Woodbridge
+Wyckoff
+Albany
+Amherst
+Amsterdam
+Auburn
+Baldwin
+Batavia
+Bay Shore
+Beacon
+Bellmore
+Bensonhurst
+Bethpage
+Binghamton
+Brentwood
+Brighton
+The Bronx
+Brooklyn
+Buffalo
+Centereach
+Central Islip
+Cheektowaga
+Cohoes
+Commack
+Coney Island
+Copiague
+Coram
+Cortland
+Deer Park
+Depew
+Dix Hills
+East Meadow
+East Massapequa
+East New York
+East Northport
+East Patchogue
+East Setauket
+Eastchester
+Eggertsville
+Elmira
+Elmont
+Farmingville
+Floral Park
+Franklin Square
+Freeport
+Garden City
+Glen Cove
+Gloversville
+Greenburgh
+Harrison
+Hauppauge
+Hempstead
+Hicksville
+Holbrook
+Holtsville
+Huntington
+Huntington Station
+Irondequoit
+Islip
+Ithaca
+Jamaica
+Jamestown
+Johnson City
+Kenmore
+Kings Park
+Kingston
+Kiryas Joel
+Lackawanna
+Lake Ronkonkoma
+Levittown
+Lindenhurst
+Lockport
+Long Beach
+Long Island City
+Lynbrook
+Mamaroneck
+Manhattan
+Massapequa
+Massapequa Park
+Mastic
+Medford
+Melville
+Merrick
+Middletown
+Mineola
+Monsey
+Mount Vernon
+Nanuet
+New City
+New Rochelle
+New York City
+Newburgh
+Niagara Falls
+North Amityville
+North Babylon
+North Bay Shore
+North Bellmore
+North Massapequa
+North Tonawanda
+North Valley Stream
+Oceanside
+Ossining
+Oswego
+Pearl River
+Peekskill
+Plainview
+Plattsburgh
+Port Chester
+Port Washington
+Poughkeepsie
+Borough of Queens
+Rochester
+Rockville Centre
+Rome
+Ronkonkoma
+Roosevelt
+Rotterdam
+Rye
+Saratoga Springs
+Sayville
+Scarsdale
+Schenectady
+Seaford
+Selden
+Shirley
+Smithtown
+Spring Valley
+Staten Island
+Syosset
+Syracuse
+Tonawanda
+Troy
+Uniondale
+Utica
+Valley Stream
+Wantagh
+Watertown
+West Albany
+West Babylon
+West Hempstead
+West Islip
+West Seneca
+Westbury
+White Plains
+Woodmere
+Yonkers
+Akron
+Alliance
+Ashland
+Ashtabula
+Aurora
+Austintown
+Avon
+Avon Center
+Avon Lake
+Barberton
+Bay Village
+Berea
+Boardman
+Bowling Green
+Broadview Heights
+Brook Park
+Brunswick
+Canton
+Cleveland
+Cuyahoga Falls
+Defiance
+Delaware
+Dublin
+East Cleveland
+Eastlake
+Elyria
+Euclid
+Fairview Park
+Findlay
+Fremont
+Gahanna
+Garfield Heights
+Green
+Hilliard
+Hudson
+Kent
+Lakewood
+Lima
+Lorain
+Mansfield
+Maple Heights
+Marion
+Marysville
+Massillon
+Mayfield Heights
+Medina
+Mentor
+Middleburg Heights
+Mount Vernon
+New Philadelphia
+Newark
+Niles
+North Canton
+North Olmsted
+North Ridgeville
+North Royalton
+Norwalk
+Oregon
+Painesville
+Parma
+Parma Heights
+Perrysburg
+Piqua
+Rocky River
+Sandusky
+Shaker Heights
+Sidney
+Solon
+South Euclid
+Steubenville
+Stow
+Streetsboro
+Strongsville
+Sylvania
+Tallmadge
+Tiffin
+Toledo
+Troy
+Twinsburg
+Wadsworth
+Warren
+Westerville
+Westlake
+Willoughby
+Wooster
+Youngstown
+Allentown
+Allison Park
+Altoona
+Back Mountain
+Baldwin
+Bethel Park
+Bethlehem
+Carlisle
+Easton
+Erie
+Harrisburg
+Hazleton
+Hermitage
+Johnstown
+King of Prussia
+Lancaster
+Lansdale
+Lebanon
+Levittown
+Limerick
+McKeesport
+Monroeville
+Mount Lebanon
+Mountain Top
+Murrysville
+New Castle
+Norristown
+Penn Hills
+Phoenixville
+Pittsburgh
+Plum
+Pottstown
+Radnor
+Reading
+Scranton
+State College
+Upper Saint Clair
+Wayne
+West Mifflin
+Whitehall Township
+Wilkes-Barre
+Wilkinsburg
+Williamsport
+Willow Grove
+Barrington
+Bristol
+Central Falls
+Coventry
+Cranston
+Cumberland
+East Providence
+Middletown
+Newport
+North Kingstown
+North Providence
+Pawtucket
+Portsmouth
+Providence
+Smithfield
+Warwick
+West Warwick
+Westerly
+Woonsocket
+Aberdeen
+Brookings
+Mitchell
+Sioux Falls
+Watertown
+Burlington
+Colchester
+Rutland
+South Burlington
+Appleton
+Ashwaubenon
+Beaver Dam
+Beloit
+Brookfield
+Caledonia
+Cudahy
+De Pere
+Eau Claire
+Fitchburg
+Fond du Lac
+Franklin
+Germantown
+Green Bay
+Greenfield
+Howard
+Janesville
+Kaukauna
+Kenosha
+La Crosse
+Madison
+Manitowoc
+Marshfield
+Menasha
+Menomonee Falls
+Menomonie
+Mequon
+Middleton
+Milwaukee
+Muskego
+Neenah
+New Berlin
+North La Crosse
+Oak Creek
+Oconomowoc
+Onalaska
+Oshkosh
+Pleasant Prairie
+Racine
+Sheboygan
+South Milwaukee
+Stevens Point
+Sun Prairie
+Superior
+Watertown
+Waukesha
+Wausau
+Wauwatosa
+West Allis
+West Bend
+Wisconsin Rapids
+Weirton
+Weirton Heights
+Wheeling
+Ansonia
+Bridgeport
+Bristol
+Branford
+Cheshire
+Fillmore
+Buckeye
+Bullhead City
+Casa Grande
+Casas Adobes
+Catalina Foothills
+Chandler
+Douglas
+Drexel Heights
+El Mirage
+Eloy
+Flagstaff
+Florence
+Flowing Wells
+Fortuna Foothills
+Fountain Hills
+Gilbert
+Glendale
+Goodyear
+Green Valley
+Kingman
+Lake Havasu City
+Marana
+Maricopa
+Mesa
+Nogales
+Oro Valley
+Payson
+Peoria
+Phoenix
+Prescott
+Prescott Valley
+Queen Creek
+Rio Rico
+Sahuarita
+San Luis
+Scottsdale
+Sierra Vista
+Sun City
+Sun City West
+Surprise
+Tanque Verde
+Tempe
+Tempe Junction
+Tucson
+Yuma
+Adelanto
+Agoura
+Agoura Hills
+Alameda
+Albany
+Alhambra
+Aliso Viejo
+Altadena
+Alum Rock
+American Canyon
+Anaheim
+Antelope
+Antioch
+Apple Valley
+Arcadia
+Arroyo Grande
+Artesia
+Arvin
+Ashland
+Atascadero
+Atwater
+Avenal
+Avocado Heights
+Azusa
+Bakersfield
+Baldwin Park
+Banning
+Barstow
+Barstow Heights
+Bay Point
+Beaumont
+Bell
+Bell Gardens
+Bellflower
+Belmont
+Benicia
+Berkeley
+Beverly Hills
+Bloomington
+Blythe
+Bostonia
+Boyle Heights
+Brawley
+Brea
+Brentwood
+Buena Park
+Burbank
+Burlingame
+Calabasas
+Calexico
+Camarillo
+Cameron Park
+Campbell
+Canoga Park
+Carlsbad
+Carmichael
+Carson
+Castaic
+Castro Valley
+Cathedral City
+Ceres
+Cerritos
+Chatsworth
+Chico
+Chino
+Chino Hills
+Chowchilla
+Chula Vista
+Citrus Heights
+Claremont
+Clearlake
+Clovis
+Coachella
+Colton
+Compton
+Concord
+Corcoran
+Corona
+Coronado
+Costa Mesa
+Covina
+Cudahy
+Culver City
+Cupertino
+Cypress
+Daly City
+Dana Point
+Danville
+Davis
+Delano
+Desert Hot Springs
+Diamond Bar
+Dinuba
+Dixon
+Downey
+Duarte
+Dublin
+East Rancho Dominguez
+East Hemet
+East Los Angeles
+East Palo Alto
+El Cajon
+El Centro
+El Cerrito
+El Dorado Hills
+El Monte
+El Segundo
+Elk Grove
+Encinitas
+Escondido
+Fair Oaks
+Fairfield
+Fallbrook
+Florin
+Folsom
+Fontana
+Foothill Farms
+Foster City
+Fountain Valley
+Fremont
+Fresno
+Fullerton
+Galt
+Garden Grove
+Gardena
+Gilroy
+Glen Avon
+Glendale
+Glendora
+Goleta
+Granite Bay
+Greenfield
+Hacienda Heights
+Hanford
+Hawthorne
+Hayward
+Hemet
+Hercules
+Hermosa Beach
+Hesperia
+Highland
+Hollister
+Hollywood
+Huntington Beach
+Huntington Park
+Imperial Beach
+Indio
+Inglewood
+Irvine
+Lodi
+Loma Linda
+Lomita
+Lompoc
+Long Beach
+Los Altos
+Los Angeles
+Los Banos
+Los Gatos
+Lynwood
+Madera
+Manhattan Beach
+Manteca
+Marina
+Martinez
+Maywood
+Mead Valley
+Menifee
+Menlo Park
+Merced
+Millbrae
+Milpitas
+Mira Loma
+Mission Viejo
+Modesto
+Monrovia
+Montclair
+Montebello
+Monterey
+Monterey Park
+Moorpark
+Moraga
+Moreno Valley
+Morgan Hill
+Mountain View
+Murrieta
+Napa
+National City
+Newark
+Newport Beach
+Nipomo
+Norco
+North Glendale
+North Highlands
+North Hollywood
+Northridge
+Norwalk
+Novato
+Oakdale
+Oakland
+Oakley
+Oceanside
+Oildale
+Ontario
+Orange
+Orangevale
+Orcutt
+Orinda
+Oroville
+Oxnard
+Oxnard Shores
+Pacifica
+Pacific Grove
+Palm Desert
+Palm Springs
+Palmdale
+Palo Alto
+Paradise
+Paramount
+Pasadena
+Paso Robles
+Patterson
+Perris
+Petaluma
+Pico Rivera
+Pinole
+Pittsburg
+Placentia
+Pleasant Hill
+Pleasanton
+Pomona
+Port Hueneme
+Porterville
+Poway
+Prunedale
+Ramona
+Rancho Cordova
+Rancho Cucamonga
+Rancho Mirage
+Rancho Palos Verdes
+Rancho San Diego
+Rancho Santa Margarita
+Redlands
+Redondo Beach
+Redwood City
+Reedley
+Rialto
+Richmond
+Ridgecrest
+Rio Linda
+Riverbank
+Riverside
+Rocklin
+Rohnert Park
+Rosamond
+Rosemead
+Rosemont
+Roseville
+Rowland Heights
+Rubidoux
+Sacramento
+Salinas
+San Bernardino
+San Bruno
+San Carlos
+San Clemente
+San Diego
+San Dimas
+San Fernando
+San Francisco
+San Gabriel
+San Jacinto
+San Jose
+San Juan Capistrano
+San Leandro
+San Lorenzo
+San Luis Obispo
+San Marcos
+San Mateo
+San Pablo
+San Pedro
+San Rafael
+San Ramon
+Sanger
+Santa Ana
+Santa Barbara
+Santa Clara
+Santa Clarita
+Santa Cruz
+Santa Fe Springs
+Santa Maria
+Santa Monica
+Santa Paula
+Santa Rosa
+Santee
+Saratoga
+Seal Beach
+Seaside
+Selma
+Shafter
+Sherman Oaks
+Simi Valley
+Soledad
+South El Monte
+South Gate
+South Lake Tahoe
+South Pasadena
+South San Francisco
+South San Jose Hills
+South Whittier
+South Yuba City
+Spring Valley
+Stanton
+Stockton
+Suisun
+Sun City
+Sunnyvale
+Temecula
+Temple City
+Thousand Oaks
+Torrance
+Tracy
+Truckee
+Tulare
+Turlock
+Tustin
+North Tustin
+Twentynine Palms
+Ukiah
+Union City
+Universal City
+Upland
+Walnut Park
+Watsonville
+West Carson
+West Covina
+West Hollywood
+West Puente Valley
+West Sacramento
+Westminster
+Westmont
+Whittier
+Wildomar
+Willowbrook
+Windsor
+Winter Gardens
+Woodland
+Woodland Hills
+Yorba Linda
+Yuba City
+Yucaipa
+Yucca Valley
+Arvada
+Aurora
+Brighton
+Broomfield
+Cañon City
+Castle Rock
+Castlewood
+Centennial
+Cimarron Hills
+Clifton
+Colorado Springs
+Columbine
+Commerce City
+Denver
+Durango
+Englewood
+Fountain
+Golden
+Grand Junction
+Highlands Ranch
+Ken Caryl
+Lafayette
+Lakewood
+Littleton
+Louisville
+Montrose
+Northglenn
+Parker
+Pueblo
+Pueblo West
+Sherrelwood
+Southglenn
+Thornton
+Westminster
+Wheat Ridge
+Dodge City
+Garden City
+Liberal
+Alamogordo
+Albuquerque
+Carlsbad
+Clovis
+Farmington
+Gallup
+Hobbs
+Las Cruces
+Rio Rancho
+Roswell
+Santa Fe
+South Valley
+Boulder City
+Carson City
+Enterprise
+Fernley
+Henderson
+Las Vegas
+Mesquite
+North Las Vegas
+Pahrump
+Paradise
+Reno
+Spanish Springs
+Sparks
+Spring Valley
+Sun Valley
+Sunrise Manor
+Whitney
+Winchester
+Amarillo
+Big Spring
+Del Rio
+Eagle Pass
+El Paso
+Hereford
+Horizon City
+Lubbock
+Midland
+Odessa
+Pampa
+Plainview
+San Angelo
+Socorro
+Socorro Mission Number 1 Colonia
+West Odessa
+Cedar City
+Saint George
+Washington
+Wasco
+Anthem
+Apache Junction
+Avondale
+Juneau
+Arcata
+Bayside
+Eureka
+McKinleyville
+Redding
+Susanville
+Boulder
+Erie
+Evans
+Fort Collins
+Greeley
+Longmont
+Loveland
+Windsor
+Boise
+Caldwell
+Coeur d'Alene
+Eagle
+Idaho Falls
+Kuna
+Lewiston
+Lewiston Orchards
+Meridian
+Moscow
+Nampa
+Pocatello
+Post Falls
+Rexburg
+Twin Falls
+Billings
+Bozeman
+Butte
+Great Falls
+Helena
+Kalispell
+Missoula
+Bismarck
+Dickinson
+Mandan
+Minot
+North Platte
+Scottsbluff
+Elko
+Albany
+Aloha
+Altamont
+Ashland
+Beaverton
+Bend
+Bethany
+Canby
+Central Point
+Coos Bay
+Corvallis
+Eugene
+Forest Grove
+Four Corners
+Grants Pass
+Gresham
+Hayesville
+Hermiston
+Hillsboro
+Keizer
+Klamath Falls
+Lake Oswego
+Lebanon
+Lents
+McMinnville
+Medford
+Milwaukie
+Newberg
+Oak Grove
+Oregon City
+Pendleton
+Portland
+Redmond
+Roseburg
+Salem
+Sherwood
+Springfield
+Tigard
+Troutdale
+Tualatin
+West Linn
+Wilsonville
+Woodburn
+Rapid City
+Bountiful
+Brigham City
+Centerville
+Clearfield
+Clinton
+Cottonwood Heights
+Draper
+Eagle Mountain
+East Millcreek
+Farmington
+Herriman
+Highland
+Holladay
+Kaysville
+Kearns
+Layton
+Lehi
+Logan
+Magna
+Midvale
+Millcreek
+Murray
+North Ogden
+North Salt Lake
+Ogden
+Orem
+Payson
+Pleasant Grove
+Provo
+Riverton
+Roy
+Salt Lake City
+Sandy City
+Sandy Hills
+Saratoga Springs
+South Jordan Heights
+South Jordan
+South Ogden
+South Salt Lake
+Spanish Fork
+Springville
+Syracuse
+Taylorsville
+Tooele
+West Jordan
+West Valley City
+Aberdeen
+Anacortes
+Arlington
+Auburn
+Battle Ground
+Bellevue
+Bellingham
+Bonney Lake
+Bothell
+Bremerton
+Burien
+Camas
+Centralia
+Cottage Lake
+Covington
+Des Moines
+Edmonds
+Ellensburg
+Everett
+Fairwood
+Federal Way
+Five Corners
+Frederickson
+Graham
+Hazel Dell
+Issaquah
+Kenmore
+Kennewick
+Kent
+Kirkland
+Lacey
+Lake Stevens
+Lakewood
+Longview
+Lynnwood
+Maple Valley
+Martha Lake
+Marysville
+Mercer Island
+Mill Creek
+Monroe
+Moses Lake
+Mount Vernon
+Mountlake Terrace
+Mukilteo
+North Creek
+Oak Harbor
+Olympia
+Opportunity
+Orchards
+Parkland
+Pasco
+Port Angeles
+Pullman
+Puyallup
+Redmond
+Renton
+Richland
+Salmon Creek
+Sammamish
+SeaTac
+Seattle
+Shoreline
+Silverdale
+South Hill
+Spanaway
+Spokane
+Spokane Valley
+Sunnyside
+Tacoma
+Tukwila
+Tumwater
+University Place
+Vancouver
+Walla Walla
+Wenatchee
+West Lake Sammamish
+West Lake Stevens
+Bainbridge Island
+Yakima
+Casper
+Cheyenne
+Gillette
+Laramie
+Rock Springs
+Sheridan
+American Fork
+Kahului
+Kailua
+Kāne‘ohe
+Kīhei
+Makakilo City
+Mililani Town
+Pearl City
+Wahiawā
+Wailuku
+Waipahu
+‘Ewa Gentry
+Hilo
+Honolulu
+Eagle River
+Fairbanks
+Anchorage
+Badger
+Milton
+Johns Creek
+Cutler Bay
+Alafaya
+Fort Bragg
+City of Milford (balance)
+Butte-Silver Bow (Balance)
+City of Sammamish
+Silver Firs
+Vineyard
+Wallingford Center
+Bel Air North
+Bel Air South
+Setauket-East Setauket
+Tonawanda
+Fort Leonard Wood
+West Bloomfield Township
+East Lake-Orient Park
+Four Corners
+Greater Northdale
+Candler-McAfee
+University
+Vero Beach South
+Kendall West
+Palm River-Clair Mel
+Arden-Arcade
+Bryn Mawr-Skyway
+Casa de Oro-Mount Helix
+Florence-Graham
+Fort Hood
+Inglewood-Finn Hill
+La Crescenta-Montrose
+East Hill-Meridian
+Security-Widefield
+Union Hill-Novelty Hill
+West Whittier-Los Nietos
+Summerlin South
+Makakilo
+Schofield Barracks
+San Tan Valley
+Enchanted Hills
+West Hills
+Oak Hill
+Bridgewater
+Warren Township
+Fairfield Heights
+Randolph
+Hot Springs National Park
+Dixiana
+Cranberry Township
+Silver Lake
+Echo Park
+Young
+Trinidad
+Trinidad
+Treinta y Tres
+Tacuarembó
+Santa Lucía
+San José de Mayo
+San Carlos
+Salto
+Rocha
+Rivera
+Progreso
+Paysandú
+Paso de Carrasco
+Pando
+Montevideo
+Minas
+Mercedes
+Melo
+Maldonado
+Las Piedras
+La Paz
+Fray Bentos
+Florida
+Durazno
+Dolores
+Delta del Tigre
+Colonia del Sacramento
+Carmelo
+Canelones
+Artigas
+Nukus
+Khŭjayli
+Oltinko’l
+Zomin
+Urgut
+Tirmiz
+Sho’rchi
+Shahrisabz
+Samarqand
+Qarshi
+Muborak
+Kitob
+Kattaqo’rg’on
+Koson
+Karakul’
+Kogon
+G’uzor
+Galaosiyo
+Juma
+Denov
+Chiroqchi
+Chelak
+Bulung’ur
+Bukhara
+Beshkent
+Boysun
+Oqtosh
+Zafar
+Yaypan
+Yangiyŭl
+Yangiyer
+Yangirabot
+Yangiqo‘rg‘on
+Yangiobod
+Wobkent
+Uychi
+Urganch
+Dashtobod
+Uchqŭrghon Shahri
+Tŭytepa
+Tŭragŭrghon
+Toshloq
+Tashkent
+Toshbuloq
+Sirdaryo
+Showot
+Shofirkon
+Salor
+Qŭshkŭpir
+Qo‘qon
+Piskent
+Payshanba
+Parkent
+Pop
+Paxtakor
+Olmaliq
+Ohangaron
+Nurota
+Novyy Turtkul’
+Navoiy
+Namangan
+Marg‘ilon
+Manghit
+Asaka
+Quvasoy
+Qŭrghontepa
+Kirguli
+Qibray
+Khŭjaobod
+Khiwa
+Haqqulobod
+Kosonsoy
+Jizzax
+Iskandar
+Hazorasp
+Gurlan
+Guliston
+Ghijduwon
+G‘azalkent
+Gagarin
+Fergana
+Dŭstlik
+Chust Shahri
+Chirchiq
+Chinoz
+Chortoq
+Bŭka
+Beshariq
+Beruniy
+Bektemir
+Bekobod
+Angren
+Andijon
+Oltiariq
+Quva
+Navoiy
+Vatican City
+Kingstown
+Kingstown Park
+La Asunción
+Anaco
+Alto Barinas
+Zaraza
+Yaritagua
+Villa de Cura
+Villa Bruzual
+Valle de La Pascua
+Valera
+Valencia
+Upata
+Turmero
+Tucupita
+Trujillo
+Tinaquillo
+Táriba
+Santa Teresa
+Santa Rita
+Santa Elena de Uairén
+San Mateo
+San Juan de los Morros
+San Juan de Colón
+San José de Guanipa
+San Joaquín
+San Felipe
+San Cristóbal
+San Carlos del Zulia
+San Carlos
+San Antonio del Táchira
+San Antonio de Los Altos
+Rubio
+La Villa del Rosario
+Quíbor
+Punto Fijo
+Punta Cardón
+Puerto La Cruz
+Puerto Cabello
+Puerto Ayacucho
+Porlamar
+Petare
+Palo Negro
+Ocumare del Tuy
+Nirgua
+Mucumpiz
+Morón
+Mérida
+Mariara
+Maracay
+Maracaibo
+Maiquetía
+Machiques
+Los Teques
+Los Rastrojos
+Los Dos Caminos
+La Victoria
+Las Tejerías
+Lagunillas
+La Guaira
+Juan Griego
+Güiria
+Güigüe
+Guatire
+Guarenas
+Guanare
+Guacara
+El Vigía
+El Tocuyo
+El Tigre
+El Limón
+El Hatillo
+Ejido
+Cumaná
+Cúa
+Coro
+Ciudad Guayana
+Ciudad Bolívar
+Chivacoa
+Charallave
+Chacao
+Tacarigua
+Caucagüito
+Catia La Mar
+Carúpano
+Carrizal
+Carora
+Caracas
+Caraballeda
+Cantaura
+Calabozo
+Cagua
+Cabimas
+Baruta
+Barquisimeto
+Barinitas
+Barinas
+Barcelona
+Araure
+Altagracia de Orituco
+Acarigua
+Maturín
+La Fría
+El Cafetal
+Caucaguita
+La Dolorita
+Guasdualito
+San Fernando de Apure
+Road Town
+Tortola
+Charlotte Amalie
+Saint Croix
+Yên Vinh
+Yên Bái
+Vũng Tàu
+Vị Thanh
+Vĩnh Yên
+Vĩnh Long
+Vinh
+Việt Trì
+Thành Phố Uông Bí
+Tuy Hòa
+Thành Phố Tuyên Quang
+Trà Vinh
+Thủ Dầu Một
+Ho Chi Minh City
+Thanh Hóa
+Thành Phố Thái Nguyên
+Thành Phố Thái Bình
+Tây Ninh
+Tân An
+Tam Kỳ
+Sơn Tây
+Sơn La
+Sông Cầu
+Sóc Trăng
+Sa Pá
+Sadek
+Rạch Giá
+Qui Nhon
+Quảng Ngãi
+Pleiku
+Thành Phố Phủ Lý
+Phú Khương
+Phan Thiết
+Phan Rang-Tháp Chàm
+Thành Phố Ninh Bình
+Nha Trang
+Thành Phố Nam Định
+Mỹ Tho
+Móng Cái
+Long Xuyên
+Lào Cai
+Thành Phố Lạng Sơn
+La Gi
+Kon Tum
+Hưng Yên
+Huế
+Thành Phố Hạ Long
+Hội An
+Thành Phố Hòa Bình
+Hà Tĩnh
+Hà Tiên
+Hanoi
+Haiphong
+Thành Phố Hải Dương
+Thành Phố Hà Giang
+Hà Đông
+Don Luan
+Kwang Binh
+Ðông Hà
+Dien Bien Phu
+Da Nang
+Ðà Lạt
+Củ Chi
+Cho Dok
+Cát Bà
+Cao Lãnh
+Thành Phố Cao Bằng
+Cần Thơ
+Cần Giờ
+Cần Giuộc
+Cam Ranh
+Cẩm Phả Mines
+Cà Mau
+Buôn Ma Thuột
+Bỉm Sơn
+Biên Hòa
+Bến Tre
+Bảo Lộc
+Bắc Ninh
+Thành phố Bạc Liêu
+Bắc Giang
+Bắc Kạn
+Đinh Văn
+Port-Vila
+Mata-Utu
+Apia
+Zvečan
+Vushtrri
+Vitina
+Ferizaj
+Suva Reka
+Shtime
+Prizren
+Pristina
+Podujeva
+Pejë
+Orahovac
+Llazicë
+Leposaviq
+Mitrovicë
+Kosovo Polje
+Istok
+Gjilan
+Glogovac
+Dragash
+Deçan
+Gjakovë
+Zinjibār
+Zabīd
+Yarīm
+Ta‘izz
+Sayyān
+Sanaa
+Saḩar
+Sa'dah
+Ma'rib
+Laḩij
+Ibb
+Ḩajjah
+Dhī as Sufāl
+Dhamār
+Bayt al Faqīh
+Bājil
+Ataq
+‘Amrān
+Al Mukallā
+Al Ḩudaydah
+Al Ḩazm
+Al Bayḑā’
+Aden
+Mamoudzou
+Dzaoudzi
+Koungou
+Roodepoort
+Zeerust
+Wolmaransstad
+White River
+Witbank
+Westonaria
+Wesselsbron
+Welkom
+Warrenton
+Warmbaths
+Vryheid
+Vryburg
+Volksrust
+Virginia
+Viljoenskroon
+Vereeniging
+Vanderbijlpark
+Upington
+Mthatha
+Umkomaas
+Ulundi
+Uitenhage
+Tzaneen
+Thohoyandou
+Theunissen
+Thaba Nchu
+Tembisa
+Stutterheim
+Stilfontein
+Stanger
+Standerton
+Springs
+Soweto
+Somerset East
+Siyabuswa
+Senekal
+Secunda
+Scottburgh
+Schweizer-Reneke
+Sasolburg
+Rustenburg
+Richmond
+Richards Bay
+Reitz
+Randfontein
+Queenstown
+Queensdale
+Pretoria
+Mokopane
+Potchefstroom
+Port Shepstone
+Port Elizabeth
+Port Alfred
+Plettenberg Bay
+Piet Retief
+Polokwane
+Pietermaritzburg
+Phuthaditjhaba
+Phalaborwa
+Parys
+Pampierstad
+Oudtshoorn
+Orkney
+Modimolle
+Nkowakowa
+Nigel
+Newcastle
+Nelspruit
+Mpumalanga
+Mpophomeni
+Mossel Bay
+Mondlo
+Mmabatho
+Middelburg
+Middelburg
+Messina
+Margate
+Mabopane
+Lydenburg
+Louis Trichardt
+Lichtenburg
+Lebowakgomo
+Lady Frere
+Ladybrand
+Kutloanong
+Kruisfontein
+Krugersdorp
+Kroonstad
+Kriel
+Komatipoort
+Kokstad
+Knysna
+Klerksdorp
+Kimberley
+Johannesburg
+Howick
+Hennenman
+Hendrina
+Heilbron
+Heidelberg
+Harrismith
+Grahamstown
+Graaff-Reinet
+Giyani
+George
+Ga-Rankuwa
+Fort Beaufort
+Fochville
+eSikhawini
+Ermelo
+Empangeni
+eMbalenhle
+East London
+Durban
+Dundee
+Duiwelskloof
+Driefontein
+Delmas
+De Aar
+Cullinan
+Cradock
+Christiana
+Carletonville
+Butterworth
+Bronkhorstspruit
+Brits
+Brakpan
+Botshabelo
+Bothaville
+Boksburg
+Bloemhof
+Bloemfontein
+Bhisho
+Bethlehem
+Bethal
+Benoni
+Beaufort West
+Barberton
+Ballitoville
+Balfour
+Allanridge
+Aliwal North
+Ekangala
+Midrand
+Centurion
+Worcester
+Stellenbosch
+Saldanha
+Paarl
+Malmesbury
+Lansdowne
+Kraaifontein
+Hermanus
+Grabouw
+Ceres
+Cape Town
+Atlantis
+Rondebosch
+Retreat
+Diepsloot
+Nchelenge
+Mbala
+Kawambwa
+Siavonga
+Sesheke
+Samfya
+Petauke
+Ndola
+Mumbwa
+Mufulira
+Mpika
+Monze
+Mongu
+Mazabuka
+Mansa
+Lusaka
+Luanshya
+Livingstone
+Kitwe
+Kasama
+Kapiri Mposhi
+Kansanshi
+Kalulushi
+Kafue
+Kabwe
+Choma
+Chipata
+Chingola
+Chililabombwe
+Zvishavane
+Victoria Falls
+Shurugwi
+Rusape
+Redcliff
+Norton
+Mutare
+Masvingo
+Marondera
+Kwekwe
+Karoi
+Kariba
+Kadoma
+Hwange
+Harare
+Gweru
+Gokwe
+Chiredzi
+Chipinge
+Chinhoyi
+Chegutu
+Bulawayo
+Bindura
+Beitbridge
+Epworth
+Chitungwiza

--- a/troubleshooting/external-enrichment/README.md
+++ b/troubleshooting/external-enrichment/README.md
@@ -1,0 +1,7 @@
+# Lab: Advanced Tuning & Troubleshooting: External Enrichment
+
+...
+
+-----
+
+[**Back to Tuning & Troubleshooting Labs Overview**](../README.md)

--- a/troubleshooting/external-enrichment/build.gradle
+++ b/troubleshooting/external-enrichment/build.gradle
@@ -1,4 +1,3 @@
-group = 'com.ververica'
 mainClassName = 'com.ververica.flink.training.exercises.TroubledStreamingJob'
 
 dependencies {

--- a/troubleshooting/external-enrichment/build.gradle
+++ b/troubleshooting/external-enrichment/build.gradle
@@ -1,0 +1,20 @@
+group = 'com.ververica'
+mainClassName = 'com.ververica.flink.training.exercises.TroubledStreamingJob'
+
+dependencies {
+    flinkShadowJar "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
+    flinkShadowJar "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
+
+    implementation project(path: ':troubleshooting:common')
+    // transitive dependencies for flinkShadowJar need to be defined above
+    // (the alternative of using configuration: 'shadow' does not work there because that adds a dependency on
+    // the jar file, not the sources)
+    flinkShadowJar project(path: ':troubleshooting:common', transitive: false)
+}
+
+sourceSets {
+    main.java.srcDirs += 'src/provided/java'
+    tasks.withType(ScalaCompile) { 
+        main.scala.srcDirs += 'src/provided/scala'
+    }
+}

--- a/troubleshooting/external-enrichment/src/main/java/com/ververica/flink/training/exercises/ExternalEnrichmentJob.java
+++ b/troubleshooting/external-enrichment/src/main/java/com/ververica/flink/training/exercises/ExternalEnrichmentJob.java
@@ -1,0 +1,226 @@
+package com.ververica.flink.training.exercises;
+
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.functions.RichFlatMapFunction;
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.util.Collector;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ververica.flink.training.common.FakeKafkaRecord;
+import com.ververica.flink.training.common.SourceUtils;
+import com.ververica.flink.training.provided.EnrichedMeasurement;
+import com.ververica.flink.training.provided.SimpleMeasurement;
+import com.ververica.flink.training.provided.TemperatureClient;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import static com.ververica.flink.training.common.EnvironmentUtils.createConfiguredEnvironment;
+import static com.ververica.flink.training.common.EnvironmentUtils.isLocal;
+
+/**
+ * Troubled streaming job that enriches data from an external component.
+ */
+public class ExternalEnrichmentJob {
+
+	/**
+	 * Creates and starts the troubled streaming job.
+	 *
+	 * @throws Exception if the application is misconfigured or fails during job submission
+	 */
+	public static void main(String[] args) throws Exception {
+		ParameterTool parameters = ParameterTool.fromArgs(args);
+
+		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
+
+		//Time Characteristics
+		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		env.getConfig().setAutoWatermarkInterval(100);
+		env.setBufferTimeout(10);
+
+		//Checkpointing Configuration
+		env.enableCheckpointing(5000);
+		env.getCheckpointConfig().setMinPauseBetweenCheckpoints(4000);
+
+		DataStream<SimpleMeasurement> sourceStream = env
+				.addSource(SourceUtils.createFakeKafkaSource())
+				.name("FakeKafkaSource")
+				.uid("FakeKafkaSource")
+				.assignTimestampsAndWatermarks(
+						WatermarkStrategy
+								.<FakeKafkaRecord>forBoundedOutOfOrderness(Duration.ofMillis(250))
+								.withTimestampAssigner(
+										(element, timestamp) -> element.getTimestamp())
+								.withIdleness(Duration.ofSeconds(1)))
+				.name("Watermarks")
+				.uid("Watermarks")
+				.flatMap(new MeasurementDeserializer())
+				.name("Deserialization")
+				.uid("Deserialization");
+
+		DataStream<EnrichedMeasurement> enrichedStream = sourceStream
+				.keyBy(SimpleMeasurement::getLocation)
+				.map(new EnrichMeasurementWithTemperature(10000))
+				.name("Enrichment");
+
+		if (isLocal(parameters)) {
+			enrichedStream.print()
+					.name("NormalOutput")
+					.uid("NormalOutput")
+					.disableChaining();
+		} else {
+			enrichedStream.addSink(new DiscardingSink<>())
+					.name("NormalOutput")
+					.uid("NormalOutput")
+					.disableChaining();
+		}
+
+		env.execute(ExternalEnrichmentJob.class.getSimpleName());
+	}
+
+	/**
+	 * Deserializes the JSON Kafka message.
+	 */
+	public static class MeasurementDeserializer extends
+			RichFlatMapFunction<FakeKafkaRecord, SimpleMeasurement> {
+		private static final long serialVersionUID = 4L;
+
+		private Counter numInvalidRecords;
+		private transient ObjectMapper instance;
+
+		@Override
+		public void open(final Configuration parameters) throws Exception {
+			super.open(parameters);
+			numInvalidRecords = getRuntimeContext().getMetricGroup().counter("numInvalidRecords");
+			ObjectMapper objectMapper = new ObjectMapper();
+			objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+			instance = objectMapper;
+		}
+
+		@Override
+		public void flatMap(
+				final FakeKafkaRecord kafkaRecord,
+				final Collector<SimpleMeasurement> out) {
+			final SimpleMeasurement node;
+			try {
+				node = deserialize(kafkaRecord.getValue());
+			} catch (IOException e) {
+				numInvalidRecords.inc();
+				return;
+			}
+			out.collect(node);
+		}
+
+		private SimpleMeasurement deserialize(final byte[] bytes) throws IOException {
+			return instance.readValue(bytes, SimpleMeasurement.class);
+		}
+	}
+
+	public static class EnrichMeasurementWithTemperature extends
+			RichMapFunction<SimpleMeasurement, EnrichedMeasurement> {
+		private static final long serialVersionUID = 1L;
+
+		private transient TemperatureClient temperatureClient;
+		private transient Map<String, TemperatureCacheEntry> cache;
+
+		private final int cacheExpiryMs;
+		private Counter cacheSizeMetric;
+		private Counter servedFromCacheMetric;
+
+		/**
+		 * Creates a new enrichment function with a (local) cache that expires after the given
+		 * number of milliseconds.
+		 */
+		public EnrichMeasurementWithTemperature(int cacheExpiryMs) {
+			this.cacheExpiryMs = cacheExpiryMs;
+		}
+
+		@Override
+		public void open(final Configuration parameters) {
+			temperatureClient = new TemperatureClient();
+			cache = new HashMap<>();
+			servedFromCacheMetric = getRuntimeContext().getMetricGroup()
+					.counter("temperatureRequestsServedFromCache");
+			cacheSizeMetric = getRuntimeContext().getMetricGroup().counter("temperatureCacheSize");
+		}
+
+		@Override
+		public EnrichedMeasurement map(final SimpleMeasurement measurement) {
+			String location = measurement.getLocation();
+			final float temperature;
+
+			TemperatureCacheEntry cachedTemperature = cache.get(location);
+			if (cachedTemperature != null && !cachedTemperature.isTooOld(cacheExpiryMs)) {
+				temperature = cachedTemperature.value;
+				servedFromCacheMetric.inc();
+			} else {
+				temperature = temperatureClient.getTemperatureFor(location);
+				TemperatureCacheEntry newEntry =
+						new TemperatureCacheEntry(System.currentTimeMillis(), temperature);
+				if (cache.put(location, newEntry) == null) {
+					cacheSizeMetric.inc();
+				}
+			}
+
+			return new EnrichedMeasurement(measurement, temperature);
+		}
+
+		private static class TemperatureCacheEntry {
+			long timestamp;
+			float value;
+
+			/**
+			 * Creates a new temperature cache entry.
+			 */
+			public TemperatureCacheEntry(final long timestamp, final float value) {
+				this.timestamp = timestamp;
+				this.value = value;
+			}
+
+			/**
+			 * Returns <code>true</code> if the entry was created more than <code>expiryMs</code>
+			 * milliseconds ago.
+			 */
+			public boolean isTooOld(int expiryMs) {
+				return System.currentTimeMillis() - timestamp >= expiryMs;
+			}
+
+			@Override
+			public boolean equals(Object o) {
+				if (this == o) {
+					return true;
+				}
+				if (o == null || getClass() != o.getClass()) {
+					return false;
+				}
+				TemperatureCacheEntry that = (TemperatureCacheEntry) o;
+				return timestamp == that.timestamp &&
+						Float.compare(that.value, value) == 0;
+			}
+
+			@Override
+			public int hashCode() {
+				return Objects.hash(timestamp, value);
+			}
+
+			@Override
+			public String toString() {
+				return "TemperatureCacheEntry{" +
+						"timestamp=" + timestamp +
+						", value=" + value +
+						'}';
+			}
+		}
+	}
+}

--- a/troubleshooting/external-enrichment/src/main/java/com/ververica/flink/training/exercises/ExternalEnrichmentJob.java
+++ b/troubleshooting/external-enrichment/src/main/java/com/ververica/flink/training/exercises/ExternalEnrichmentJob.java
@@ -6,7 +6,6 @@ import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Counter;
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
@@ -44,8 +43,7 @@ public class ExternalEnrichmentJob {
 
 		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
 
-		//Time Characteristics
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		//Timing Configuration
 		env.getConfig().setAutoWatermarkInterval(100);
 		env.setBufferTimeout(10);
 

--- a/troubleshooting/external-enrichment/src/main/resources/log4j.properties
+++ b/troubleshooting/external-enrichment/src/main/resources/log4j.properties
@@ -1,0 +1,23 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+log4j.rootLogger=INFO, console
+
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{HH:mm:ss,SSS} %-5p %-60c %x - %m%n

--- a/troubleshooting/external-enrichment/src/provided/java/com/ververica/flink/training/provided/EnrichedMeasurement.java
+++ b/troubleshooting/external-enrichment/src/provided/java/com/ververica/flink/training/provided/EnrichedMeasurement.java
@@ -1,0 +1,64 @@
+package com.ververica.flink.training.provided;
+
+import java.util.Objects;
+
+@SuppressWarnings({"unused", "RedundantSuppression"})
+public class EnrichedMeasurement extends SimpleMeasurement {
+
+	private float temperature;
+
+	public EnrichedMeasurement() {
+	}
+
+	public EnrichedMeasurement(
+			final int sensorId,
+			final double value,
+			final String location,
+			final float temperature) {
+		super(sensorId, value, location);
+		this.temperature = temperature;
+	}
+
+	public EnrichedMeasurement(
+			final SimpleMeasurement measurement,
+			final float temperature) {
+		super(measurement);
+		this.temperature = temperature;
+	}
+
+	public float getTemperature() {
+		return temperature;
+	}
+
+	public void setTemperature(float temperature) {
+		this.temperature = temperature;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		EnrichedMeasurement that = (EnrichedMeasurement) o;
+		return Float.compare(that.temperature, temperature) == 0;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), temperature);
+	}
+
+	@Override
+	public String toString() {
+		return "EnrichedMeasurement{" +
+				super.toString() +
+				", temperature=" + temperature +
+				'}';
+	}
+}

--- a/troubleshooting/external-enrichment/src/provided/java/com/ververica/flink/training/provided/SimpleMeasurement.java
+++ b/troubleshooting/external-enrichment/src/provided/java/com/ververica/flink/training/provided/SimpleMeasurement.java
@@ -1,0 +1,82 @@
+package com.ververica.flink.training.provided;
+
+import java.util.Objects;
+
+@SuppressWarnings({"unused", "RedundantSuppression"})
+public class SimpleMeasurement {
+
+	private int sensorId;
+	private double value;
+	private String location;
+
+	public SimpleMeasurement() {
+	}
+
+	public SimpleMeasurement(
+			final int sensorId,
+			final double value,
+			final String location) {
+		this.sensorId = sensorId;
+		this.value = value;
+		this.location = location;
+	}
+
+	public SimpleMeasurement(SimpleMeasurement other) {
+		this.sensorId = other.getSensorId();
+		this.value = other.getValue();
+		this.location = other.getLocation();
+	}
+
+	public int getSensorId() {
+		return sensorId;
+	}
+
+	public void setSensorId(final int sensorId) {
+		this.sensorId = sensorId;
+	}
+
+	public double getValue() {
+		return value;
+	}
+
+	public void setValue(final double value) {
+		this.value = value;
+	}
+
+	public String getLocation() {
+		return location;
+	}
+
+	public void setLocation(final String location) {
+		this.location = location;
+	}
+
+	@Override
+	public boolean equals(final Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		final SimpleMeasurement
+				that = (SimpleMeasurement) o;
+		return sensorId == that.sensorId &&
+				Double.compare(that.value, value) == 0 &&
+				Objects.equals(location, that.location);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(sensorId, value, location);
+	}
+
+	@Override
+	public String toString() {
+		return "SimpleMeasurement{" +
+				"sensorId=" + sensorId +
+				", value=" + value +
+				", location='" + location + '\'' +
+				'}';
+	}
+}

--- a/troubleshooting/external-enrichment/src/provided/java/com/ververica/flink/training/provided/TemperatureClient.java
+++ b/troubleshooting/external-enrichment/src/provided/java/com/ververica/flink/training/provided/TemperatureClient.java
@@ -1,0 +1,61 @@
+package com.ververica.flink.training.provided;
+
+import com.ververica.flink.training.common.DoNotChangeThis;
+
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * Client to retrieve temperatures from an external service.
+ */
+@DoNotChangeThis
+public class TemperatureClient {
+
+	private static final ExecutorService pool = Executors.newFixedThreadPool(30,
+			new ThreadFactory() {
+				private final ThreadFactory threadFactory = Executors.defaultThreadFactory();
+
+				@Override
+				public Thread newThread(Runnable r) {
+					Thread thread = threadFactory.newThread(r);
+					thread.setName("temp-client-" + thread.getName());
+					return thread;
+				}
+			});
+
+	private static final float TEMPERATURE_LIMIT = 100;
+	private final Random rand = new Random(42);
+
+    /**
+     * Gets the temperature for the given location.
+     */
+	public Float getTemperatureFor(String location) {
+		return new TemperatureSupplier().get();
+	}
+
+    /**
+     * Asynchronous getter for the temperature for the given location.
+     */
+	public void asyncGetTemperatureFor(String location, Consumer<Float> callback) {
+		CompletableFuture.supplyAsync(new TemperatureSupplier(), pool)
+				.thenAcceptAsync(callback,
+						org.apache.flink.runtime.concurrent.Executors.directExecutor());
+	}
+
+	private class TemperatureSupplier implements Supplier<Float> {
+		@Override
+		public Float get() {
+			try {
+				Thread.sleep(rand.nextInt(5));
+			} catch (InterruptedException e) {
+				//Swallowing Interruption here
+			}
+			return rand.nextFloat() * TEMPERATURE_LIMIT;
+		}
+	}
+}

--- a/troubleshooting/external-enrichment/src/solution/java/com/ververica/flink/training/solutions/ExternalEnrichmentJobSolution.java
+++ b/troubleshooting/external-enrichment/src/solution/java/com/ververica/flink/training/solutions/ExternalEnrichmentJobSolution.java
@@ -5,7 +5,6 @@ import org.apache.flink.api.common.functions.RichFlatMapFunction;
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Counter;
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.AsyncDataStream;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -49,8 +48,7 @@ public class ExternalEnrichmentJobSolution {
 
 		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
 
-		//Time Characteristics
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		//Timing Configuration
 		env.getConfig().setAutoWatermarkInterval(100);
 		env.setBufferTimeout(10);
 

--- a/troubleshooting/external-enrichment/src/solution/java/com/ververica/flink/training/solutions/ExternalEnrichmentJobSolution.java
+++ b/troubleshooting/external-enrichment/src/solution/java/com/ververica/flink/training/solutions/ExternalEnrichmentJobSolution.java
@@ -1,0 +1,261 @@
+package com.ververica.flink.training.solutions;
+
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.functions.RichFlatMapFunction;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.api.datastream.AsyncDataStream;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.async.ResultFuture;
+import org.apache.flink.streaming.api.functions.async.RichAsyncFunction;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.util.Collector;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ververica.flink.training.common.FakeKafkaRecord;
+import com.ververica.flink.training.common.SourceUtils;
+import com.ververica.flink.training.provided.EnrichedMeasurement;
+import com.ververica.flink.training.provided.SimpleMeasurement;
+import com.ververica.flink.training.provided.TemperatureClient;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import static com.ververica.flink.training.common.EnvironmentUtils.createConfiguredEnvironment;
+import static com.ververica.flink.training.common.EnvironmentUtils.isLocal;
+
+/**
+ * Troubled streaming job that enriches data from an external component.
+ */
+public class ExternalEnrichmentJobSolution {
+
+	/**
+	 * Creates and starts the troubled streaming job.
+	 *
+	 * @throws Exception if the application is misconfigured or fails during job submission
+	 */
+	public static void main(String[] args) throws Exception {
+		ParameterTool parameters = ParameterTool.fromArgs(args);
+
+		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
+
+		//Time Characteristics
+		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		env.getConfig().setAutoWatermarkInterval(100);
+		env.setBufferTimeout(10);
+
+		//Checkpointing Configuration
+		env.enableCheckpointing(5000);
+		env.getCheckpointConfig().setMinPauseBetweenCheckpoints(4000);
+
+		DataStream<SimpleMeasurement> sourceStream = env
+				.addSource(SourceUtils.createFakeKafkaSource())
+				.name("FakeKafkaSource")
+				.uid("FakeKafkaSource")
+				.assignTimestampsAndWatermarks(
+						WatermarkStrategy
+								.<FakeKafkaRecord>forBoundedOutOfOrderness(Duration.ofMillis(250))
+								.withTimestampAssigner(
+										(element, timestamp) -> element.getTimestamp())
+								.withIdleness(Duration.ofSeconds(1)))
+				.name("Watermarks")
+				.uid("Watermarks")
+				.flatMap(new MeasurementDeserializer())
+				.name("Deserialization")
+				.uid("Deserialization");
+
+		DataStream<EnrichedMeasurement> enrichedStream = AsyncDataStream.unorderedWait(
+				sourceStream.keyBy(SimpleMeasurement::getLocation),
+				new EnrichMeasurementWithTemperatureAsync(10000),
+				0,
+				TimeUnit.MILLISECONDS,
+				20)
+				.name("Enrichment");
+
+		if (isLocal(parameters)) {
+			enrichedStream.print()
+					.name("NormalOutput")
+					.uid("NormalOutput")
+					.disableChaining();
+		} else {
+			enrichedStream.addSink(new DiscardingSink<>())
+					.name("NormalOutput")
+					.uid("NormalOutput")
+					.disableChaining();
+		}
+
+		env.execute(ExternalEnrichmentJobSolution.class.getSimpleName());
+	}
+
+	/**
+	 * Deserializes the JSON Kafka message.
+	 */
+	public static class MeasurementDeserializer extends
+			RichFlatMapFunction<FakeKafkaRecord, SimpleMeasurement> {
+		private static final long serialVersionUID = 4L;
+
+		private Counter numInvalidRecords;
+		private transient ObjectMapper instance;
+
+		@Override
+		public void open(final Configuration parameters) throws Exception {
+			super.open(parameters);
+			numInvalidRecords = getRuntimeContext().getMetricGroup().counter("numInvalidRecords");
+			ObjectMapper objectMapper = new ObjectMapper();
+			objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+			instance = objectMapper;
+		}
+
+		@Override
+		public void flatMap(
+				final FakeKafkaRecord kafkaRecord,
+				final Collector<SimpleMeasurement> out) {
+			final SimpleMeasurement node;
+			try {
+				node = deserialize(kafkaRecord.getValue());
+			} catch (IOException e) {
+				numInvalidRecords.inc();
+				return;
+			}
+			out.collect(node);
+		}
+
+		private SimpleMeasurement deserialize(final byte[] bytes) throws IOException {
+			return instance.readValue(bytes, SimpleMeasurement.class);
+		}
+	}
+
+	public static class EnrichMeasurementWithTemperatureAsync extends
+			RichAsyncFunction<SimpleMeasurement, EnrichedMeasurement> {
+		private static final long serialVersionUID = 2L;
+
+		private transient TemperatureClient temperatureClient;
+		private transient Map<String, TemperatureCacheEntry> cache;
+
+		private final int cacheExpiryMs;
+		private Counter cacheSizeMetric;
+		private Counter servedFromCacheMetric;
+
+		/**
+		 * Creates a new enrichment function with a (local) cache that expires after the given
+		 * number of milliseconds.
+		 */
+		public EnrichMeasurementWithTemperatureAsync(int cacheExpiryMs) {
+			this.cacheExpiryMs = cacheExpiryMs;
+		}
+
+		@Override
+		public void open(final Configuration parameters) {
+			temperatureClient = new TemperatureClient();
+			cache = new HashMap<>();
+			servedFromCacheMetric = getRuntimeContext().getMetricGroup()
+					.counter("temperatureRequestsServedFromCache");
+			cacheSizeMetric = getRuntimeContext().getMetricGroup().counter("temperatureCacheSize");
+		}
+
+		@Override
+		public void asyncInvoke(
+				SimpleMeasurement measurement,
+				ResultFuture<EnrichedMeasurement> resultFuture) {
+			String location = measurement.getLocation();
+			final float temperature;
+
+			TemperatureCacheEntry cachedTemperature = cache.get(location);
+			if (cachedTemperature != null && !cachedTemperature.isTooOld(cacheExpiryMs)) {
+				temperature = cachedTemperature.value;
+				EnrichedMeasurement enrichedMeasurement =
+						new EnrichedMeasurement(measurement, temperature);
+				resultFuture.complete(Collections.singleton(enrichedMeasurement));
+				servedFromCacheMetric.inc();
+			} else {
+				temperatureClient.asyncGetTemperatureFor(
+						measurement.getLocation(),
+						new TemperatureCallBack(resultFuture, measurement, location));
+			}
+		}
+
+		private static class TemperatureCacheEntry {
+			long timestamp;
+			float value;
+
+			/**
+			 * Creates a new temperature cache entry.
+			 */
+			public TemperatureCacheEntry(final long timestamp, final float value) {
+				this.timestamp = timestamp;
+				this.value = value;
+			}
+
+			/**
+			 * Returns <code>true</code> if the entry was created more than <code>expiryMs</code>
+			 * milliseconds ago.
+			 */
+			public boolean isTooOld(int expiryMs) {
+				return System.currentTimeMillis() - timestamp >= expiryMs;
+			}
+
+			@Override
+			public boolean equals(Object o) {
+				if (this == o) {
+					return true;
+				}
+				if (o == null || getClass() != o.getClass()) {
+					return false;
+				}
+				TemperatureCacheEntry that = (TemperatureCacheEntry) o;
+				return timestamp == that.timestamp &&
+						Float.compare(that.value, value) == 0;
+			}
+
+			@Override
+			public int hashCode() {
+				return Objects.hash(timestamp, value);
+			}
+
+			@Override
+			public String toString() {
+				return "TemperatureCacheEntry{" +
+						"timestamp=" + timestamp +
+						", value=" + value +
+						'}';
+			}
+		}
+
+		private class TemperatureCallBack implements Consumer<Float> {
+			private final ResultFuture<EnrichedMeasurement> resultFuture;
+			private final SimpleMeasurement measurement;
+			private final String location;
+
+			public TemperatureCallBack(
+					final ResultFuture<EnrichedMeasurement> resultFuture,
+					final SimpleMeasurement measurement, final String location) {
+				this.resultFuture = resultFuture;
+				this.measurement = measurement;
+				this.location = location;
+			}
+
+			@Override
+			public void accept(final Float temperature) {
+				EnrichedMeasurement enrichedMeasurement =
+						new EnrichedMeasurement(measurement, temperature);
+				resultFuture.complete(Collections.singleton(enrichedMeasurement));
+
+				TemperatureCacheEntry newEntry =
+						new TemperatureCacheEntry(System.currentTimeMillis(), temperature);
+				if (cache.put(location, newEntry) == null) {
+					cacheSizeMetric.inc();
+				}
+			}
+		}
+	}
+}

--- a/troubleshooting/introduction/README.md
+++ b/troubleshooting/introduction/README.md
@@ -1,0 +1,48 @@
+# Lab: Introduction to Tuning & Troubleshooting
+
+## Introduction
+
+This lab provides the basis of the hands-on part of the "Introduction to Apache Flink Tuning & Troubleshooting"
+training by Ververica. Please follow the [Setup Instructions](../../README.md#setup-your-development-environment) first
+and then continue reading here.
+
+### Infrastructure
+
+During the training, participants will be asked to run the Flink job `TroubledStreamingJob` locally as well as on
+Ververica Platform.
+
+### Running Locally
+
+Executing `com.ververica.flink.training.exercises.TroubledStreamingJob#main()` with `--local true` will create a local
+Flink cluster running the troubled streaming job.
+
+Once running, you can access Flink's Web UI via http://localhost:8081.
+
+You can also specify the parallelism via `--parallelism <number>` if needed (may be valuable in local setups).
+
+### The Flink Job
+
+This simple Flink job reads measurement data from a Kafka topic with eight partitions. For the purpose of this training,
+the `KafkaConsumer` is replaced by `FakeKafkaSource`. The result of a calculation based on the measurement value is
+averaged over 1 second. The overall flow is depicted below:
+
+```
++-------------------+     +-----------------------+     +-----------------+     +----------------------+     +--------------------+
+|                   |     |                       |     |                 |     |                      |     |                    |
+| Fake Kafka Source | --> | Watermarks/Timestamps | --> | Deserialization | --> | Windowed Aggregation | --> | Sink: NormalOutput |
+|                   |     |                       |     |                 |     |                      |     |                    |
++-------------------+     +-----------------------+     +-----------------+     +----------------------+     +--------------------+
+                                                                                            \
+                                                                                             \               +--------------------+
+                                                                                              \              |                    |
+                                                                                               +-----------> | Sink: LateDataSink |    
+                                                                                                             |                    |
+                                                                                                             +--------------------+
+```
+
+In local mode, the sinks print their values on `stdout` (NormalOutput) and `stderr` (LateDataSink), which simplifies debugging.
+Otherwise, a `DiscardingSink` is used for each sink.
+
+-----
+
+[**Back to Tuning & Troubleshooting Labs Overview**](../README.md)

--- a/troubleshooting/introduction/README.md
+++ b/troubleshooting/introduction/README.md
@@ -13,10 +13,19 @@ Ververica Platform.
 
 ### Running Locally
 
-Executing `com.ververica.flink.training.exercises.TroubledStreamingJob#main()` with `--local true` will create a local
-Flink cluster running the troubled streaming job.
+Executing `com.ververica.flink.training.exercises.TroubledStreamingJob#main()` should create a local Flink cluster
+running the troubled streaming job and serving Flink's Web UI at http://localhost:8081.
+If port 8081 is blocked and Flink won't start, or if the Web UI is not showing up, you can also configure and force
+the local mode via the `--local` program argument and set the port the Web UI is listening on:
 
-Once running, you can access Flink's Web UI via http://localhost:8081.
+* `--local -1`: defaults via `StreamExecutionEnvironment.getExecutionEnvironment()` (no Web UI, no extra settings)
+* `--local <port|port-range>`: uses `StreamExecutionEnvironment.createLocalEnvironmentWithWebUI()` and
+  - sets a `fixedDelayRestart` failure strategy with 15s delay and infinite restarts
+  - configures the Web UI to listen on a port in the given range
+    If more than one port is given, please find the port in the logs from this line:
+```
+12:11:04.062 [main] INFO o.a.f.r.d.DispatcherRestEndpoint - Web frontend listening at http://localhost:8081.
+```
 
 You can also specify the parallelism via `--parallelism <number>` if needed (may be valuable in local setups).
 

--- a/troubleshooting/introduction/build.gradle
+++ b/troubleshooting/introduction/build.gradle
@@ -1,0 +1,13 @@
+group = 'com.ververica'
+mainClassName = 'com.ververica.flink.training.exercises.TroubledStreamingJob'
+
+dependencies {
+    flinkShadowJar "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
+    flinkShadowJar "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
+
+    implementation project(path: ':troubleshooting:common')
+    // transitive dependencies for flinkShadowJar need to be defined above
+    // (the alternative of using configuration: 'shadow' does not work there because that adds a dependency on
+    // the jar file, not the sources)
+    flinkShadowJar project(path: ':troubleshooting:common', transitive: false)
+}

--- a/troubleshooting/introduction/build.gradle
+++ b/troubleshooting/introduction/build.gradle
@@ -1,4 +1,3 @@
-group = 'com.ververica'
 mainClassName = 'com.ververica.flink.training.exercises.TroubledStreamingJob'
 
 dependencies {

--- a/troubleshooting/introduction/src/main/java/com/ververica/flink/training/exercises/TroubledStreamingJob.java
+++ b/troubleshooting/introduction/src/main/java/com/ververica/flink/training/exercises/TroubledStreamingJob.java
@@ -1,0 +1,176 @@
+package com.ververica.flink.training.exercises;
+
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
+import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.streaming.api.functions.timestamps.BoundedOutOfOrdernessTimestampExtractor;
+import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
+import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.OutputTag;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ververica.flink.training.common.FakeKafkaRecord;
+import com.ververica.flink.training.common.SourceUtils;
+import com.ververica.flink.training.common.WindowedMeasurements;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import static com.ververica.flink.training.common.EnvironmentUtils.createConfiguredEnvironment;
+import static com.ververica.flink.training.common.EnvironmentUtils.isLocal;
+
+/**
+ * Troubled streaming job exercise.
+ */
+public class TroubledStreamingJob {
+
+    /**
+     * Creates and starts the troubled streaming job.
+	 *
+	 * @throws Exception if the application is misconfigured or fails during job submission
+     */
+	public static void main(String[] args) throws Exception {
+		ParameterTool parameters = ParameterTool.fromArgs(args);
+
+		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
+
+		//Time Characteristics
+		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		env.getConfig().setAutoWatermarkInterval(2000);
+
+		//Checkpointing Configuration
+		env.enableCheckpointing(5000);
+		env.getCheckpointConfig().setMinPauseBetweenCheckpoints(4000);
+
+		DataStream<JsonNode> sourceStream = env
+				.addSource(SourceUtils.createFakeKafkaSource())
+				.name("FakeKafkaSource")
+				.uid("FakeKafkaSource")
+				.assignTimestampsAndWatermarks(new MeasurementTSExtractor())
+				.name("Watermarks")
+				.uid("Watermarks")
+				.map(new MeasurementDeserializer())
+				.name("Deserialization")
+				.uid("Deserialization");
+
+		OutputTag<JsonNode> lateDataTag = new OutputTag<JsonNode>("late-data") {
+			private static final long serialVersionUID = 33513631677208956L;
+		};
+
+		SingleOutputStreamOperator<WindowedMeasurements> aggregatedPerLocation = sourceStream
+				.keyBy(jsonNode -> jsonNode.get("location").asText())
+				.timeWindow(Time.of(1, TimeUnit.SECONDS))
+				.sideOutputLateData(lateDataTag)
+				.process(new MeasurementWindowAggregatingFunction())
+				.name("WindowedAggregationPerLocation")
+				.uid("WindowedAggregationPerLocation");
+
+		if (isLocal(parameters)) {
+			aggregatedPerLocation.print()
+					.name("NormalOutput")
+					.uid("NormalOutput")
+					.disableChaining();
+			aggregatedPerLocation.getSideOutput(lateDataTag).printToErr()
+					.name("LateDataSink")
+					.uid("LateDataSink")
+					.disableChaining();
+		} else {
+			aggregatedPerLocation.addSink(new DiscardingSink<>())
+					.name("NormalOutput")
+					.uid("NormalOutput")
+					.disableChaining();
+			aggregatedPerLocation.getSideOutput(lateDataTag).addSink(new DiscardingSink<>())
+					.name("LateDataSink")
+					.uid("LateDataSink")
+					.disableChaining();
+		}
+
+		env.execute(TroubledStreamingJob.class.getSimpleName());
+	}
+
+	/**
+	 * Deserializes the JSON Kafka message.
+	 */
+	public static class MeasurementDeserializer extends RichMapFunction<FakeKafkaRecord, JsonNode> {
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public JsonNode map(final FakeKafkaRecord kafkaRecord) throws Exception {
+			return deserialize(kafkaRecord.getValue());
+		}
+
+		private JsonNode deserialize(final byte[] bytes) throws IOException {
+			return ObjectMapperSingleton.getInstance().readValue(bytes, JsonNode.class);
+		}
+	}
+
+	public static class MeasurementTSExtractor
+			extends BoundedOutOfOrdernessTimestampExtractor<FakeKafkaRecord> {
+		private static final long serialVersionUID = 1L;
+
+		MeasurementTSExtractor() {
+			super(Time.of(250, TimeUnit.MILLISECONDS));
+		}
+
+		@Override
+		public long extractTimestamp(final FakeKafkaRecord record) {
+			return record.getTimestamp();
+		}
+	}
+
+	public static class MeasurementWindowAggregatingFunction
+			extends ProcessWindowFunction<JsonNode, WindowedMeasurements, String, TimeWindow> {
+		private static final long serialVersionUID = 1L;
+
+		private static final int EVENT_TIME_LAG_WINDOW_SIZE = 10_000;
+
+		private transient DescriptiveStatisticsHistogram eventTimeLag;
+
+		@Override
+		public void process(
+				final String location,
+				final Context context,
+				final Iterable<JsonNode> input,
+				final Collector<WindowedMeasurements> out) {
+
+			WindowedMeasurements aggregate = new WindowedMeasurements();
+			for (JsonNode record : input) {
+				double result = Double.parseDouble(record.get("value").asText());
+				aggregate.addMeasurement(result);
+			}
+
+			final TimeWindow window = context.window();
+			aggregate.setWindow(window);
+			aggregate.setLocation(location);
+
+			eventTimeLag.update(System.currentTimeMillis() - window.getEnd());
+			out.collect(aggregate);
+		}
+
+		@Override
+		public void open(Configuration parameters) throws Exception {
+			super.open(parameters);
+
+			eventTimeLag = getRuntimeContext().getMetricGroup().histogram("eventTimeLag",
+					new DescriptiveStatisticsHistogram(EVENT_TIME_LAG_WINDOW_SIZE));
+		}
+	}
+
+	private static class ObjectMapperSingleton {
+		static ObjectMapper getInstance() {
+			ObjectMapper objectMapper = new ObjectMapper();
+			objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+			return objectMapper;
+		}
+	}
+}

--- a/troubleshooting/introduction/src/main/java/com/ververica/flink/training/exercises/TroubledStreamingJob.java
+++ b/troubleshooting/introduction/src/main/java/com/ververica/flink/training/exercises/TroubledStreamingJob.java
@@ -4,13 +4,13 @@ import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.timestamps.BoundedOutOfOrdernessTimestampExtractor;
 import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
+import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 import org.apache.flink.util.Collector;
@@ -44,8 +44,7 @@ public class TroubledStreamingJob {
 
 		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
 
-		//Time Characteristics
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		//Timing Configuration
 		env.getConfig().setAutoWatermarkInterval(2000);
 
 		//Checkpointing Configuration
@@ -69,7 +68,7 @@ public class TroubledStreamingJob {
 
 		SingleOutputStreamOperator<WindowedMeasurements> aggregatedPerLocation = sourceStream
 				.keyBy(jsonNode -> jsonNode.get("location").asText())
-				.timeWindow(Time.of(1, TimeUnit.SECONDS))
+				.window(TumblingEventTimeWindows.of(Time.seconds(1)))
 				.sideOutputLateData(lateDataTag)
 				.process(new MeasurementWindowAggregatingFunction())
 				.name("WindowedAggregationPerLocation")

--- a/troubleshooting/introduction/src/main/resources/log4j.properties
+++ b/troubleshooting/introduction/src/main/resources/log4j.properties
@@ -1,0 +1,23 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+log4j.rootLogger=INFO, console
+
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{HH:mm:ss,SSS} %-5p %-60c %x - %m%n

--- a/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/SimpleMeasurement.java
+++ b/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/SimpleMeasurement.java
@@ -1,0 +1,76 @@
+package com.ververica.flink.training.solutions;
+
+import java.util.Objects;
+
+@SuppressWarnings({"unused", "RedundantSuppression"})
+public class SimpleMeasurement {
+
+	private int sensorId;
+	private double value;
+	private String location;
+
+	public SimpleMeasurement() {
+	}
+
+	public SimpleMeasurement(
+			final int sensorId,
+			final double value,
+			final String location) {
+		this.sensorId = sensorId;
+		this.value = value;
+		this.location = location;
+	}
+
+	public int getSensorId() {
+		return sensorId;
+	}
+
+	public void setSensorId(final int sensorId) {
+		this.sensorId = sensorId;
+	}
+
+	public double getValue() {
+		return value;
+	}
+
+	public void setValue(final double value) {
+		this.value = value;
+	}
+
+	public String getLocation() {
+		return location;
+	}
+
+	public void setLocation(final String location) {
+		this.location = location;
+	}
+
+	@Override
+	public boolean equals(final Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		final SimpleMeasurement
+				that = (SimpleMeasurement) o;
+		return sensorId == that.sensorId &&
+				Double.compare(that.value, value) == 0 &&
+				Objects.equals(location, that.location);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(sensorId, value, location);
+	}
+
+	@Override
+	public String toString() {
+		return "SimpleMeasurement{" +
+				"sensorId=" + sensorId +
+				", value=" + value +
+				", location='" + location + '\'' +
+				'}';
+	}
+}

--- a/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution1.java
+++ b/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution1.java
@@ -1,0 +1,194 @@
+package com.ververica.flink.training.solutions;
+
+import org.apache.flink.api.common.functions.RichFlatMapFunction;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
+import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.streaming.api.functions.timestamps.BoundedOutOfOrdernessTimestampExtractor;
+import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
+import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.OutputTag;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ververica.flink.training.common.FakeKafkaRecord;
+import com.ververica.flink.training.common.SourceUtils;
+import com.ververica.flink.training.common.WindowedMeasurements;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import static com.ververica.flink.training.common.EnvironmentUtils.createConfiguredEnvironment;
+import static com.ververica.flink.training.common.EnvironmentUtils.isLocal;
+
+/**
+ * Troubled streaming job evolved on top of {@link com.ververica.flink.training.exercises.TroubledStreamingJob}
+ * by fixing job crashes due to parsing errors.
+ */
+public class TroubledStreamingJobSolution1 {
+
+    /**
+     * Creates and starts the troubled streaming job.
+	 *
+	 * @throws Exception if the application is misconfigured or fails during job submission
+     */
+	public static void main(String[] args) throws Exception {
+		ParameterTool parameters = ParameterTool.fromArgs(args);
+
+		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
+
+		//Time Characteristics
+		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		env.getConfig().setAutoWatermarkInterval(2000);
+
+		//Checkpointing Configuration
+		env.enableCheckpointing(5000);
+		env.getCheckpointConfig().setMinPauseBetweenCheckpoints(4000);
+
+		DataStream<JsonNode> sourceStream = env
+				.addSource(SourceUtils.createFakeKafkaSource())
+				.name("FakeKafkaSource")
+				.uid("FakeKafkaSource")
+				.assignTimestampsAndWatermarks(new MeasurementTSExtractor())
+				.name("Watermarks")
+				.uid("Watermarks")
+				.flatMap(new MeasurementDeserializer())
+				.name("Deserialization")
+				.uid("Deserialization");
+
+		OutputTag<JsonNode> lateDataTag = new OutputTag<JsonNode>("late-data") {
+			private static final long serialVersionUID = 33513631677208956L;
+		};
+
+		SingleOutputStreamOperator<WindowedMeasurements> aggregatedPerLocation = sourceStream
+				.keyBy(jsonNode -> jsonNode.get("location").asText())
+				.timeWindow(Time.of(1, TimeUnit.SECONDS))
+				.sideOutputLateData(lateDataTag)
+				.process(new MeasurementWindowAggregatingFunction())
+				.name("WindowedAggregationPerLocation")
+				.uid("WindowedAggregationPerLocation");
+
+		if (isLocal(parameters)) {
+			aggregatedPerLocation.print()
+					.name("NormalOutput")
+					.uid("NormalOutput")
+					.disableChaining();
+			aggregatedPerLocation.getSideOutput(lateDataTag).printToErr()
+					.name("LateDataSink")
+					.uid("LateDataSink")
+					.disableChaining();
+		} else {
+			aggregatedPerLocation.addSink(new DiscardingSink<>())
+					.name("NormalOutput")
+					.uid("NormalOutput")
+					.disableChaining();
+			aggregatedPerLocation.getSideOutput(lateDataTag).addSink(new DiscardingSink<>())
+					.name("LateDataSink")
+					.uid("LateDataSink")
+					.disableChaining();
+		}
+
+		env.execute(TroubledStreamingJobSolution1.class.getSimpleName());
+	}
+
+	/**
+	 * Deserializes the JSON Kafka message.
+	 */
+	public static class MeasurementDeserializer extends
+			RichFlatMapFunction<FakeKafkaRecord, JsonNode> {
+		private static final long serialVersionUID = 2L;
+
+		private Counter numInvalidRecords;
+
+		@Override
+		public void open(final Configuration parameters) throws Exception {
+			super.open(parameters);
+			numInvalidRecords = getRuntimeContext().getMetricGroup().counter("numInvalidRecords");
+		}
+
+		@Override
+		public void flatMap(final FakeKafkaRecord kafkaRecord, final Collector<JsonNode> out) {
+			final JsonNode node;
+			try {
+				node = deserialize(kafkaRecord.getValue());
+			} catch (IOException e) {
+				numInvalidRecords.inc();
+				return;
+			}
+			out.collect(node);
+		}
+
+		private JsonNode deserialize(final byte[] bytes) throws IOException {
+			return ObjectMapperSingleton.getInstance().readValue(bytes, JsonNode.class);
+		}
+	}
+
+	public static class MeasurementTSExtractor
+			extends BoundedOutOfOrdernessTimestampExtractor<FakeKafkaRecord> {
+		private static final long serialVersionUID = 1L;
+
+		MeasurementTSExtractor() {
+			super(Time.of(250, TimeUnit.MILLISECONDS));
+		}
+
+		@Override
+		public long extractTimestamp(final FakeKafkaRecord record) {
+			return record.getTimestamp();
+		}
+	}
+
+	public static class MeasurementWindowAggregatingFunction
+			extends ProcessWindowFunction<JsonNode, WindowedMeasurements, String, TimeWindow> {
+		private static final long serialVersionUID = 1L;
+
+		private static final int EVENT_TIME_LAG_WINDOW_SIZE = 10_000;
+
+		private transient DescriptiveStatisticsHistogram eventTimeLag;
+
+		@Override
+		public void process(
+				final String location,
+				final Context context,
+				final Iterable<JsonNode> input,
+				final Collector<WindowedMeasurements> out) {
+
+			WindowedMeasurements aggregate = new WindowedMeasurements();
+			for (JsonNode record : input) {
+				double result = Double.parseDouble(record.get("value").asText());
+				aggregate.addMeasurement(result);
+			}
+
+			final TimeWindow window = context.window();
+			aggregate.setWindow(window);
+			aggregate.setLocation(location);
+
+			eventTimeLag.update(System.currentTimeMillis() - window.getEnd());
+			out.collect(aggregate);
+		}
+
+		@Override
+		public void open(Configuration parameters) throws Exception {
+			super.open(parameters);
+
+			eventTimeLag = getRuntimeContext().getMetricGroup().histogram("eventTimeLag",
+					new DescriptiveStatisticsHistogram(EVENT_TIME_LAG_WINDOW_SIZE));
+		}
+	}
+
+	private static class ObjectMapperSingleton {
+		static ObjectMapper getInstance() {
+			ObjectMapper objectMapper = new ObjectMapper();
+			objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+			return objectMapper;
+		}
+	}
+}

--- a/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution1.java
+++ b/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution1.java
@@ -5,13 +5,13 @@ import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.timestamps.BoundedOutOfOrdernessTimestampExtractor;
 import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
+import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 import org.apache.flink.util.Collector;
@@ -46,8 +46,7 @@ public class TroubledStreamingJobSolution1 {
 
 		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
 
-		//Time Characteristics
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		//Timing Configuration
 		env.getConfig().setAutoWatermarkInterval(2000);
 
 		//Checkpointing Configuration
@@ -71,7 +70,7 @@ public class TroubledStreamingJobSolution1 {
 
 		SingleOutputStreamOperator<WindowedMeasurements> aggregatedPerLocation = sourceStream
 				.keyBy(jsonNode -> jsonNode.get("location").asText())
-				.timeWindow(Time.of(1, TimeUnit.SECONDS))
+				.window(TumblingEventTimeWindows.of(Time.seconds(1)))
 				.sideOutputLateData(lateDataTag)
 				.process(new MeasurementWindowAggregatingFunction())
 				.name("WindowedAggregationPerLocation")

--- a/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution2.java
+++ b/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution2.java
@@ -1,0 +1,246 @@
+package com.ververica.flink.training.solutions;
+
+import org.apache.flink.api.common.functions.RichFlatMapFunction;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
+import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.OutputTag;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ververica.flink.training.common.FakeKafkaRecord;
+import com.ververica.flink.training.common.SourceUtils;
+import com.ververica.flink.training.common.WindowedMeasurements;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import static com.ververica.flink.training.common.EnvironmentUtils.createConfiguredEnvironment;
+import static com.ververica.flink.training.common.EnvironmentUtils.isLocal;
+
+/**
+ * Troubled streaming job evolved on top of {@link TroubledStreamingJobSolution1} by fixing the
+ * watermarking to cope with idle partitions.
+ */
+public class TroubledStreamingJobSolution2 {
+
+    /**
+     * Creates and starts the troubled streaming job.
+	 *
+	 * @throws Exception if the application is misconfigured or fails during job submission
+     */
+	public static void main(String[] args) throws Exception {
+		ParameterTool parameters = ParameterTool.fromArgs(args);
+
+		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
+
+		//Time Characteristics
+		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		env.getConfig().setAutoWatermarkInterval(2000);
+
+		//Checkpointing Configuration
+		env.enableCheckpointing(5000);
+		env.getCheckpointConfig().setMinPauseBetweenCheckpoints(4000);
+
+		DataStream<JsonNode> sourceStream = env
+				.addSource(SourceUtils.createFakeKafkaSource())
+				.name("FakeKafkaSource")
+				.uid("FakeKafkaSource")
+				.assignTimestampsAndWatermarks(
+						new MeasurementTSExtractor(Time.of(250, TimeUnit.MILLISECONDS),
+								Time.of(1, TimeUnit.SECONDS)))
+				.name("Watermarks")
+				.uid("Watermarks")
+				.flatMap(new MeasurementDeserializer())
+				.name("Deserialization")
+				.uid("Deserialization");
+
+		OutputTag<JsonNode> lateDataTag = new OutputTag<JsonNode>("late-data") {
+			private static final long serialVersionUID = 33513631677208956L;
+		};
+
+		SingleOutputStreamOperator<WindowedMeasurements> aggregatedPerLocation = sourceStream
+				.keyBy(jsonNode -> jsonNode.get("location").asText())
+				.timeWindow(Time.of(1, TimeUnit.SECONDS))
+				.sideOutputLateData(lateDataTag)
+				.process(new MeasurementWindowAggregatingFunction())
+				.name("WindowedAggregationPerLocation")
+				.uid("WindowedAggregationPerLocation");
+
+		if (isLocal(parameters)) {
+			aggregatedPerLocation.print()
+					.name("NormalOutput")
+					.uid("NormalOutput")
+					.disableChaining();
+			aggregatedPerLocation.getSideOutput(lateDataTag).printToErr()
+					.name("LateDataSink")
+					.uid("LateDataSink")
+					.disableChaining();
+		} else {
+			aggregatedPerLocation.addSink(new DiscardingSink<>())
+					.name("NormalOutput")
+					.uid("NormalOutput")
+					.disableChaining();
+			aggregatedPerLocation.getSideOutput(lateDataTag).addSink(new DiscardingSink<>())
+					.name("LateDataSink")
+					.uid("LateDataSink")
+					.disableChaining();
+		}
+
+		env.execute(TroubledStreamingJobSolution2.class.getSimpleName());
+	}
+
+	/**
+	 * Deserializes the JSON Kafka message.
+	 */
+	public static class MeasurementDeserializer extends
+			RichFlatMapFunction<FakeKafkaRecord, JsonNode> {
+		private static final long serialVersionUID = 2L;
+
+		private Counter numInvalidRecords;
+
+		@Override
+		public void open(final Configuration parameters) throws Exception {
+			super.open(parameters);
+			numInvalidRecords = getRuntimeContext().getMetricGroup().counter("numInvalidRecords");
+		}
+
+		@Override
+		public void flatMap(final FakeKafkaRecord kafkaRecord, final Collector<JsonNode> out) {
+			final JsonNode node;
+			try {
+				node = deserialize(kafkaRecord.getValue());
+			} catch (IOException e) {
+				numInvalidRecords.inc();
+				return;
+			}
+			out.collect(node);
+		}
+
+		private JsonNode deserialize(final byte[] bytes) throws IOException {
+			return ObjectMapperSingleton.getInstance().readValue(bytes, JsonNode.class);
+		}
+	}
+
+	public static class MeasurementTSExtractor implements
+			AssignerWithPeriodicWatermarks<FakeKafkaRecord> {
+		private static final long serialVersionUID = 2L;
+
+		private long currentMaxTimestamp;
+		private long lastEmittedWatermark = Long.MIN_VALUE;
+		private long lastRecordProcessingTime;
+
+		private final long maxOutOfOrderness;
+		private final long idleTimeout;
+
+		MeasurementTSExtractor(Time maxOutOfOrderness, Time idleTimeout) {
+			if (maxOutOfOrderness.toMilliseconds() < 0) {
+				throw new RuntimeException("Tried to set the maximum allowed " +
+						"lateness to " + maxOutOfOrderness +
+						". This parameter cannot be negative.");
+			}
+
+			if (idleTimeout.toMilliseconds() < 0) {
+				throw new RuntimeException("Tried to set the idle Timeout" + idleTimeout +
+						". This parameter cannot be negative.");
+			}
+
+			this.maxOutOfOrderness = maxOutOfOrderness.toMilliseconds();
+			this.idleTimeout = idleTimeout.toMilliseconds();
+			this.currentMaxTimestamp = Long.MIN_VALUE;
+		}
+
+        /**
+         * Gets the configured out of orderness (in ms).
+         */
+		public long getMaxOutOfOrdernessInMillis() {
+			return maxOutOfOrderness;
+		}
+
+		@Override
+		public final Watermark getCurrentWatermark() {
+
+			// if last record was processed more than the idleTimeout in the past, consider this
+			// source idle and set timestamp to current processing time
+			long currentProcessingTime = System.currentTimeMillis();
+			if (lastRecordProcessingTime < currentProcessingTime - idleTimeout) {
+				this.currentMaxTimestamp = currentProcessingTime;
+			}
+
+			long potentialWM = this.currentMaxTimestamp - maxOutOfOrderness;
+			if (potentialWM >= lastEmittedWatermark) {
+				lastEmittedWatermark = potentialWM;
+			}
+			return new Watermark(lastEmittedWatermark);
+		}
+
+		@Override
+		public final long extractTimestamp(FakeKafkaRecord element, long previousElementTimestamp) {
+			lastRecordProcessingTime = System.currentTimeMillis();
+			long timestamp = element.getTimestamp();
+			if (timestamp > currentMaxTimestamp) {
+				currentMaxTimestamp = timestamp;
+			}
+			return timestamp;
+		}
+	}
+
+	public static class MeasurementWindowAggregatingFunction
+			extends ProcessWindowFunction<JsonNode, WindowedMeasurements, String, TimeWindow> {
+		private static final long serialVersionUID = 1L;
+
+		private static final int EVENT_TIME_LAG_WINDOW_SIZE = 10_000;
+
+		private transient DescriptiveStatisticsHistogram eventTimeLag;
+
+		@Override
+		public void process(
+				final String location,
+				final Context context,
+				final Iterable<JsonNode> input,
+				final Collector<WindowedMeasurements> out) {
+
+			WindowedMeasurements aggregate = new WindowedMeasurements();
+			for (JsonNode record : input) {
+				double result = Double.parseDouble(record.get("value").asText());
+				aggregate.addMeasurement(result);
+			}
+
+			final TimeWindow window = context.window();
+			aggregate.setWindow(window);
+			aggregate.setLocation(location);
+
+			eventTimeLag.update(System.currentTimeMillis() - window.getEnd());
+			out.collect(aggregate);
+		}
+
+		@Override
+		public void open(Configuration parameters) throws Exception {
+			super.open(parameters);
+
+			eventTimeLag = getRuntimeContext().getMetricGroup().histogram("eventTimeLag",
+					new DescriptiveStatisticsHistogram(EVENT_TIME_LAG_WINDOW_SIZE));
+		}
+	}
+
+	private static class ObjectMapperSingleton {
+		static ObjectMapper getInstance() {
+			ObjectMapper objectMapper = new ObjectMapper();
+			objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+			return objectMapper;
+		}
+	}
+}

--- a/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution2.java
+++ b/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution2.java
@@ -1,5 +1,6 @@
 package com.ververica.flink.training.solutions;
 
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.RichFlatMapFunction;
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
@@ -8,10 +9,8 @@ import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
-import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
@@ -26,7 +25,7 @@ import com.ververica.flink.training.common.SourceUtils;
 import com.ververica.flink.training.common.WindowedMeasurements;
 
 import java.io.IOException;
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 
 import static com.ververica.flink.training.common.EnvironmentUtils.createConfiguredEnvironment;
 import static com.ververica.flink.training.common.EnvironmentUtils.isLocal;
@@ -59,8 +58,11 @@ public class TroubledStreamingJobSolution2 {
 				.name("FakeKafkaSource")
 				.uid("FakeKafkaSource")
 				.assignTimestampsAndWatermarks(
-						new MeasurementTSExtractor(Time.of(250, TimeUnit.MILLISECONDS),
-								Time.of(1, TimeUnit.SECONDS)))
+						WatermarkStrategy
+								.<FakeKafkaRecord>forBoundedOutOfOrderness(Duration.ofMillis(250))
+								.withTimestampAssigner(
+										(element, timestamp) -> element.getTimestamp())
+								.withIdleness(Duration.ofSeconds(1)))
 				.name("Watermarks")
 				.uid("Watermarks")
 				.flatMap(new MeasurementDeserializer())
@@ -131,69 +133,6 @@ public class TroubledStreamingJobSolution2 {
 
 		private JsonNode deserialize(final byte[] bytes) throws IOException {
 			return ObjectMapperSingleton.getInstance().readValue(bytes, JsonNode.class);
-		}
-	}
-
-	public static class MeasurementTSExtractor implements
-			AssignerWithPeriodicWatermarks<FakeKafkaRecord> {
-		private static final long serialVersionUID = 2L;
-
-		private long currentMaxTimestamp;
-		private long lastEmittedWatermark = Long.MIN_VALUE;
-		private long lastRecordProcessingTime;
-
-		private final long maxOutOfOrderness;
-		private final long idleTimeout;
-
-		MeasurementTSExtractor(Time maxOutOfOrderness, Time idleTimeout) {
-			if (maxOutOfOrderness.toMilliseconds() < 0) {
-				throw new RuntimeException("Tried to set the maximum allowed " +
-						"lateness to " + maxOutOfOrderness +
-						". This parameter cannot be negative.");
-			}
-
-			if (idleTimeout.toMilliseconds() < 0) {
-				throw new RuntimeException("Tried to set the idle Timeout" + idleTimeout +
-						". This parameter cannot be negative.");
-			}
-
-			this.maxOutOfOrderness = maxOutOfOrderness.toMilliseconds();
-			this.idleTimeout = idleTimeout.toMilliseconds();
-			this.currentMaxTimestamp = Long.MIN_VALUE;
-		}
-
-        /**
-         * Gets the configured out of orderness (in ms).
-         */
-		public long getMaxOutOfOrdernessInMillis() {
-			return maxOutOfOrderness;
-		}
-
-		@Override
-		public final Watermark getCurrentWatermark() {
-
-			// if last record was processed more than the idleTimeout in the past, consider this
-			// source idle and set timestamp to current processing time
-			long currentProcessingTime = System.currentTimeMillis();
-			if (lastRecordProcessingTime < currentProcessingTime - idleTimeout) {
-				this.currentMaxTimestamp = currentProcessingTime;
-			}
-
-			long potentialWM = this.currentMaxTimestamp - maxOutOfOrderness;
-			if (potentialWM >= lastEmittedWatermark) {
-				lastEmittedWatermark = potentialWM;
-			}
-			return new Watermark(lastEmittedWatermark);
-		}
-
-		@Override
-		public final long extractTimestamp(FakeKafkaRecord element, long previousElementTimestamp) {
-			lastRecordProcessingTime = System.currentTimeMillis();
-			long timestamp = element.getTimestamp();
-			if (timestamp > currentMaxTimestamp) {
-				currentMaxTimestamp = timestamp;
-			}
-			return timestamp;
 		}
 	}
 

--- a/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution2.java
+++ b/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution2.java
@@ -5,7 +5,6 @@ import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -13,6 +12,7 @@ import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
 import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 import org.apache.flink.util.Collector;
@@ -47,8 +47,7 @@ public class TroubledStreamingJobSolution2 {
 
 		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
 
-		//Time Characteristics
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		//Timing Configuration
 		env.getConfig().setAutoWatermarkInterval(2000);
 
 		//Checkpointing Configuration
@@ -74,7 +73,7 @@ public class TroubledStreamingJobSolution2 {
 
 		SingleOutputStreamOperator<WindowedMeasurements> aggregatedPerLocation = sourceStream
 				.keyBy(jsonNode -> jsonNode.get("location").asText())
-				.timeWindow(Time.of(1, TimeUnit.SECONDS))
+				.window(TumblingEventTimeWindows.of(Time.seconds(1)))
 				.sideOutputLateData(lateDataTag)
 				.process(new MeasurementWindowAggregatingFunction())
 				.name("WindowedAggregationPerLocation")

--- a/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution31.java
+++ b/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution31.java
@@ -1,5 +1,6 @@
 package com.ververica.flink.training.solutions;
 
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.RichFlatMapFunction;
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
@@ -8,10 +9,8 @@ import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
-import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
@@ -26,7 +25,7 @@ import com.ververica.flink.training.common.SourceUtils;
 import com.ververica.flink.training.common.WindowedMeasurements;
 
 import java.io.IOException;
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 
 import static com.ververica.flink.training.common.EnvironmentUtils.createConfiguredEnvironment;
 import static com.ververica.flink.training.common.EnvironmentUtils.isLocal;
@@ -59,8 +58,11 @@ public class TroubledStreamingJobSolution31 {
 				.name("FakeKafkaSource")
 				.uid("FakeKafkaSource")
 				.assignTimestampsAndWatermarks(
-						new MeasurementTSExtractor(Time.of(250, TimeUnit.MILLISECONDS),
-								Time.of(1, TimeUnit.SECONDS)))
+						WatermarkStrategy
+								.<FakeKafkaRecord>forBoundedOutOfOrderness(Duration.ofMillis(250))
+								.withTimestampAssigner(
+										(element, timestamp) -> element.getTimestamp())
+								.withIdleness(Duration.ofSeconds(1)))
 				.name("Watermarks")
 				.uid("Watermarks")
 				.flatMap(new MeasurementDeserializer())
@@ -131,69 +133,6 @@ public class TroubledStreamingJobSolution31 {
 
 		private JsonNode deserialize(final byte[] bytes) throws IOException {
 			return ObjectMapperSingleton.getInstance().readValue(bytes, JsonNode.class);
-		}
-	}
-
-	public static class MeasurementTSExtractor implements
-			AssignerWithPeriodicWatermarks<FakeKafkaRecord> {
-		private static final long serialVersionUID = 2L;
-
-		private long currentMaxTimestamp;
-		private long lastEmittedWatermark = Long.MIN_VALUE;
-		private long lastRecordProcessingTime;
-
-		private final long maxOutOfOrderness;
-		private final long idleTimeout;
-
-		MeasurementTSExtractor(Time maxOutOfOrderness, Time idleTimeout) {
-			if (maxOutOfOrderness.toMilliseconds() < 0) {
-				throw new RuntimeException("Tried to set the maximum allowed " +
-						"lateness to " + maxOutOfOrderness +
-						". This parameter cannot be negative.");
-			}
-
-			if (idleTimeout.toMilliseconds() < 0) {
-				throw new RuntimeException("Tried to set the idle Timeout" + idleTimeout +
-						". This parameter cannot be negative.");
-			}
-
-			this.maxOutOfOrderness = maxOutOfOrderness.toMilliseconds();
-			this.idleTimeout = idleTimeout.toMilliseconds();
-			this.currentMaxTimestamp = Long.MIN_VALUE;
-		}
-
-        /**
-         * Gets the configured out of orderness (in ms).
-         */
-		public long getMaxOutOfOrdernessInMillis() {
-			return maxOutOfOrderness;
-		}
-
-		@Override
-		public final Watermark getCurrentWatermark() {
-
-			// if last record was processed more than the idleTimeout in the past, consider this
-			// source idle and set timestamp to current processing time
-			long currentProcessingTime = System.currentTimeMillis();
-			if (lastRecordProcessingTime < currentProcessingTime - idleTimeout) {
-				this.currentMaxTimestamp = currentProcessingTime;
-			}
-
-			long potentialWM = this.currentMaxTimestamp - maxOutOfOrderness;
-			if (potentialWM >= lastEmittedWatermark) {
-				lastEmittedWatermark = potentialWM;
-			}
-			return new Watermark(lastEmittedWatermark);
-		}
-
-		@Override
-		public final long extractTimestamp(FakeKafkaRecord element, long previousElementTimestamp) {
-			lastRecordProcessingTime = System.currentTimeMillis();
-			long timestamp = element.getTimestamp();
-			if (timestamp > currentMaxTimestamp) {
-				currentMaxTimestamp = timestamp;
-			}
-			return timestamp;
 		}
 	}
 

--- a/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution31.java
+++ b/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution31.java
@@ -5,7 +5,6 @@ import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -13,6 +12,7 @@ import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
 import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 import org.apache.flink.util.Collector;
@@ -47,8 +47,7 @@ public class TroubledStreamingJobSolution31 {
 
 		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
 
-		//Time Characteristics
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		//Timing Configuration
 		env.getConfig().setAutoWatermarkInterval(100);
 
 		//Checkpointing Configuration
@@ -74,7 +73,7 @@ public class TroubledStreamingJobSolution31 {
 
 		SingleOutputStreamOperator<WindowedMeasurements> aggregatedPerLocation = sourceStream
 				.keyBy(jsonNode -> jsonNode.get("location").asText())
-				.timeWindow(Time.of(1, TimeUnit.SECONDS))
+				.window(TumblingEventTimeWindows.of(Time.seconds(1)))
 				.sideOutputLateData(lateDataTag)
 				.process(new MeasurementWindowAggregatingFunction())
 				.name("WindowedAggregationPerLocation")

--- a/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution31.java
+++ b/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution31.java
@@ -1,0 +1,246 @@
+package com.ververica.flink.training.solutions;
+
+import org.apache.flink.api.common.functions.RichFlatMapFunction;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
+import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.OutputTag;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ververica.flink.training.common.FakeKafkaRecord;
+import com.ververica.flink.training.common.SourceUtils;
+import com.ververica.flink.training.common.WindowedMeasurements;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import static com.ververica.flink.training.common.EnvironmentUtils.createConfiguredEnvironment;
+import static com.ververica.flink.training.common.EnvironmentUtils.isLocal;
+
+/**
+ * Troubled streaming job evolved on top of {@link TroubledStreamingJobSolution2} by optimising
+ * latency with a smaller watermarking interval.
+ */
+public class TroubledStreamingJobSolution31 {
+
+    /**
+     * Creates and starts the troubled streaming job.
+	 *
+	 * @throws Exception if the application is misconfigured or fails during job submission
+     */
+	public static void main(String[] args) throws Exception {
+		ParameterTool parameters = ParameterTool.fromArgs(args);
+
+		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
+
+		//Time Characteristics
+		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		env.getConfig().setAutoWatermarkInterval(100);
+
+		//Checkpointing Configuration
+		env.enableCheckpointing(5000);
+		env.getCheckpointConfig().setMinPauseBetweenCheckpoints(4000);
+
+		DataStream<JsonNode> sourceStream = env
+				.addSource(SourceUtils.createFakeKafkaSource())
+				.name("FakeKafkaSource")
+				.uid("FakeKafkaSource")
+				.assignTimestampsAndWatermarks(
+						new MeasurementTSExtractor(Time.of(250, TimeUnit.MILLISECONDS),
+								Time.of(1, TimeUnit.SECONDS)))
+				.name("Watermarks")
+				.uid("Watermarks")
+				.flatMap(new MeasurementDeserializer())
+				.name("Deserialization")
+				.uid("Deserialization");
+
+		OutputTag<JsonNode> lateDataTag = new OutputTag<JsonNode>("late-data") {
+			private static final long serialVersionUID = 33513631677208956L;
+		};
+
+		SingleOutputStreamOperator<WindowedMeasurements> aggregatedPerLocation = sourceStream
+				.keyBy(jsonNode -> jsonNode.get("location").asText())
+				.timeWindow(Time.of(1, TimeUnit.SECONDS))
+				.sideOutputLateData(lateDataTag)
+				.process(new MeasurementWindowAggregatingFunction())
+				.name("WindowedAggregationPerLocation")
+				.uid("WindowedAggregationPerLocation");
+
+		if (isLocal(parameters)) {
+			aggregatedPerLocation.print()
+					.name("NormalOutput")
+					.uid("NormalOutput")
+					.disableChaining();
+			aggregatedPerLocation.getSideOutput(lateDataTag).printToErr()
+					.name("LateDataSink")
+					.uid("LateDataSink")
+					.disableChaining();
+		} else {
+			aggregatedPerLocation.addSink(new DiscardingSink<>())
+					.name("NormalOutput")
+					.uid("NormalOutput")
+					.disableChaining();
+			aggregatedPerLocation.getSideOutput(lateDataTag).addSink(new DiscardingSink<>())
+					.name("LateDataSink")
+					.uid("LateDataSink")
+					.disableChaining();
+		}
+
+		env.execute(TroubledStreamingJobSolution31.class.getSimpleName());
+	}
+
+	/**
+	 * Deserializes the JSON Kafka message.
+	 */
+	public static class MeasurementDeserializer extends
+			RichFlatMapFunction<FakeKafkaRecord, JsonNode> {
+		private static final long serialVersionUID = 2L;
+
+		private Counter numInvalidRecords;
+
+		@Override
+		public void open(final Configuration parameters) throws Exception {
+			super.open(parameters);
+			numInvalidRecords = getRuntimeContext().getMetricGroup().counter("numInvalidRecords");
+		}
+
+		@Override
+		public void flatMap(final FakeKafkaRecord kafkaRecord, final Collector<JsonNode> out) {
+			final JsonNode node;
+			try {
+				node = deserialize(kafkaRecord.getValue());
+			} catch (IOException e) {
+				numInvalidRecords.inc();
+				return;
+			}
+			out.collect(node);
+		}
+
+		private JsonNode deserialize(final byte[] bytes) throws IOException {
+			return ObjectMapperSingleton.getInstance().readValue(bytes, JsonNode.class);
+		}
+	}
+
+	public static class MeasurementTSExtractor implements
+			AssignerWithPeriodicWatermarks<FakeKafkaRecord> {
+		private static final long serialVersionUID = 2L;
+
+		private long currentMaxTimestamp;
+		private long lastEmittedWatermark = Long.MIN_VALUE;
+		private long lastRecordProcessingTime;
+
+		private final long maxOutOfOrderness;
+		private final long idleTimeout;
+
+		MeasurementTSExtractor(Time maxOutOfOrderness, Time idleTimeout) {
+			if (maxOutOfOrderness.toMilliseconds() < 0) {
+				throw new RuntimeException("Tried to set the maximum allowed " +
+						"lateness to " + maxOutOfOrderness +
+						". This parameter cannot be negative.");
+			}
+
+			if (idleTimeout.toMilliseconds() < 0) {
+				throw new RuntimeException("Tried to set the idle Timeout" + idleTimeout +
+						". This parameter cannot be negative.");
+			}
+
+			this.maxOutOfOrderness = maxOutOfOrderness.toMilliseconds();
+			this.idleTimeout = idleTimeout.toMilliseconds();
+			this.currentMaxTimestamp = Long.MIN_VALUE;
+		}
+
+        /**
+         * Gets the configured out of orderness (in ms).
+         */
+		public long getMaxOutOfOrdernessInMillis() {
+			return maxOutOfOrderness;
+		}
+
+		@Override
+		public final Watermark getCurrentWatermark() {
+
+			// if last record was processed more than the idleTimeout in the past, consider this
+			// source idle and set timestamp to current processing time
+			long currentProcessingTime = System.currentTimeMillis();
+			if (lastRecordProcessingTime < currentProcessingTime - idleTimeout) {
+				this.currentMaxTimestamp = currentProcessingTime;
+			}
+
+			long potentialWM = this.currentMaxTimestamp - maxOutOfOrderness;
+			if (potentialWM >= lastEmittedWatermark) {
+				lastEmittedWatermark = potentialWM;
+			}
+			return new Watermark(lastEmittedWatermark);
+		}
+
+		@Override
+		public final long extractTimestamp(FakeKafkaRecord element, long previousElementTimestamp) {
+			lastRecordProcessingTime = System.currentTimeMillis();
+			long timestamp = element.getTimestamp();
+			if (timestamp > currentMaxTimestamp) {
+				currentMaxTimestamp = timestamp;
+			}
+			return timestamp;
+		}
+	}
+
+	public static class MeasurementWindowAggregatingFunction
+			extends ProcessWindowFunction<JsonNode, WindowedMeasurements, String, TimeWindow> {
+		private static final long serialVersionUID = 1L;
+
+		private static final int EVENT_TIME_LAG_WINDOW_SIZE = 10_000;
+
+		private transient DescriptiveStatisticsHistogram eventTimeLag;
+
+		@Override
+		public void process(
+				final String location,
+				final Context context,
+				final Iterable<JsonNode> input,
+				final Collector<WindowedMeasurements> out) {
+
+			WindowedMeasurements aggregate = new WindowedMeasurements();
+			for (JsonNode record : input) {
+				double result = Double.parseDouble(record.get("value").asText());
+				aggregate.addMeasurement(result);
+			}
+
+			final TimeWindow window = context.window();
+			aggregate.setWindow(window);
+			aggregate.setLocation(location);
+
+			eventTimeLag.update(System.currentTimeMillis() - window.getEnd());
+			out.collect(aggregate);
+		}
+
+		@Override
+		public void open(Configuration parameters) throws Exception {
+			super.open(parameters);
+
+			eventTimeLag = getRuntimeContext().getMetricGroup().histogram("eventTimeLag",
+					new DescriptiveStatisticsHistogram(EVENT_TIME_LAG_WINDOW_SIZE));
+		}
+	}
+
+	private static class ObjectMapperSingleton {
+		static ObjectMapper getInstance() {
+			ObjectMapper objectMapper = new ObjectMapper();
+			objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+			return objectMapper;
+		}
+	}
+}

--- a/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution32.java
+++ b/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution32.java
@@ -1,0 +1,279 @@
+package com.ververica.flink.training.solutions;
+
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.api.common.functions.RichFlatMapFunction;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
+import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.OutputTag;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ververica.flink.training.common.FakeKafkaRecord;
+import com.ververica.flink.training.common.SourceUtils;
+import com.ververica.flink.training.common.WindowedMeasurements;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import static com.ververica.flink.training.common.EnvironmentUtils.createConfiguredEnvironment;
+import static com.ververica.flink.training.common.EnvironmentUtils.isLocal;
+
+/**
+ * Troubled streaming job evolved on top of {@link TroubledStreamingJobSolution31} by optimising
+ * latency with pre-aggregation.
+ */
+public class TroubledStreamingJobSolution32 {
+
+    /**
+     * Creates and starts the troubled streaming job.
+	 *
+	 * @throws Exception if the application is misconfigured or fails during job submission
+     */
+	public static void main(String[] args) throws Exception {
+		ParameterTool parameters = ParameterTool.fromArgs(args);
+
+		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
+
+		//Time Characteristics
+		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		env.getConfig().setAutoWatermarkInterval(100);
+
+		//Checkpointing Configuration
+		env.enableCheckpointing(5000);
+		env.getCheckpointConfig().setMinPauseBetweenCheckpoints(4000);
+
+		DataStream<JsonNode> sourceStream = env
+				.addSource(SourceUtils.createFakeKafkaSource())
+				.name("FakeKafkaSource")
+				.uid("FakeKafkaSource")
+				.assignTimestampsAndWatermarks(
+						new MeasurementTSExtractor(Time.of(250, TimeUnit.MILLISECONDS),
+								Time.of(1, TimeUnit.SECONDS)))
+				.name("Watermarks")
+				.uid("Watermarks")
+				.flatMap(new MeasurementDeserializer())
+				.name("Deserialization")
+				.uid("Deserialization");
+
+		OutputTag<JsonNode> lateDataTag = new OutputTag<JsonNode>("late-data") {
+			private static final long serialVersionUID = 33513631677208956L;
+		};
+
+		SingleOutputStreamOperator<WindowedMeasurements> aggregatedPerLocation = sourceStream
+				.keyBy(jsonNode -> jsonNode.get("location").asText())
+				.timeWindow(Time.of(1, TimeUnit.SECONDS))
+				.sideOutputLateData(lateDataTag)
+				.aggregate(new MeasurementWindowAggregatingFunction(),
+						new MeasurementWindowProcessFunction())
+				.name("WindowedAggregationPerLocation")
+				.uid("WindowedAggregationPerLocation");
+
+		if (isLocal(parameters)) {
+			aggregatedPerLocation.print()
+					.name("NormalOutput")
+					.uid("NormalOutput")
+					.disableChaining();
+			aggregatedPerLocation.getSideOutput(lateDataTag).printToErr()
+					.name("LateDataSink")
+					.uid("LateDataSink")
+					.disableChaining();
+		} else {
+			aggregatedPerLocation.addSink(new DiscardingSink<>())
+					.name("NormalOutput")
+					.uid("NormalOutput")
+					.disableChaining();
+			aggregatedPerLocation.getSideOutput(lateDataTag).addSink(new DiscardingSink<>())
+					.name("LateDataSink")
+					.uid("LateDataSink")
+					.disableChaining();
+		}
+
+		env.execute(TroubledStreamingJobSolution32.class.getSimpleName());
+	}
+
+	/**
+	 * Deserializes the JSON Kafka message.
+	 */
+	public static class MeasurementDeserializer extends
+			RichFlatMapFunction<FakeKafkaRecord, JsonNode> {
+		private static final long serialVersionUID = 2L;
+
+		private Counter numInvalidRecords;
+
+		@Override
+		public void open(final Configuration parameters) throws Exception {
+			super.open(parameters);
+			numInvalidRecords = getRuntimeContext().getMetricGroup().counter("numInvalidRecords");
+		}
+
+		@Override
+		public void flatMap(final FakeKafkaRecord kafkaRecord, final Collector<JsonNode> out) {
+			final JsonNode node;
+			try {
+				node = deserialize(kafkaRecord.getValue());
+			} catch (IOException e) {
+				numInvalidRecords.inc();
+				return;
+			}
+			out.collect(node);
+		}
+
+		private JsonNode deserialize(final byte[] bytes) throws IOException {
+			return ObjectMapperSingleton.getInstance().readValue(bytes, JsonNode.class);
+		}
+	}
+
+	public static class MeasurementTSExtractor implements
+			AssignerWithPeriodicWatermarks<FakeKafkaRecord> {
+		private static final long serialVersionUID = 2L;
+
+		private long currentMaxTimestamp;
+		private long lastEmittedWatermark = Long.MIN_VALUE;
+		private long lastRecordProcessingTime;
+
+		private final long maxOutOfOrderness;
+		private final long idleTimeout;
+
+		MeasurementTSExtractor(Time maxOutOfOrderness, Time idleTimeout) {
+			if (maxOutOfOrderness.toMilliseconds() < 0) {
+				throw new RuntimeException("Tried to set the maximum allowed " +
+						"lateness to " + maxOutOfOrderness +
+						". This parameter cannot be negative.");
+			}
+
+			if (idleTimeout.toMilliseconds() < 0) {
+				throw new RuntimeException("Tried to set the idle Timeout" + idleTimeout +
+						". This parameter cannot be negative.");
+			}
+
+			this.maxOutOfOrderness = maxOutOfOrderness.toMilliseconds();
+			this.idleTimeout = idleTimeout.toMilliseconds();
+			this.currentMaxTimestamp = Long.MIN_VALUE;
+		}
+
+        /**
+         * Gets the configured out of orderness (in ms).
+         */
+		public long getMaxOutOfOrdernessInMillis() {
+			return maxOutOfOrderness;
+		}
+
+		@Override
+		public final Watermark getCurrentWatermark() {
+
+			// if last record was processed more than the idleTimeout in the past, consider this
+			// source idle and set timestamp to current processing time
+			long currentProcessingTime = System.currentTimeMillis();
+			if (lastRecordProcessingTime < currentProcessingTime - idleTimeout) {
+				this.currentMaxTimestamp = currentProcessingTime;
+			}
+
+			long potentialWM = this.currentMaxTimestamp - maxOutOfOrderness;
+			if (potentialWM >= lastEmittedWatermark) {
+				lastEmittedWatermark = potentialWM;
+			}
+			return new Watermark(lastEmittedWatermark);
+		}
+
+		@Override
+		public final long extractTimestamp(FakeKafkaRecord element, long previousElementTimestamp) {
+			lastRecordProcessingTime = System.currentTimeMillis();
+			long timestamp = element.getTimestamp();
+			if (timestamp > currentMaxTimestamp) {
+				currentMaxTimestamp = timestamp;
+			}
+			return timestamp;
+		}
+	}
+
+	public static class MeasurementWindowAggregatingFunction
+			implements AggregateFunction<JsonNode, WindowedMeasurements, WindowedMeasurements> {
+		private static final long serialVersionUID = 2L;
+
+		@Override
+		public WindowedMeasurements createAccumulator() {
+			return new WindowedMeasurements();
+		}
+
+		@Override
+		public WindowedMeasurements add(
+				final JsonNode record,
+				final WindowedMeasurements aggregate) {
+			double result = Double.parseDouble(record.get("value").asText());
+			aggregate.addMeasurement(result);
+			return aggregate;
+		}
+
+		@Override
+		public WindowedMeasurements getResult(final WindowedMeasurements windowedMeasurements) {
+			return windowedMeasurements;
+		}
+
+		@Override
+		public WindowedMeasurements merge(
+				final WindowedMeasurements agg1,
+				final WindowedMeasurements agg2) {
+			agg2.setEventsPerWindow(agg1.getEventsPerWindow() + agg2.getEventsPerWindow());
+			agg2.setSumPerWindow(agg1.getSumPerWindow() + agg2.getSumPerWindow());
+			return agg2;
+		}
+	}
+
+	public static class MeasurementWindowProcessFunction
+			extends
+			ProcessWindowFunction<WindowedMeasurements, WindowedMeasurements, String, TimeWindow> {
+		private static final long serialVersionUID = 1L;
+
+		private static final int EVENT_TIME_LAG_WINDOW_SIZE = 10_000;
+
+		private transient DescriptiveStatisticsHistogram eventTimeLag;
+
+		@Override
+		public void process(
+				final String location,
+				final Context context,
+				final Iterable<WindowedMeasurements> input,
+				final Collector<WindowedMeasurements> out) {
+
+			// Windows with pre-aggregation only forward the final to the WindowFunction
+			WindowedMeasurements aggregate = input.iterator().next();
+
+			final TimeWindow window = context.window();
+			aggregate.setWindow(window);
+			aggregate.setLocation(location);
+
+			eventTimeLag.update(System.currentTimeMillis() - window.getEnd());
+			out.collect(aggregate);
+		}
+
+		@Override
+		public void open(Configuration parameters) throws Exception {
+			super.open(parameters);
+
+			eventTimeLag = getRuntimeContext().getMetricGroup().histogram("eventTimeLag",
+					new DescriptiveStatisticsHistogram(EVENT_TIME_LAG_WINDOW_SIZE));
+		}
+	}
+
+	private static class ObjectMapperSingleton {
+		static ObjectMapper getInstance() {
+			ObjectMapper objectMapper = new ObjectMapper();
+			objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+			return objectMapper;
+		}
+	}
+}

--- a/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution32.java
+++ b/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution32.java
@@ -6,7 +6,6 @@ import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -14,6 +13,7 @@ import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
 import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 import org.apache.flink.util.Collector;
@@ -48,8 +48,7 @@ public class TroubledStreamingJobSolution32 {
 
 		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
 
-		//Time Characteristics
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		//Timing Configuration
 		env.getConfig().setAutoWatermarkInterval(100);
 
 		//Checkpointing Configuration
@@ -75,7 +74,7 @@ public class TroubledStreamingJobSolution32 {
 
 		SingleOutputStreamOperator<WindowedMeasurements> aggregatedPerLocation = sourceStream
 				.keyBy(jsonNode -> jsonNode.get("location").asText())
-				.timeWindow(Time.of(1, TimeUnit.SECONDS))
+				.window(TumblingEventTimeWindows.of(Time.seconds(1)))
 				.sideOutputLateData(lateDataTag)
 				.aggregate(new MeasurementWindowAggregatingFunction(),
 						new MeasurementWindowProcessFunction())

--- a/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution32.java
+++ b/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution32.java
@@ -1,5 +1,6 @@
 package com.ververica.flink.training.solutions;
 
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.AggregateFunction;
 import org.apache.flink.api.common.functions.RichFlatMapFunction;
 import org.apache.flink.api.java.utils.ParameterTool;
@@ -9,10 +10,8 @@ import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
-import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
@@ -27,7 +26,7 @@ import com.ververica.flink.training.common.SourceUtils;
 import com.ververica.flink.training.common.WindowedMeasurements;
 
 import java.io.IOException;
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 
 import static com.ververica.flink.training.common.EnvironmentUtils.createConfiguredEnvironment;
 import static com.ververica.flink.training.common.EnvironmentUtils.isLocal;
@@ -60,8 +59,11 @@ public class TroubledStreamingJobSolution32 {
 				.name("FakeKafkaSource")
 				.uid("FakeKafkaSource")
 				.assignTimestampsAndWatermarks(
-						new MeasurementTSExtractor(Time.of(250, TimeUnit.MILLISECONDS),
-								Time.of(1, TimeUnit.SECONDS)))
+						WatermarkStrategy
+								.<FakeKafkaRecord>forBoundedOutOfOrderness(Duration.ofMillis(250))
+								.withTimestampAssigner(
+										(element, timestamp) -> element.getTimestamp())
+								.withIdleness(Duration.ofSeconds(1)))
 				.name("Watermarks")
 				.uid("Watermarks")
 				.flatMap(new MeasurementDeserializer())
@@ -133,69 +135,6 @@ public class TroubledStreamingJobSolution32 {
 
 		private JsonNode deserialize(final byte[] bytes) throws IOException {
 			return ObjectMapperSingleton.getInstance().readValue(bytes, JsonNode.class);
-		}
-	}
-
-	public static class MeasurementTSExtractor implements
-			AssignerWithPeriodicWatermarks<FakeKafkaRecord> {
-		private static final long serialVersionUID = 2L;
-
-		private long currentMaxTimestamp;
-		private long lastEmittedWatermark = Long.MIN_VALUE;
-		private long lastRecordProcessingTime;
-
-		private final long maxOutOfOrderness;
-		private final long idleTimeout;
-
-		MeasurementTSExtractor(Time maxOutOfOrderness, Time idleTimeout) {
-			if (maxOutOfOrderness.toMilliseconds() < 0) {
-				throw new RuntimeException("Tried to set the maximum allowed " +
-						"lateness to " + maxOutOfOrderness +
-						". This parameter cannot be negative.");
-			}
-
-			if (idleTimeout.toMilliseconds() < 0) {
-				throw new RuntimeException("Tried to set the idle Timeout" + idleTimeout +
-						". This parameter cannot be negative.");
-			}
-
-			this.maxOutOfOrderness = maxOutOfOrderness.toMilliseconds();
-			this.idleTimeout = idleTimeout.toMilliseconds();
-			this.currentMaxTimestamp = Long.MIN_VALUE;
-		}
-
-        /**
-         * Gets the configured out of orderness (in ms).
-         */
-		public long getMaxOutOfOrdernessInMillis() {
-			return maxOutOfOrderness;
-		}
-
-		@Override
-		public final Watermark getCurrentWatermark() {
-
-			// if last record was processed more than the idleTimeout in the past, consider this
-			// source idle and set timestamp to current processing time
-			long currentProcessingTime = System.currentTimeMillis();
-			if (lastRecordProcessingTime < currentProcessingTime - idleTimeout) {
-				this.currentMaxTimestamp = currentProcessingTime;
-			}
-
-			long potentialWM = this.currentMaxTimestamp - maxOutOfOrderness;
-			if (potentialWM >= lastEmittedWatermark) {
-				lastEmittedWatermark = potentialWM;
-			}
-			return new Watermark(lastEmittedWatermark);
-		}
-
-		@Override
-		public final long extractTimestamp(FakeKafkaRecord element, long previousElementTimestamp) {
-			lastRecordProcessingTime = System.currentTimeMillis();
-			long timestamp = element.getTimestamp();
-			if (timestamp > currentMaxTimestamp) {
-				currentMaxTimestamp = timestamp;
-			}
-			return timestamp;
 		}
 	}
 

--- a/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution33.java
+++ b/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution33.java
@@ -6,7 +6,6 @@ import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -14,6 +13,7 @@ import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
 import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 import org.apache.flink.util.Collector;
@@ -48,8 +48,7 @@ public class TroubledStreamingJobSolution33 {
 
 		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
 
-		//Time Characteristics
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		//Timing Configuration
 		env.getConfig().setAutoWatermarkInterval(100);
 		env.setBufferTimeout(10);
 
@@ -76,7 +75,7 @@ public class TroubledStreamingJobSolution33 {
 
 		SingleOutputStreamOperator<WindowedMeasurements> aggregatedPerLocation = sourceStream
 				.keyBy(jsonNode -> jsonNode.get("location").asText())
-				.timeWindow(Time.of(1, TimeUnit.SECONDS))
+				.window(TumblingEventTimeWindows.of(Time.seconds(1)))
 				.sideOutputLateData(lateDataTag)
 				.aggregate(new MeasurementWindowAggregatingFunction(),
 						new MeasurementWindowProcessFunction())

--- a/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution33.java
+++ b/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution33.java
@@ -1,0 +1,280 @@
+package com.ververica.flink.training.solutions;
+
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.api.common.functions.RichFlatMapFunction;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
+import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.OutputTag;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ververica.flink.training.common.FakeKafkaRecord;
+import com.ververica.flink.training.common.SourceUtils;
+import com.ververica.flink.training.common.WindowedMeasurements;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import static com.ververica.flink.training.common.EnvironmentUtils.createConfiguredEnvironment;
+import static com.ververica.flink.training.common.EnvironmentUtils.isLocal;
+
+/**
+ * Troubled streaming job evolved on top of {@link TroubledStreamingJobSolution32} by optimising
+ * latency with a reduced buffer timeout.
+ */
+public class TroubledStreamingJobSolution33 {
+
+    /**
+     * Creates and starts the troubled streaming job.
+	 *
+	 * @throws Exception if the application is misconfigured or fails during job submission
+     */
+	public static void main(String[] args) throws Exception {
+		ParameterTool parameters = ParameterTool.fromArgs(args);
+
+		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
+
+		//Time Characteristics
+		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		env.getConfig().setAutoWatermarkInterval(100);
+		env.setBufferTimeout(10);
+
+		//Checkpointing Configuration
+		env.enableCheckpointing(5000);
+		env.getCheckpointConfig().setMinPauseBetweenCheckpoints(4000);
+
+		DataStream<JsonNode> sourceStream = env
+				.addSource(SourceUtils.createFakeKafkaSource())
+				.name("FakeKafkaSource")
+				.uid("FakeKafkaSource")
+				.assignTimestampsAndWatermarks(
+						new MeasurementTSExtractor(Time.of(250, TimeUnit.MILLISECONDS),
+								Time.of(1, TimeUnit.SECONDS)))
+				.name("Watermarks")
+				.uid("Watermarks")
+				.flatMap(new MeasurementDeserializer())
+				.name("Deserialization")
+				.uid("Deserialization");
+
+		OutputTag<JsonNode> lateDataTag = new OutputTag<JsonNode>("late-data") {
+			private static final long serialVersionUID = 33513631677208956L;
+		};
+
+		SingleOutputStreamOperator<WindowedMeasurements> aggregatedPerLocation = sourceStream
+				.keyBy(jsonNode -> jsonNode.get("location").asText())
+				.timeWindow(Time.of(1, TimeUnit.SECONDS))
+				.sideOutputLateData(lateDataTag)
+				.aggregate(new MeasurementWindowAggregatingFunction(),
+						new MeasurementWindowProcessFunction())
+				.name("WindowedAggregationPerLocation")
+				.uid("WindowedAggregationPerLocation");
+
+		if (isLocal(parameters)) {
+			aggregatedPerLocation.print()
+					.name("NormalOutput")
+					.uid("NormalOutput")
+					.disableChaining();
+			aggregatedPerLocation.getSideOutput(lateDataTag).printToErr()
+					.name("LateDataSink")
+					.uid("LateDataSink")
+					.disableChaining();
+		} else {
+			aggregatedPerLocation.addSink(new DiscardingSink<>())
+					.name("NormalOutput")
+					.uid("NormalOutput")
+					.disableChaining();
+			aggregatedPerLocation.getSideOutput(lateDataTag).addSink(new DiscardingSink<>())
+					.name("LateDataSink")
+					.uid("LateDataSink")
+					.disableChaining();
+		}
+
+		env.execute(TroubledStreamingJobSolution33.class.getSimpleName());
+	}
+
+	/**
+	 * Deserializes the JSON Kafka message.
+	 */
+	public static class MeasurementDeserializer extends
+			RichFlatMapFunction<FakeKafkaRecord, JsonNode> {
+		private static final long serialVersionUID = 2L;
+
+		private Counter numInvalidRecords;
+
+		@Override
+		public void open(final Configuration parameters) throws Exception {
+			super.open(parameters);
+			numInvalidRecords = getRuntimeContext().getMetricGroup().counter("numInvalidRecords");
+		}
+
+		@Override
+		public void flatMap(final FakeKafkaRecord kafkaRecord, final Collector<JsonNode> out) {
+			final JsonNode node;
+			try {
+				node = deserialize(kafkaRecord.getValue());
+			} catch (IOException e) {
+				numInvalidRecords.inc();
+				return;
+			}
+			out.collect(node);
+		}
+
+		private JsonNode deserialize(final byte[] bytes) throws IOException {
+			return ObjectMapperSingleton.getInstance().readValue(bytes, JsonNode.class);
+		}
+	}
+
+	public static class MeasurementTSExtractor implements
+			AssignerWithPeriodicWatermarks<FakeKafkaRecord> {
+		private static final long serialVersionUID = 2L;
+
+		private long currentMaxTimestamp;
+		private long lastEmittedWatermark = Long.MIN_VALUE;
+		private long lastRecordProcessingTime;
+
+		private final long maxOutOfOrderness;
+		private final long idleTimeout;
+
+		MeasurementTSExtractor(Time maxOutOfOrderness, Time idleTimeout) {
+			if (maxOutOfOrderness.toMilliseconds() < 0) {
+				throw new RuntimeException("Tried to set the maximum allowed " +
+						"lateness to " + maxOutOfOrderness +
+						". This parameter cannot be negative.");
+			}
+
+			if (idleTimeout.toMilliseconds() < 0) {
+				throw new RuntimeException("Tried to set the idle Timeout" + idleTimeout +
+						". This parameter cannot be negative.");
+			}
+
+			this.maxOutOfOrderness = maxOutOfOrderness.toMilliseconds();
+			this.idleTimeout = idleTimeout.toMilliseconds();
+			this.currentMaxTimestamp = Long.MIN_VALUE;
+		}
+
+		/**
+		 * Gets the configured out of orderness (in ms).
+		 */
+		public long getMaxOutOfOrdernessInMillis() {
+			return maxOutOfOrderness;
+		}
+
+		@Override
+		public final Watermark getCurrentWatermark() {
+
+			// if last record was processed more than the idleTimeout in the past, consider this
+			// source idle and set timestamp to current processing time
+			long currentProcessingTime = System.currentTimeMillis();
+			if (lastRecordProcessingTime < currentProcessingTime - idleTimeout) {
+				this.currentMaxTimestamp = currentProcessingTime;
+			}
+
+			long potentialWM = this.currentMaxTimestamp - maxOutOfOrderness;
+			if (potentialWM >= lastEmittedWatermark) {
+				lastEmittedWatermark = potentialWM;
+			}
+			return new Watermark(lastEmittedWatermark);
+		}
+
+		@Override
+		public final long extractTimestamp(FakeKafkaRecord element, long previousElementTimestamp) {
+			lastRecordProcessingTime = System.currentTimeMillis();
+			long timestamp = element.getTimestamp();
+			if (timestamp > currentMaxTimestamp) {
+				currentMaxTimestamp = timestamp;
+			}
+			return timestamp;
+		}
+	}
+
+	public static class MeasurementWindowAggregatingFunction
+			implements AggregateFunction<JsonNode, WindowedMeasurements, WindowedMeasurements> {
+		private static final long serialVersionUID = 2L;
+
+		@Override
+		public WindowedMeasurements createAccumulator() {
+			return new WindowedMeasurements();
+		}
+
+		@Override
+		public WindowedMeasurements add(
+				final JsonNode record,
+				final WindowedMeasurements aggregate) {
+			double result = Double.parseDouble(record.get("value").asText());
+			aggregate.addMeasurement(result);
+			return aggregate;
+		}
+
+		@Override
+		public WindowedMeasurements getResult(final WindowedMeasurements windowedMeasurements) {
+			return windowedMeasurements;
+		}
+
+		@Override
+		public WindowedMeasurements merge(
+				final WindowedMeasurements agg1,
+				final WindowedMeasurements agg2) {
+			agg2.setEventsPerWindow(agg1.getEventsPerWindow() + agg2.getEventsPerWindow());
+			agg2.setSumPerWindow(agg1.getSumPerWindow() + agg2.getSumPerWindow());
+			return agg2;
+		}
+	}
+
+	public static class MeasurementWindowProcessFunction
+			extends
+			ProcessWindowFunction<WindowedMeasurements, WindowedMeasurements, String, TimeWindow> {
+		private static final long serialVersionUID = 1L;
+
+		private static final int EVENT_TIME_LAG_WINDOW_SIZE = 10_000;
+
+		private transient DescriptiveStatisticsHistogram eventTimeLag;
+
+		@Override
+		public void process(
+				final String location,
+				final Context context,
+				final Iterable<WindowedMeasurements> input,
+				final Collector<WindowedMeasurements> out) {
+
+			// Windows with pre-aggregation only forward the final to the WindowFunction
+			WindowedMeasurements aggregate = input.iterator().next();
+
+			final TimeWindow window = context.window();
+			aggregate.setWindow(window);
+			aggregate.setLocation(location);
+
+			eventTimeLag.update(System.currentTimeMillis() - window.getEnd());
+			out.collect(aggregate);
+		}
+
+		@Override
+		public void open(Configuration parameters) throws Exception {
+			super.open(parameters);
+
+			eventTimeLag = getRuntimeContext().getMetricGroup().histogram("eventTimeLag",
+					new DescriptiveStatisticsHistogram(EVENT_TIME_LAG_WINDOW_SIZE));
+		}
+	}
+
+	private static class ObjectMapperSingleton {
+		static ObjectMapper getInstance() {
+			ObjectMapper objectMapper = new ObjectMapper();
+			objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+			return objectMapper;
+		}
+	}
+}

--- a/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution33.java
+++ b/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution33.java
@@ -1,5 +1,6 @@
 package com.ververica.flink.training.solutions;
 
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.AggregateFunction;
 import org.apache.flink.api.common.functions.RichFlatMapFunction;
 import org.apache.flink.api.java.utils.ParameterTool;
@@ -9,10 +10,8 @@ import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
-import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
@@ -27,7 +26,7 @@ import com.ververica.flink.training.common.SourceUtils;
 import com.ververica.flink.training.common.WindowedMeasurements;
 
 import java.io.IOException;
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 
 import static com.ververica.flink.training.common.EnvironmentUtils.createConfiguredEnvironment;
 import static com.ververica.flink.training.common.EnvironmentUtils.isLocal;
@@ -61,8 +60,11 @@ public class TroubledStreamingJobSolution33 {
 				.name("FakeKafkaSource")
 				.uid("FakeKafkaSource")
 				.assignTimestampsAndWatermarks(
-						new MeasurementTSExtractor(Time.of(250, TimeUnit.MILLISECONDS),
-								Time.of(1, TimeUnit.SECONDS)))
+						WatermarkStrategy
+								.<FakeKafkaRecord>forBoundedOutOfOrderness(Duration.ofMillis(250))
+								.withTimestampAssigner(
+										(element, timestamp) -> element.getTimestamp())
+								.withIdleness(Duration.ofSeconds(1)))
 				.name("Watermarks")
 				.uid("Watermarks")
 				.flatMap(new MeasurementDeserializer())
@@ -134,69 +136,6 @@ public class TroubledStreamingJobSolution33 {
 
 		private JsonNode deserialize(final byte[] bytes) throws IOException {
 			return ObjectMapperSingleton.getInstance().readValue(bytes, JsonNode.class);
-		}
-	}
-
-	public static class MeasurementTSExtractor implements
-			AssignerWithPeriodicWatermarks<FakeKafkaRecord> {
-		private static final long serialVersionUID = 2L;
-
-		private long currentMaxTimestamp;
-		private long lastEmittedWatermark = Long.MIN_VALUE;
-		private long lastRecordProcessingTime;
-
-		private final long maxOutOfOrderness;
-		private final long idleTimeout;
-
-		MeasurementTSExtractor(Time maxOutOfOrderness, Time idleTimeout) {
-			if (maxOutOfOrderness.toMilliseconds() < 0) {
-				throw new RuntimeException("Tried to set the maximum allowed " +
-						"lateness to " + maxOutOfOrderness +
-						". This parameter cannot be negative.");
-			}
-
-			if (idleTimeout.toMilliseconds() < 0) {
-				throw new RuntimeException("Tried to set the idle Timeout" + idleTimeout +
-						". This parameter cannot be negative.");
-			}
-
-			this.maxOutOfOrderness = maxOutOfOrderness.toMilliseconds();
-			this.idleTimeout = idleTimeout.toMilliseconds();
-			this.currentMaxTimestamp = Long.MIN_VALUE;
-		}
-
-		/**
-		 * Gets the configured out of orderness (in ms).
-		 */
-		public long getMaxOutOfOrdernessInMillis() {
-			return maxOutOfOrderness;
-		}
-
-		@Override
-		public final Watermark getCurrentWatermark() {
-
-			// if last record was processed more than the idleTimeout in the past, consider this
-			// source idle and set timestamp to current processing time
-			long currentProcessingTime = System.currentTimeMillis();
-			if (lastRecordProcessingTime < currentProcessingTime - idleTimeout) {
-				this.currentMaxTimestamp = currentProcessingTime;
-			}
-
-			long potentialWM = this.currentMaxTimestamp - maxOutOfOrderness;
-			if (potentialWM >= lastEmittedWatermark) {
-				lastEmittedWatermark = potentialWM;
-			}
-			return new Watermark(lastEmittedWatermark);
-		}
-
-		@Override
-		public final long extractTimestamp(FakeKafkaRecord element, long previousElementTimestamp) {
-			lastRecordProcessingTime = System.currentTimeMillis();
-			long timestamp = element.getTimestamp();
-			if (timestamp > currentMaxTimestamp) {
-				currentMaxTimestamp = timestamp;
-			}
-			return timestamp;
 		}
 	}
 

--- a/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution41.java
+++ b/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution41.java
@@ -1,5 +1,6 @@
 package com.ververica.flink.training.solutions;
 
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.AggregateFunction;
 import org.apache.flink.api.common.functions.RichFlatMapFunction;
 import org.apache.flink.api.java.utils.ParameterTool;
@@ -9,10 +10,8 @@ import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
-import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
@@ -27,7 +26,7 @@ import com.ververica.flink.training.common.SourceUtils;
 import com.ververica.flink.training.common.WindowedMeasurements;
 
 import java.io.IOException;
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 
 import static com.ververica.flink.training.common.EnvironmentUtils.createConfiguredEnvironment;
 import static com.ververica.flink.training.common.EnvironmentUtils.isLocal;
@@ -61,8 +60,11 @@ public class TroubledStreamingJobSolution41 {
 				.name("FakeKafkaSource")
 				.uid("FakeKafkaSource")
 				.assignTimestampsAndWatermarks(
-						new MeasurementTSExtractor(Time.of(250, TimeUnit.MILLISECONDS),
-								Time.of(1, TimeUnit.SECONDS)))
+						WatermarkStrategy
+								.<FakeKafkaRecord>forBoundedOutOfOrderness(Duration.ofMillis(250))
+								.withTimestampAssigner(
+										(element, timestamp) -> element.getTimestamp())
+								.withIdleness(Duration.ofSeconds(1)))
 				.name("Watermarks")
 				.uid("Watermarks")
 				.flatMap(new MeasurementDeserializer())
@@ -134,69 +136,6 @@ public class TroubledStreamingJobSolution41 {
 
 		private Measurement deserialize(final byte[] bytes) throws IOException {
 			return ObjectMapperSingleton.getInstance().readValue(bytes, Measurement.class);
-		}
-	}
-
-	public static class MeasurementTSExtractor implements
-			AssignerWithPeriodicWatermarks<FakeKafkaRecord> {
-		private static final long serialVersionUID = 2L;
-
-		private long currentMaxTimestamp;
-		private long lastEmittedWatermark = Long.MIN_VALUE;
-		private long lastRecordProcessingTime;
-
-		private final long maxOutOfOrderness;
-		private final long idleTimeout;
-
-		MeasurementTSExtractor(Time maxOutOfOrderness, Time idleTimeout) {
-			if (maxOutOfOrderness.toMilliseconds() < 0) {
-				throw new RuntimeException("Tried to set the maximum allowed " +
-						"lateness to " + maxOutOfOrderness +
-						". This parameter cannot be negative.");
-			}
-
-			if (idleTimeout.toMilliseconds() < 0) {
-				throw new RuntimeException("Tried to set the idle Timeout" + idleTimeout +
-						". This parameter cannot be negative.");
-			}
-
-			this.maxOutOfOrderness = maxOutOfOrderness.toMilliseconds();
-			this.idleTimeout = idleTimeout.toMilliseconds();
-			this.currentMaxTimestamp = Long.MIN_VALUE;
-		}
-
-		/**
-		 * Gets the configured out of orderness (in ms).
-		 */
-		public long getMaxOutOfOrdernessInMillis() {
-			return maxOutOfOrderness;
-		}
-
-		@Override
-		public final Watermark getCurrentWatermark() {
-
-			// if last record was processed more than the idleTimeout in the past, consider this
-			// source idle and set timestamp to current processing time
-			long currentProcessingTime = System.currentTimeMillis();
-			if (lastRecordProcessingTime < currentProcessingTime - idleTimeout) {
-				this.currentMaxTimestamp = currentProcessingTime;
-			}
-
-			long potentialWM = this.currentMaxTimestamp - maxOutOfOrderness;
-			if (potentialWM >= lastEmittedWatermark) {
-				lastEmittedWatermark = potentialWM;
-			}
-			return new Watermark(lastEmittedWatermark);
-		}
-
-		@Override
-		public final long extractTimestamp(FakeKafkaRecord element, long previousElementTimestamp) {
-			lastRecordProcessingTime = System.currentTimeMillis();
-			long timestamp = element.getTimestamp();
-			if (timestamp > currentMaxTimestamp) {
-				currentMaxTimestamp = timestamp;
-			}
-			return timestamp;
 		}
 	}
 

--- a/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution41.java
+++ b/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution41.java
@@ -6,7 +6,6 @@ import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -14,6 +13,7 @@ import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
 import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 import org.apache.flink.util.Collector;
@@ -48,8 +48,7 @@ public class TroubledStreamingJobSolution41 {
 
 		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
 
-		//Time Characteristics
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		//Timing Configuration
 		env.getConfig().setAutoWatermarkInterval(100);
 		env.setBufferTimeout(10);
 
@@ -76,7 +75,7 @@ public class TroubledStreamingJobSolution41 {
 
 		SingleOutputStreamOperator<WindowedMeasurements> aggregatedPerLocation = sourceStream
 				.keyBy(Measurement::getLocation)
-				.timeWindow(Time.of(1, TimeUnit.SECONDS))
+				.window(TumblingEventTimeWindows.of(Time.seconds(1)))
 				.sideOutputLateData(lateDataTag)
 				.aggregate(new MeasurementWindowAggregatingFunction(),
 						new MeasurementWindowProcessFunction())

--- a/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution41.java
+++ b/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution41.java
@@ -1,0 +1,279 @@
+package com.ververica.flink.training.solutions;
+
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.api.common.functions.RichFlatMapFunction;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
+import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.OutputTag;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ververica.flink.training.common.FakeKafkaRecord;
+import com.ververica.flink.training.common.Measurement;
+import com.ververica.flink.training.common.SourceUtils;
+import com.ververica.flink.training.common.WindowedMeasurements;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import static com.ververica.flink.training.common.EnvironmentUtils.createConfiguredEnvironment;
+import static com.ververica.flink.training.common.EnvironmentUtils.isLocal;
+
+/**
+ * Troubled streaming job evolved on top of {@link TroubledStreamingJobSolution33} by optimising
+ * throughput with a POJO instead of a {@link com.fasterxml.jackson.databind.JsonNode} in the stream.
+ */
+public class TroubledStreamingJobSolution41 {
+
+    /**
+     * Creates and starts the troubled streaming job.
+	 *
+	 * @throws Exception if the application is misconfigured or fails during job submission
+     */
+	public static void main(String[] args) throws Exception {
+		ParameterTool parameters = ParameterTool.fromArgs(args);
+
+		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
+
+		//Time Characteristics
+		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		env.getConfig().setAutoWatermarkInterval(100);
+		env.setBufferTimeout(10);
+
+		//Checkpointing Configuration
+		env.enableCheckpointing(5000);
+		env.getCheckpointConfig().setMinPauseBetweenCheckpoints(4000);
+
+		DataStream<Measurement> sourceStream = env
+				.addSource(SourceUtils.createFakeKafkaSource())
+				.name("FakeKafkaSource")
+				.uid("FakeKafkaSource")
+				.assignTimestampsAndWatermarks(
+						new MeasurementTSExtractor(Time.of(250, TimeUnit.MILLISECONDS),
+								Time.of(1, TimeUnit.SECONDS)))
+				.name("Watermarks")
+				.uid("Watermarks")
+				.flatMap(new MeasurementDeserializer())
+				.name("Deserialization")
+				.uid("Deserialization");
+
+		OutputTag<Measurement> lateDataTag = new OutputTag<Measurement>("late-data") {
+			private static final long serialVersionUID = 33513631677208956L;
+		};
+
+		SingleOutputStreamOperator<WindowedMeasurements> aggregatedPerLocation = sourceStream
+				.keyBy(Measurement::getLocation)
+				.timeWindow(Time.of(1, TimeUnit.SECONDS))
+				.sideOutputLateData(lateDataTag)
+				.aggregate(new MeasurementWindowAggregatingFunction(),
+						new MeasurementWindowProcessFunction())
+				.name("WindowedAggregationPerLocation")
+				.uid("WindowedAggregationPerLocation");
+
+		if (isLocal(parameters)) {
+			aggregatedPerLocation.print()
+					.name("NormalOutput")
+					.uid("NormalOutput")
+					.disableChaining();
+			aggregatedPerLocation.getSideOutput(lateDataTag).printToErr()
+					.name("LateDataSink")
+					.uid("LateDataSink")
+					.disableChaining();
+		} else {
+			aggregatedPerLocation.addSink(new DiscardingSink<>())
+					.name("NormalOutput")
+					.uid("NormalOutput")
+					.disableChaining();
+			aggregatedPerLocation.getSideOutput(lateDataTag).addSink(new DiscardingSink<>())
+					.name("LateDataSink")
+					.uid("LateDataSink")
+					.disableChaining();
+		}
+
+		env.execute(TroubledStreamingJobSolution41.class.getSimpleName());
+	}
+
+	/**
+	 * Deserializes the JSON Kafka message.
+	 */
+	public static class MeasurementDeserializer extends
+			RichFlatMapFunction<FakeKafkaRecord, Measurement> {
+		private static final long serialVersionUID = 3L;
+
+		private Counter numInvalidRecords;
+
+		@Override
+		public void open(final Configuration parameters) throws Exception {
+			super.open(parameters);
+			numInvalidRecords = getRuntimeContext().getMetricGroup().counter("numInvalidRecords");
+		}
+
+		@Override
+		public void flatMap(final FakeKafkaRecord kafkaRecord, final Collector<Measurement> out) {
+			final Measurement node;
+			try {
+				node = deserialize(kafkaRecord.getValue());
+			} catch (IOException e) {
+				numInvalidRecords.inc();
+				return;
+			}
+			out.collect(node);
+		}
+
+		private Measurement deserialize(final byte[] bytes) throws IOException {
+			return ObjectMapperSingleton.getInstance().readValue(bytes, Measurement.class);
+		}
+	}
+
+	public static class MeasurementTSExtractor implements
+			AssignerWithPeriodicWatermarks<FakeKafkaRecord> {
+		private static final long serialVersionUID = 2L;
+
+		private long currentMaxTimestamp;
+		private long lastEmittedWatermark = Long.MIN_VALUE;
+		private long lastRecordProcessingTime;
+
+		private final long maxOutOfOrderness;
+		private final long idleTimeout;
+
+		MeasurementTSExtractor(Time maxOutOfOrderness, Time idleTimeout) {
+			if (maxOutOfOrderness.toMilliseconds() < 0) {
+				throw new RuntimeException("Tried to set the maximum allowed " +
+						"lateness to " + maxOutOfOrderness +
+						". This parameter cannot be negative.");
+			}
+
+			if (idleTimeout.toMilliseconds() < 0) {
+				throw new RuntimeException("Tried to set the idle Timeout" + idleTimeout +
+						". This parameter cannot be negative.");
+			}
+
+			this.maxOutOfOrderness = maxOutOfOrderness.toMilliseconds();
+			this.idleTimeout = idleTimeout.toMilliseconds();
+			this.currentMaxTimestamp = Long.MIN_VALUE;
+		}
+
+		/**
+		 * Gets the configured out of orderness (in ms).
+		 */
+		public long getMaxOutOfOrdernessInMillis() {
+			return maxOutOfOrderness;
+		}
+
+		@Override
+		public final Watermark getCurrentWatermark() {
+
+			// if last record was processed more than the idleTimeout in the past, consider this
+			// source idle and set timestamp to current processing time
+			long currentProcessingTime = System.currentTimeMillis();
+			if (lastRecordProcessingTime < currentProcessingTime - idleTimeout) {
+				this.currentMaxTimestamp = currentProcessingTime;
+			}
+
+			long potentialWM = this.currentMaxTimestamp - maxOutOfOrderness;
+			if (potentialWM >= lastEmittedWatermark) {
+				lastEmittedWatermark = potentialWM;
+			}
+			return new Watermark(lastEmittedWatermark);
+		}
+
+		@Override
+		public final long extractTimestamp(FakeKafkaRecord element, long previousElementTimestamp) {
+			lastRecordProcessingTime = System.currentTimeMillis();
+			long timestamp = element.getTimestamp();
+			if (timestamp > currentMaxTimestamp) {
+				currentMaxTimestamp = timestamp;
+			}
+			return timestamp;
+		}
+	}
+
+	public static class MeasurementWindowAggregatingFunction
+			implements AggregateFunction<Measurement, WindowedMeasurements, WindowedMeasurements> {
+		private static final long serialVersionUID = -1083906142198231377L;
+
+		@Override
+		public WindowedMeasurements createAccumulator() {
+			return new WindowedMeasurements();
+		}
+
+		@Override
+		public WindowedMeasurements add(
+				final Measurement record,
+				final WindowedMeasurements aggregate) {
+			aggregate.addMeasurement(record);
+			return aggregate;
+		}
+
+		@Override
+		public WindowedMeasurements getResult(final WindowedMeasurements windowedMeasurements) {
+			return windowedMeasurements;
+		}
+
+		@Override
+		public WindowedMeasurements merge(
+				final WindowedMeasurements agg1,
+				final WindowedMeasurements agg2) {
+			agg2.setEventsPerWindow(agg1.getEventsPerWindow() + agg2.getEventsPerWindow());
+			agg2.setSumPerWindow(agg1.getSumPerWindow() + agg2.getSumPerWindow());
+			return agg2;
+		}
+	}
+
+	public static class MeasurementWindowProcessFunction
+			extends
+			ProcessWindowFunction<WindowedMeasurements, WindowedMeasurements, String, TimeWindow> {
+		private static final long serialVersionUID = 1L;
+
+		private static final int EVENT_TIME_LAG_WINDOW_SIZE = 10_000;
+
+		private transient DescriptiveStatisticsHistogram eventTimeLag;
+
+		@Override
+		public void process(
+				final String location,
+				final Context context,
+				final Iterable<WindowedMeasurements> input,
+				final Collector<WindowedMeasurements> out) {
+
+			// Windows with pre-aggregation only forward the final to the WindowFunction
+			WindowedMeasurements aggregate = input.iterator().next();
+
+			final TimeWindow window = context.window();
+			aggregate.setWindow(window);
+			aggregate.setLocation(location);
+
+			eventTimeLag.update(System.currentTimeMillis() - window.getEnd());
+			out.collect(aggregate);
+		}
+
+		@Override
+		public void open(Configuration parameters) throws Exception {
+			super.open(parameters);
+
+			eventTimeLag = getRuntimeContext().getMetricGroup().histogram("eventTimeLag",
+					new DescriptiveStatisticsHistogram(EVENT_TIME_LAG_WINDOW_SIZE));
+		}
+	}
+
+	private static class ObjectMapperSingleton {
+		static ObjectMapper getInstance() {
+			ObjectMapper objectMapper = new ObjectMapper();
+			objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+			return objectMapper;
+		}
+	}
+}

--- a/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution42.java
+++ b/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution42.java
@@ -6,7 +6,6 @@ import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -14,6 +13,7 @@ import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
 import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 import org.apache.flink.util.Collector;
@@ -48,8 +48,7 @@ public class TroubledStreamingJobSolution42 {
 
 		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
 
-		//Time Characteristics
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		//Timing Configuration
 		env.getConfig().setAutoWatermarkInterval(100);
 		env.setBufferTimeout(10);
 
@@ -76,7 +75,7 @@ public class TroubledStreamingJobSolution42 {
 
 		SingleOutputStreamOperator<WindowedMeasurements> aggregatedPerLocation = sourceStream
 				.keyBy(Measurement::getLocation)
-				.timeWindow(Time.of(1, TimeUnit.SECONDS))
+				.window(TumblingEventTimeWindows.of(Time.seconds(1)))
 				.sideOutputLateData(lateDataTag)
 				.aggregate(new MeasurementWindowAggregatingFunction(),
 						new MeasurementWindowProcessFunction())

--- a/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution42.java
+++ b/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution42.java
@@ -1,0 +1,279 @@
+package com.ververica.flink.training.solutions;
+
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.api.common.functions.RichFlatMapFunction;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
+import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.OutputTag;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ververica.flink.training.common.FakeKafkaRecord;
+import com.ververica.flink.training.common.Measurement;
+import com.ververica.flink.training.common.SourceUtils;
+import com.ververica.flink.training.common.WindowedMeasurements;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import static com.ververica.flink.training.common.EnvironmentUtils.createConfiguredEnvironment;
+import static com.ververica.flink.training.common.EnvironmentUtils.isLocal;
+
+/**
+ * Troubled streaming job evolved on top of {@link TroubledStreamingJobSolution41} by optimising
+ * throughput initializing {@link ObjectMapper} only once.
+ */
+public class TroubledStreamingJobSolution42 {
+
+    /**
+     * Creates and starts the troubled streaming job.
+	 *
+	 * @throws Exception if the application is misconfigured or fails during job submission
+     */
+	public static void main(String[] args) throws Exception {
+		ParameterTool parameters = ParameterTool.fromArgs(args);
+
+		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
+
+		//Time Characteristics
+		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		env.getConfig().setAutoWatermarkInterval(100);
+		env.setBufferTimeout(10);
+
+		//Checkpointing Configuration
+		env.enableCheckpointing(5000);
+		env.getCheckpointConfig().setMinPauseBetweenCheckpoints(4000);
+
+		DataStream<Measurement> sourceStream = env
+				.addSource(SourceUtils.createFakeKafkaSource())
+				.name("FakeKafkaSource")
+				.uid("FakeKafkaSource")
+				.assignTimestampsAndWatermarks(
+						new MeasurementTSExtractor(Time.of(250, TimeUnit.MILLISECONDS),
+								Time.of(1, TimeUnit.SECONDS)))
+				.name("Watermarks")
+				.uid("Watermarks")
+				.flatMap(new MeasurementDeserializer())
+				.name("Deserialization")
+				.uid("Deserialization");
+
+		OutputTag<Measurement> lateDataTag = new OutputTag<Measurement>("late-data") {
+			private static final long serialVersionUID = 33513631677208956L;
+		};
+
+		SingleOutputStreamOperator<WindowedMeasurements> aggregatedPerLocation = sourceStream
+				.keyBy(Measurement::getLocation)
+				.timeWindow(Time.of(1, TimeUnit.SECONDS))
+				.sideOutputLateData(lateDataTag)
+				.aggregate(new MeasurementWindowAggregatingFunction(),
+						new MeasurementWindowProcessFunction())
+				.name("WindowedAggregationPerLocation")
+				.uid("WindowedAggregationPerLocation");
+
+		if (isLocal(parameters)) {
+			aggregatedPerLocation.print()
+					.name("NormalOutput")
+					.uid("NormalOutput")
+					.disableChaining();
+			aggregatedPerLocation.getSideOutput(lateDataTag).printToErr()
+					.name("LateDataSink")
+					.uid("LateDataSink")
+					.disableChaining();
+		} else {
+			aggregatedPerLocation.addSink(new DiscardingSink<>())
+					.name("NormalOutput")
+					.uid("NormalOutput")
+					.disableChaining();
+			aggregatedPerLocation.getSideOutput(lateDataTag).addSink(new DiscardingSink<>())
+					.name("LateDataSink")
+					.uid("LateDataSink")
+					.disableChaining();
+		}
+
+		env.execute(TroubledStreamingJobSolution42.class.getSimpleName());
+	}
+
+	/**
+	 * Deserializes the JSON Kafka message.
+	 */
+	public static class MeasurementDeserializer extends
+			RichFlatMapFunction<FakeKafkaRecord, Measurement> {
+		private static final long serialVersionUID = 3L;
+
+		private Counter numInvalidRecords;
+		private transient ObjectMapper instance;
+
+		@Override
+		public void open(final Configuration parameters) throws Exception {
+			super.open(parameters);
+			numInvalidRecords = getRuntimeContext().getMetricGroup().counter("numInvalidRecords");
+			instance = createObjectMapper();
+		}
+
+		@Override
+		public void flatMap(final FakeKafkaRecord kafkaRecord, final Collector<Measurement> out) {
+			final Measurement node;
+			try {
+				node = deserialize(kafkaRecord.getValue());
+			} catch (IOException e) {
+				numInvalidRecords.inc();
+				return;
+			}
+			out.collect(node);
+		}
+
+		private Measurement deserialize(final byte[] bytes) throws IOException {
+			return instance.readValue(bytes, Measurement.class);
+		}
+	}
+
+	public static class MeasurementTSExtractor implements
+			AssignerWithPeriodicWatermarks<FakeKafkaRecord> {
+		private static final long serialVersionUID = 2L;
+
+		private long currentMaxTimestamp;
+		private long lastEmittedWatermark = Long.MIN_VALUE;
+		private long lastRecordProcessingTime;
+
+		private final long maxOutOfOrderness;
+		private final long idleTimeout;
+
+		MeasurementTSExtractor(Time maxOutOfOrderness, Time idleTimeout) {
+			if (maxOutOfOrderness.toMilliseconds() < 0) {
+				throw new RuntimeException("Tried to set the maximum allowed " +
+						"lateness to " + maxOutOfOrderness +
+						". This parameter cannot be negative.");
+			}
+
+			if (idleTimeout.toMilliseconds() < 0) {
+				throw new RuntimeException("Tried to set the idle Timeout" + idleTimeout +
+						". This parameter cannot be negative.");
+			}
+
+			this.maxOutOfOrderness = maxOutOfOrderness.toMilliseconds();
+			this.idleTimeout = idleTimeout.toMilliseconds();
+			this.currentMaxTimestamp = Long.MIN_VALUE;
+		}
+
+		/**
+		 * Gets the configured out of orderness (in ms).
+		 */
+		public long getMaxOutOfOrdernessInMillis() {
+			return maxOutOfOrderness;
+		}
+
+		@Override
+		public final Watermark getCurrentWatermark() {
+
+			// if last record was processed more than the idleTimeout in the past, consider this
+			// source idle and set timestamp to current processing time
+			long currentProcessingTime = System.currentTimeMillis();
+			if (lastRecordProcessingTime < currentProcessingTime - idleTimeout) {
+				this.currentMaxTimestamp = currentProcessingTime;
+			}
+
+			long potentialWM = this.currentMaxTimestamp - maxOutOfOrderness;
+			if (potentialWM >= lastEmittedWatermark) {
+				lastEmittedWatermark = potentialWM;
+			}
+			return new Watermark(lastEmittedWatermark);
+		}
+
+		@Override
+		public final long extractTimestamp(FakeKafkaRecord element, long previousElementTimestamp) {
+			lastRecordProcessingTime = System.currentTimeMillis();
+			long timestamp = element.getTimestamp();
+			if (timestamp > currentMaxTimestamp) {
+				currentMaxTimestamp = timestamp;
+			}
+			return timestamp;
+		}
+	}
+
+	public static class MeasurementWindowAggregatingFunction
+			implements AggregateFunction<Measurement, WindowedMeasurements, WindowedMeasurements> {
+		private static final long serialVersionUID = -1083906142198231377L;
+
+		@Override
+		public WindowedMeasurements createAccumulator() {
+			return new WindowedMeasurements();
+		}
+
+		@Override
+		public WindowedMeasurements add(
+				final Measurement record,
+				final WindowedMeasurements aggregate) {
+			aggregate.addMeasurement(record);
+			return aggregate;
+		}
+
+		@Override
+		public WindowedMeasurements getResult(final WindowedMeasurements windowedMeasurements) {
+			return windowedMeasurements;
+		}
+
+		@Override
+		public WindowedMeasurements merge(
+				final WindowedMeasurements agg1,
+				final WindowedMeasurements agg2) {
+			agg2.setEventsPerWindow(agg1.getEventsPerWindow() + agg2.getEventsPerWindow());
+			agg2.setSumPerWindow(agg1.getSumPerWindow() + agg2.getSumPerWindow());
+			return agg2;
+		}
+	}
+
+	public static class MeasurementWindowProcessFunction
+			extends
+			ProcessWindowFunction<WindowedMeasurements, WindowedMeasurements, String, TimeWindow> {
+		private static final long serialVersionUID = 1L;
+
+		private static final int EVENT_TIME_LAG_WINDOW_SIZE = 10_000;
+
+		private transient DescriptiveStatisticsHistogram eventTimeLag;
+
+		@Override
+		public void process(
+				final String location,
+				final Context context,
+				final Iterable<WindowedMeasurements> input,
+				final Collector<WindowedMeasurements> out) {
+
+			// Windows with pre-aggregation only forward the final to the WindowFunction
+			WindowedMeasurements aggregate = input.iterator().next();
+
+			final TimeWindow window = context.window();
+			aggregate.setWindow(window);
+			aggregate.setLocation(location);
+
+			eventTimeLag.update(System.currentTimeMillis() - window.getEnd());
+			out.collect(aggregate);
+		}
+
+		@Override
+		public void open(Configuration parameters) throws Exception {
+			super.open(parameters);
+
+			eventTimeLag = getRuntimeContext().getMetricGroup().histogram("eventTimeLag",
+					new DescriptiveStatisticsHistogram(EVENT_TIME_LAG_WINDOW_SIZE));
+		}
+	}
+
+	private static ObjectMapper createObjectMapper() {
+		ObjectMapper objectMapper = new ObjectMapper();
+		objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+		return objectMapper;
+	}
+}

--- a/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution42.java
+++ b/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution42.java
@@ -1,5 +1,6 @@
 package com.ververica.flink.training.solutions;
 
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.AggregateFunction;
 import org.apache.flink.api.common.functions.RichFlatMapFunction;
 import org.apache.flink.api.java.utils.ParameterTool;
@@ -9,10 +10,8 @@ import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
-import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
@@ -27,7 +26,7 @@ import com.ververica.flink.training.common.SourceUtils;
 import com.ververica.flink.training.common.WindowedMeasurements;
 
 import java.io.IOException;
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 
 import static com.ververica.flink.training.common.EnvironmentUtils.createConfiguredEnvironment;
 import static com.ververica.flink.training.common.EnvironmentUtils.isLocal;
@@ -61,8 +60,11 @@ public class TroubledStreamingJobSolution42 {
 				.name("FakeKafkaSource")
 				.uid("FakeKafkaSource")
 				.assignTimestampsAndWatermarks(
-						new MeasurementTSExtractor(Time.of(250, TimeUnit.MILLISECONDS),
-								Time.of(1, TimeUnit.SECONDS)))
+						WatermarkStrategy
+								.<FakeKafkaRecord>forBoundedOutOfOrderness(Duration.ofMillis(250))
+								.withTimestampAssigner(
+										(element, timestamp) -> element.getTimestamp())
+								.withIdleness(Duration.ofSeconds(1)))
 				.name("Watermarks")
 				.uid("Watermarks")
 				.flatMap(new MeasurementDeserializer())
@@ -136,69 +138,6 @@ public class TroubledStreamingJobSolution42 {
 
 		private Measurement deserialize(final byte[] bytes) throws IOException {
 			return instance.readValue(bytes, Measurement.class);
-		}
-	}
-
-	public static class MeasurementTSExtractor implements
-			AssignerWithPeriodicWatermarks<FakeKafkaRecord> {
-		private static final long serialVersionUID = 2L;
-
-		private long currentMaxTimestamp;
-		private long lastEmittedWatermark = Long.MIN_VALUE;
-		private long lastRecordProcessingTime;
-
-		private final long maxOutOfOrderness;
-		private final long idleTimeout;
-
-		MeasurementTSExtractor(Time maxOutOfOrderness, Time idleTimeout) {
-			if (maxOutOfOrderness.toMilliseconds() < 0) {
-				throw new RuntimeException("Tried to set the maximum allowed " +
-						"lateness to " + maxOutOfOrderness +
-						". This parameter cannot be negative.");
-			}
-
-			if (idleTimeout.toMilliseconds() < 0) {
-				throw new RuntimeException("Tried to set the idle Timeout" + idleTimeout +
-						". This parameter cannot be negative.");
-			}
-
-			this.maxOutOfOrderness = maxOutOfOrderness.toMilliseconds();
-			this.idleTimeout = idleTimeout.toMilliseconds();
-			this.currentMaxTimestamp = Long.MIN_VALUE;
-		}
-
-		/**
-		 * Gets the configured out of orderness (in ms).
-		 */
-		public long getMaxOutOfOrdernessInMillis() {
-			return maxOutOfOrderness;
-		}
-
-		@Override
-		public final Watermark getCurrentWatermark() {
-
-			// if last record was processed more than the idleTimeout in the past, consider this
-			// source idle and set timestamp to current processing time
-			long currentProcessingTime = System.currentTimeMillis();
-			if (lastRecordProcessingTime < currentProcessingTime - idleTimeout) {
-				this.currentMaxTimestamp = currentProcessingTime;
-			}
-
-			long potentialWM = this.currentMaxTimestamp - maxOutOfOrderness;
-			if (potentialWM >= lastEmittedWatermark) {
-				lastEmittedWatermark = potentialWM;
-			}
-			return new Watermark(lastEmittedWatermark);
-		}
-
-		@Override
-		public final long extractTimestamp(FakeKafkaRecord element, long previousElementTimestamp) {
-			lastRecordProcessingTime = System.currentTimeMillis();
-			long timestamp = element.getTimestamp();
-			if (timestamp > currentMaxTimestamp) {
-				currentMaxTimestamp = timestamp;
-			}
-			return timestamp;
 		}
 	}
 

--- a/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution43.java
+++ b/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution43.java
@@ -1,5 +1,6 @@
 package com.ververica.flink.training.solutions;
 
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.AggregateFunction;
 import org.apache.flink.api.common.functions.RichFlatMapFunction;
 import org.apache.flink.api.java.utils.ParameterTool;
@@ -9,10 +10,8 @@ import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
-import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
@@ -26,7 +25,7 @@ import com.ververica.flink.training.common.SourceUtils;
 import com.ververica.flink.training.common.WindowedMeasurements;
 
 import java.io.IOException;
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 
 import static com.ververica.flink.training.common.EnvironmentUtils.createConfiguredEnvironment;
 import static com.ververica.flink.training.common.EnvironmentUtils.isLocal;
@@ -60,8 +59,11 @@ public class TroubledStreamingJobSolution43 {
 				.name("FakeKafkaSource")
 				.uid("FakeKafkaSource")
 				.assignTimestampsAndWatermarks(
-						new MeasurementTSExtractor(Time.of(250, TimeUnit.MILLISECONDS),
-								Time.of(1, TimeUnit.SECONDS)))
+						WatermarkStrategy
+								.<FakeKafkaRecord>forBoundedOutOfOrderness(Duration.ofMillis(250))
+								.withTimestampAssigner(
+										(element, timestamp) -> element.getTimestamp())
+								.withIdleness(Duration.ofSeconds(1)))
 				.name("Watermarks")
 				.uid("Watermarks")
 				.flatMap(new MeasurementDeserializer())
@@ -137,69 +139,6 @@ public class TroubledStreamingJobSolution43 {
 
 		private SimpleMeasurement deserialize(final byte[] bytes) throws IOException {
 			return instance.readValue(bytes, SimpleMeasurement.class);
-		}
-	}
-
-	public static class MeasurementTSExtractor implements
-			AssignerWithPeriodicWatermarks<FakeKafkaRecord> {
-		private static final long serialVersionUID = 2L;
-
-		private long currentMaxTimestamp;
-		private long lastEmittedWatermark = Long.MIN_VALUE;
-		private long lastRecordProcessingTime;
-
-		private final long maxOutOfOrderness;
-		private final long idleTimeout;
-
-		MeasurementTSExtractor(Time maxOutOfOrderness, Time idleTimeout) {
-			if (maxOutOfOrderness.toMilliseconds() < 0) {
-				throw new RuntimeException("Tried to set the maximum allowed " +
-						"lateness to " + maxOutOfOrderness +
-						". This parameter cannot be negative.");
-			}
-
-			if (idleTimeout.toMilliseconds() < 0) {
-				throw new RuntimeException("Tried to set the idle Timeout" + idleTimeout +
-						". This parameter cannot be negative.");
-			}
-
-			this.maxOutOfOrderness = maxOutOfOrderness.toMilliseconds();
-			this.idleTimeout = idleTimeout.toMilliseconds();
-			this.currentMaxTimestamp = Long.MIN_VALUE;
-		}
-
-		/**
-		 * Gets the configured out of orderness (in ms).
-		 */
-		public long getMaxOutOfOrdernessInMillis() {
-			return maxOutOfOrderness;
-		}
-
-		@Override
-		public final Watermark getCurrentWatermark() {
-
-			// if last record was processed more than the idleTimeout in the past, consider this
-			// source idle and set timestamp to current processing time
-			long currentProcessingTime = System.currentTimeMillis();
-			if (lastRecordProcessingTime < currentProcessingTime - idleTimeout) {
-				this.currentMaxTimestamp = currentProcessingTime;
-			}
-
-			long potentialWM = this.currentMaxTimestamp - maxOutOfOrderness;
-			if (potentialWM >= lastEmittedWatermark) {
-				lastEmittedWatermark = potentialWM;
-			}
-			return new Watermark(lastEmittedWatermark);
-		}
-
-		@Override
-		public final long extractTimestamp(FakeKafkaRecord element, long previousElementTimestamp) {
-			lastRecordProcessingTime = System.currentTimeMillis();
-			long timestamp = element.getTimestamp();
-			if (timestamp > currentMaxTimestamp) {
-				currentMaxTimestamp = timestamp;
-			}
-			return timestamp;
 		}
 	}
 

--- a/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution43.java
+++ b/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution43.java
@@ -6,7 +6,6 @@ import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -14,6 +13,7 @@ import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
 import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 import org.apache.flink.util.Collector;
@@ -47,8 +47,7 @@ public class TroubledStreamingJobSolution43 {
 
 		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
 
-		//Time Characteristics
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		//Timing Configuration
 		env.getConfig().setAutoWatermarkInterval(100);
 		env.setBufferTimeout(10);
 
@@ -75,7 +74,7 @@ public class TroubledStreamingJobSolution43 {
 
 		SingleOutputStreamOperator<WindowedMeasurements> aggregatedPerLocation = sourceStream
 				.keyBy(SimpleMeasurement::getLocation)
-				.timeWindow(Time.of(1, TimeUnit.SECONDS))
+				.window(TumblingEventTimeWindows.of(Time.seconds(1)))
 				.sideOutputLateData(lateDataTag)
 				.aggregate(new MeasurementWindowAggregatingFunction(),
 						new MeasurementWindowProcessFunction())

--- a/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution43.java
+++ b/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution43.java
@@ -1,0 +1,282 @@
+package com.ververica.flink.training.solutions;
+
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.api.common.functions.RichFlatMapFunction;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
+import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.OutputTag;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ververica.flink.training.common.FakeKafkaRecord;
+import com.ververica.flink.training.common.SourceUtils;
+import com.ververica.flink.training.common.WindowedMeasurements;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import static com.ververica.flink.training.common.EnvironmentUtils.createConfiguredEnvironment;
+import static com.ververica.flink.training.common.EnvironmentUtils.isLocal;
+
+/**
+ * Troubled streaming job evolved on top of {@link TroubledStreamingJobSolution42} by optimising
+ * throughput removing unnecessary POJO fields.
+ */
+public class TroubledStreamingJobSolution43 {
+
+    /**
+     * Creates and starts the troubled streaming job.
+	 *
+	 * @throws Exception if the application is misconfigured or fails during job submission
+     */
+	public static void main(String[] args) throws Exception {
+		ParameterTool parameters = ParameterTool.fromArgs(args);
+
+		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
+
+		//Time Characteristics
+		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		env.getConfig().setAutoWatermarkInterval(100);
+		env.setBufferTimeout(10);
+
+		//Checkpointing Configuration
+		env.enableCheckpointing(5000);
+		env.getCheckpointConfig().setMinPauseBetweenCheckpoints(4000);
+
+		DataStream<SimpleMeasurement> sourceStream = env
+				.addSource(SourceUtils.createFakeKafkaSource())
+				.name("FakeKafkaSource")
+				.uid("FakeKafkaSource")
+				.assignTimestampsAndWatermarks(
+						new MeasurementTSExtractor(Time.of(250, TimeUnit.MILLISECONDS),
+								Time.of(1, TimeUnit.SECONDS)))
+				.name("Watermarks")
+				.uid("Watermarks")
+				.flatMap(new MeasurementDeserializer())
+				.name("Deserialization")
+				.uid("Deserialization");
+
+		OutputTag<SimpleMeasurement> lateDataTag = new OutputTag<SimpleMeasurement>("late-data") {
+			private static final long serialVersionUID = 33513631677208956L;
+		};
+
+		SingleOutputStreamOperator<WindowedMeasurements> aggregatedPerLocation = sourceStream
+				.keyBy(SimpleMeasurement::getLocation)
+				.timeWindow(Time.of(1, TimeUnit.SECONDS))
+				.sideOutputLateData(lateDataTag)
+				.aggregate(new MeasurementWindowAggregatingFunction(),
+						new MeasurementWindowProcessFunction())
+				.name("WindowedAggregationPerLocation")
+				.uid("WindowedAggregationPerLocation");
+
+		if (isLocal(parameters)) {
+			aggregatedPerLocation.print()
+					.name("NormalOutput")
+					.uid("NormalOutput")
+					.disableChaining();
+			aggregatedPerLocation.getSideOutput(lateDataTag).printToErr()
+					.name("LateDataSink")
+					.uid("LateDataSink")
+					.disableChaining();
+		} else {
+			aggregatedPerLocation.addSink(new DiscardingSink<>())
+					.name("NormalOutput")
+					.uid("NormalOutput")
+					.disableChaining();
+			aggregatedPerLocation.getSideOutput(lateDataTag).addSink(new DiscardingSink<>())
+					.name("LateDataSink")
+					.uid("LateDataSink")
+					.disableChaining();
+		}
+
+		env.execute(TroubledStreamingJobSolution43.class.getSimpleName());
+	}
+
+	/**
+	 * Deserializes the JSON Kafka message.
+	 */
+	public static class MeasurementDeserializer extends
+			RichFlatMapFunction<FakeKafkaRecord, SimpleMeasurement> {
+		private static final long serialVersionUID = 4L;
+
+		private Counter numInvalidRecords;
+		private transient ObjectMapper instance;
+
+		@Override
+		public void open(final Configuration parameters) throws Exception {
+			super.open(parameters);
+			numInvalidRecords = getRuntimeContext().getMetricGroup().counter("numInvalidRecords");
+			instance = createObjectMapper();
+		}
+
+		@Override
+		public void flatMap(
+				final FakeKafkaRecord kafkaRecord,
+				final Collector<SimpleMeasurement> out) {
+			final SimpleMeasurement node;
+			try {
+				node = deserialize(kafkaRecord.getValue());
+			} catch (IOException e) {
+				numInvalidRecords.inc();
+				return;
+			}
+			out.collect(node);
+		}
+
+		private SimpleMeasurement deserialize(final byte[] bytes) throws IOException {
+			return instance.readValue(bytes, SimpleMeasurement.class);
+		}
+	}
+
+	public static class MeasurementTSExtractor implements
+			AssignerWithPeriodicWatermarks<FakeKafkaRecord> {
+		private static final long serialVersionUID = 2L;
+
+		private long currentMaxTimestamp;
+		private long lastEmittedWatermark = Long.MIN_VALUE;
+		private long lastRecordProcessingTime;
+
+		private final long maxOutOfOrderness;
+		private final long idleTimeout;
+
+		MeasurementTSExtractor(Time maxOutOfOrderness, Time idleTimeout) {
+			if (maxOutOfOrderness.toMilliseconds() < 0) {
+				throw new RuntimeException("Tried to set the maximum allowed " +
+						"lateness to " + maxOutOfOrderness +
+						". This parameter cannot be negative.");
+			}
+
+			if (idleTimeout.toMilliseconds() < 0) {
+				throw new RuntimeException("Tried to set the idle Timeout" + idleTimeout +
+						". This parameter cannot be negative.");
+			}
+
+			this.maxOutOfOrderness = maxOutOfOrderness.toMilliseconds();
+			this.idleTimeout = idleTimeout.toMilliseconds();
+			this.currentMaxTimestamp = Long.MIN_VALUE;
+		}
+
+		/**
+		 * Gets the configured out of orderness (in ms).
+		 */
+		public long getMaxOutOfOrdernessInMillis() {
+			return maxOutOfOrderness;
+		}
+
+		@Override
+		public final Watermark getCurrentWatermark() {
+
+			// if last record was processed more than the idleTimeout in the past, consider this
+			// source idle and set timestamp to current processing time
+			long currentProcessingTime = System.currentTimeMillis();
+			if (lastRecordProcessingTime < currentProcessingTime - idleTimeout) {
+				this.currentMaxTimestamp = currentProcessingTime;
+			}
+
+			long potentialWM = this.currentMaxTimestamp - maxOutOfOrderness;
+			if (potentialWM >= lastEmittedWatermark) {
+				lastEmittedWatermark = potentialWM;
+			}
+			return new Watermark(lastEmittedWatermark);
+		}
+
+		@Override
+		public final long extractTimestamp(FakeKafkaRecord element, long previousElementTimestamp) {
+			lastRecordProcessingTime = System.currentTimeMillis();
+			long timestamp = element.getTimestamp();
+			if (timestamp > currentMaxTimestamp) {
+				currentMaxTimestamp = timestamp;
+			}
+			return timestamp;
+		}
+	}
+
+	public static class MeasurementWindowAggregatingFunction
+			implements
+			AggregateFunction<SimpleMeasurement, WindowedMeasurements, WindowedMeasurements> {
+		private static final long serialVersionUID = -1083906142198231377L;
+
+		@Override
+		public WindowedMeasurements createAccumulator() {
+			return new WindowedMeasurements();
+		}
+
+		@Override
+		public WindowedMeasurements add(
+				final SimpleMeasurement record,
+				final WindowedMeasurements aggregate) {
+			double result = record.getValue();
+			aggregate.addMeasurement(result);
+			return aggregate;
+		}
+
+		@Override
+		public WindowedMeasurements getResult(final WindowedMeasurements windowedMeasurements) {
+			return windowedMeasurements;
+		}
+
+		@Override
+		public WindowedMeasurements merge(
+				final WindowedMeasurements agg1,
+				final WindowedMeasurements agg2) {
+			agg2.setEventsPerWindow(agg1.getEventsPerWindow() + agg2.getEventsPerWindow());
+			agg2.setSumPerWindow(agg1.getSumPerWindow() + agg2.getSumPerWindow());
+			return agg2;
+		}
+	}
+
+	public static class MeasurementWindowProcessFunction
+			extends
+			ProcessWindowFunction<WindowedMeasurements, WindowedMeasurements, String, TimeWindow> {
+		private static final long serialVersionUID = 1L;
+
+		private static final int EVENT_TIME_LAG_WINDOW_SIZE = 10_000;
+
+		private transient DescriptiveStatisticsHistogram eventTimeLag;
+
+		@Override
+		public void process(
+				final String location,
+				final Context context,
+				final Iterable<WindowedMeasurements> input,
+				final Collector<WindowedMeasurements> out) {
+
+			// Windows with pre-aggregation only forward the final to the WindowFunction
+			WindowedMeasurements aggregate = input.iterator().next();
+
+			final TimeWindow window = context.window();
+			aggregate.setWindow(window);
+			aggregate.setLocation(location);
+
+			eventTimeLag.update(System.currentTimeMillis() - window.getEnd());
+			out.collect(aggregate);
+		}
+
+		@Override
+		public void open(Configuration parameters) throws Exception {
+			super.open(parameters);
+
+			eventTimeLag = getRuntimeContext().getMetricGroup().histogram("eventTimeLag",
+					new DescriptiveStatisticsHistogram(EVENT_TIME_LAG_WINDOW_SIZE));
+		}
+	}
+
+	private static ObjectMapper createObjectMapper() {
+		ObjectMapper objectMapper = new ObjectMapper();
+		objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+		return objectMapper;
+	}
+}

--- a/troubleshooting/object-reuse/README.md
+++ b/troubleshooting/object-reuse/README.md
@@ -1,0 +1,7 @@
+# Lab: Advanced Tuning & Troubleshooting: Object Reuse
+
+...
+
+-----
+
+[**Back to Tuning & Troubleshooting Labs Overview**](../README.md)

--- a/troubleshooting/object-reuse/build.gradle
+++ b/troubleshooting/object-reuse/build.gradle
@@ -1,0 +1,17 @@
+group = 'com.ververica'
+mainClassName = 'com.ververica.flink.training.exercises.TroubledStreamingJob'
+
+dependencies {
+    implementation project(path: ':troubleshooting:common')
+    // transitive dependencies for flinkShadowJar need to be defined above
+    // (the alternative of using configuration: 'shadow' does not work there because that adds a dependency on
+    // the jar file, not the sources)
+    flinkShadowJar project(path: ':troubleshooting:common', transitive: false)
+}
+
+sourceSets {
+    main.java.srcDirs += 'src/provided/java'
+    tasks.withType(ScalaCompile) { 
+        main.scala.srcDirs += 'src/provided/scala'
+    }
+}

--- a/troubleshooting/object-reuse/build.gradle
+++ b/troubleshooting/object-reuse/build.gradle
@@ -1,4 +1,3 @@
-group = 'com.ververica'
 mainClassName = 'com.ververica.flink.training.exercises.TroubledStreamingJob'
 
 dependencies {

--- a/troubleshooting/object-reuse/src/main/java/com/ververica/flink/training/exercises/ObjectReuseJob.java
+++ b/troubleshooting/object-reuse/src/main/java/com/ververica/flink/training/exercises/ObjectReuseJob.java
@@ -12,6 +12,7 @@ import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.streaming.api.windowing.assigners.SlidingProcessingTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.OutputTag;
@@ -25,7 +26,6 @@ import com.ververica.flink.training.provided.WeatherUtils;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import static com.ververica.flink.training.common.EnvironmentUtils.createConfiguredEnvironment;
 
@@ -104,7 +104,7 @@ public class ObjectReuseJob {
 		// (3) stream with an windowed-average of the temperature (to smoothens sensor
 		//     measurements, variant B); then converted into local temperature units (°F in the US)
 		keyedTemperatureStream
-				.timeWindow(Time.of(10, TimeUnit.SECONDS), Time.of(1, TimeUnit.SECONDS))
+				.window(SlidingProcessingTimeWindows.of(Time.seconds(10), Time.seconds(1)))
 				.aggregate(new WindowAverageSensor())
 				.name("WindowAverageTemperature")
 				.uid("WindowAverageTemperature")

--- a/troubleshooting/object-reuse/src/main/java/com/ververica/flink/training/exercises/ObjectReuseJob.java
+++ b/troubleshooting/object-reuse/src/main/java/com/ververica/flink/training/exercises/ObjectReuseJob.java
@@ -1,0 +1,306 @@
+package com.ververica.flink.training.exercises;
+
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.api.common.functions.RichFlatMapFunction;
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.datastream.DataStreamUtils;
+import org.apache.flink.streaming.api.datastream.KeyedStream;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.OutputTag;
+
+import com.ververica.flink.training.provided.ExtendedMeasurement;
+import com.ververica.flink.training.provided.GeoUtils2;
+import com.ververica.flink.training.provided.MeanGauge;
+import com.ververica.flink.training.provided.ObjectReuseExtendedMeasurementSource;
+import com.ververica.flink.training.provided.WeatherUtils;
+
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static com.ververica.flink.training.common.EnvironmentUtils.createConfiguredEnvironment;
+
+/**
+ * Object reuse exercise.
+ */
+public class ObjectReuseJob {
+
+	/**
+	 * Creates and starts the object reuse job.
+	 *
+	 * @throws Exception if the application is misconfigured or fails during job submission
+	 */
+	public static void main(String[] args) throws Exception {
+		ParameterTool parameters = ParameterTool.fromArgs(args);
+
+		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
+
+		final boolean objectReuse = parameters.getBoolean("objectReuse", false);
+		if (objectReuse) {
+			env.getConfig().enableObjectReuse();
+		}
+
+		//Checkpointing Configuration
+		env.enableCheckpointing(5000);
+		env.getCheckpointConfig().setMinPauseBetweenCheckpoints(4000);
+
+		final OutputTag<ExtendedMeasurement> temperatureTag =
+				new OutputTag<ExtendedMeasurement>("temperature") {
+					private static final long serialVersionUID = -3127503822430851744L;
+				};
+		final OutputTag<ExtendedMeasurement> windTag =
+				new OutputTag<ExtendedMeasurement>("wind") {
+					private static final long serialVersionUID = 4249595595891069268L;
+				};
+
+		SingleOutputStreamOperator<ExtendedMeasurement> splitStream = env
+				.addSource(new ObjectReuseExtendedMeasurementSource())
+				.name("FakeMeasurementSource")
+				.uid("FakeMeasurementSource")
+				.keyBy(ExtendedMeasurement::getSensor)
+				.process(new SplitSensors(temperatureTag, windTag))
+				.name("SplitSensors")
+				.uid("SplitSensors");
+
+		// (1) stream with the temperature converted into local temperature units (°F in the US)
+		splitStream.getSideOutput(temperatureTag)
+				.map(new ConvertToLocalTemperature())
+				.name("ConvertToLocalTemperature")
+				.uid("ConvertToLocalTemperature")
+				.addSink(new DiscardingSink<>())
+				.name("LocalizedTemperatureSink")
+				.uid("LocalizedTemperatureSink")
+				.disableChaining();
+
+		// no need to do keyBy again; we did not change the key!
+		KeyedStream<ExtendedMeasurement, ExtendedMeasurement.Sensor> keyedTemperatureStream =
+				DataStreamUtils.reinterpretAsKeyedStream(
+						splitStream.getSideOutput(temperatureTag),
+						ExtendedMeasurement::getSensor);
+
+		// (2) stream with an (exponentially) moving average of the temperature (smoothens sensor
+		//     measurements, variant A); then converted into local temperature units (°F in the US)
+		keyedTemperatureStream
+				.flatMap(new MovingAverageSensors())
+				.name("MovingAverageTemperature")
+				.uid("MovingAverageTemperature")
+				.map(new ConvertToLocalTemperature())
+				.name("ConvertToLocalAverageTemperature")
+				.uid("ConvertToLocalAverageTemperature")
+				.addSink(new DiscardingSink<>())
+				.name("LocalizedAverageTemperatureSink")
+				.uid("LocalizedAverageTemperatureSink")
+				.disableChaining();
+
+		// (3) stream with an windowed-average of the temperature (to smoothens sensor
+		//     measurements, variant B); then converted into local temperature units (°F in the US)
+		keyedTemperatureStream
+				.timeWindow(Time.of(10, TimeUnit.SECONDS), Time.of(1, TimeUnit.SECONDS))
+				.aggregate(new WindowAverageSensor())
+				.name("WindowAverageTemperature")
+				.uid("WindowAverageTemperature")
+				.map(new ConvertToLocalTemperature())
+				.name("ConvertToLocalWindowedTemperature")
+				.uid("ConvertToLocalWindowedTemperature")
+				.addSink(new DiscardingSink<>())
+				.name("LocalizedWindowedTemperatureSink")
+				.uid("LocalizedWindowedTemperatureSink")
+				.disableChaining();
+
+		// (4) stream with the wind speed converted into local speed units (mph in the US)
+		splitStream.getSideOutput(windTag)
+				.map(new ConvertToLocalWindSpeed())
+				.name("NormalizeWindSpeed")
+				.uid("NormalizeWindSpeed")
+				.addSink(new DiscardingSink<>())
+				.name("WindSink")
+				.uid("WindSink")
+				.disableChaining();
+
+		env.execute(ObjectReuseJob.class.getSimpleName());
+	}
+
+	/**
+	 * Splits a stream into multiple side-outputs, one for each sensor.
+	 */
+	private static class SplitSensors extends
+			KeyedProcessFunction<ExtendedMeasurement.Sensor, ExtendedMeasurement, ExtendedMeasurement> {
+		private static final long serialVersionUID = 1L;
+
+		private final EnumMap<ExtendedMeasurement.SensorType, OutputTag<ExtendedMeasurement>>
+				outputTagBySensor =
+				new EnumMap<>(ExtendedMeasurement.SensorType.class);
+
+		SplitSensors(
+				OutputTag<ExtendedMeasurement> temperatureTag,
+				OutputTag<ExtendedMeasurement> windTag) {
+			outputTagBySensor.put(ExtendedMeasurement.SensorType.Temperature, temperatureTag);
+			outputTagBySensor.put(ExtendedMeasurement.SensorType.Wind, windTag);
+		}
+
+		@Override
+		public void processElement(
+				ExtendedMeasurement value,
+				Context ctx,
+				Collector<ExtendedMeasurement> out) {
+			ExtendedMeasurement.SensorType sensorType = value.getSensor().getSensorType();
+			OutputTag<ExtendedMeasurement> output = outputTagBySensor.get(sensorType);
+			ctx.output(output, value);
+		}
+	}
+
+	/**
+	 * Implements an exponentially moving average with a coefficient of <code>0.5</code>, i.e.
+	 * <ul>
+	 *     <li><code>avg[0] = value[0]</code> (not forwarded to the next stream)</li>
+	 *     <li><code>avg[i] = avg[i-1] * 0.5 + value[i] * 0.5</code> (for <code>i > 0</code>)</li>
+	 * </ul>
+	 *
+	 * <p>See <a href="https://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average">
+	 *     https://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average</a>
+	 */
+	private static class MovingAverageSensors extends
+			RichFlatMapFunction<ExtendedMeasurement, ExtendedMeasurement> {
+		private static final long serialVersionUID = 1L;
+
+		private final Map<ExtendedMeasurement.Sensor, Tuple2<Float, Double>> lastAverage =
+				new HashMap<>();
+
+		@Override
+		public void flatMap(ExtendedMeasurement value, Collector<ExtendedMeasurement> out) {
+			ExtendedMeasurement.Sensor sensor = value.getSensor();
+
+			Tuple2<Float, Double> last = lastAverage.get(sensor);
+			if (last != null) {
+				float newAccuracy = (last.f0 + value.getMeasurement().getAccuracy()) / 2.0f;
+				double newValue = (last.f1 + value.getMeasurement().getValue()) / 2.0;
+				value.getMeasurement().setAccuracy(newAccuracy);
+				value.getMeasurement().setValue(newValue);
+				// do not forward the first value (it only stands alone)
+				out.collect(value);
+			}
+			lastAverage.put(
+					sensor,
+					Tuple2.of(
+							value.getMeasurement().getAccuracy(),
+							value.getMeasurement().getValue()
+					));
+		}
+	}
+
+	@SuppressWarnings("WeakerAccess")
+	public static class WindowedAggregate {
+		public double sumValue = 0.0;
+		public double sumAccuracy = 0.0;
+		public long count = 0;
+		public ExtendedMeasurement lastValue = null;
+
+		/**
+		 * Constructor.
+		 */
+		public WindowedAggregate() {
+		}
+	}
+
+	/**
+	 * Aggregate function determining average sensor values and accuracies per sensor instance.
+	 */
+	private static class WindowAverageSensor implements
+			AggregateFunction<ExtendedMeasurement, WindowedAggregate, ExtendedMeasurement> {
+		@Override
+		public WindowedAggregate createAccumulator() {
+			return new WindowedAggregate();
+		}
+
+		@Override
+		public WindowedAggregate add(ExtendedMeasurement value, WindowedAggregate accumulator) {
+			accumulator.sumAccuracy += value.getMeasurement().getAccuracy();
+			accumulator.sumValue += value.getMeasurement().getValue();
+			accumulator.count++;
+			accumulator.lastValue = value;
+			return accumulator;
+		}
+
+		@Override
+		public ExtendedMeasurement getResult(WindowedAggregate accumulator) {
+			ExtendedMeasurement result = accumulator.lastValue;
+			result.getMeasurement().setValue(accumulator.sumValue / accumulator.count);
+			result.getMeasurement()
+					.setAccuracy((float) (accumulator.sumAccuracy / accumulator.count));
+			return result;
+		}
+
+		@Override
+		public WindowedAggregate merge(WindowedAggregate a, WindowedAggregate b) {
+			a.count += b.count;
+			a.sumValue += b.sumValue;
+			a.sumAccuracy += b.sumAccuracy;
+			if (b.lastValue.getMeasurement().getTimestamp() >
+					a.lastValue.getMeasurement().getTimestamp()) {
+				a.lastValue = b.lastValue;
+			}
+			return a;
+		}
+	}
+
+	/**
+	 * Converts SI units to locale-dependent units, i.e. °C to °F for the US. Adds a custom metric
+	 * to report temperatures in the US.
+	 */
+	private static class ConvertToLocalTemperature extends
+			RichMapFunction<ExtendedMeasurement, ExtendedMeasurement> {
+		private static final long serialVersionUID = 1L;
+
+		private transient MeanGauge normalizedTemperatureUS;
+
+		@Override
+		public void open(final Configuration parameters) {
+			normalizedTemperatureUS = getRuntimeContext().getMetricGroup()
+					.gauge("normalizedTemperatureUSmean", new MeanGauge());
+			getRuntimeContext().getMetricGroup().gauge(
+					"normalizedTemperatureUSmin", new MeanGauge.MinGauge(normalizedTemperatureUS));
+			getRuntimeContext().getMetricGroup().gauge(
+					"normalizedTemperatureUSmax", new MeanGauge.MaxGauge(normalizedTemperatureUS));
+		}
+
+		@Override
+		public ExtendedMeasurement map(ExtendedMeasurement value) {
+			ExtendedMeasurement.Location location = value.getLocation();
+			if (GeoUtils2.isInUS(location.getLongitude(), location.getLatitude())) {
+				ExtendedMeasurement.MeasurementValue measurement = value.getMeasurement();
+				double normalized = WeatherUtils.celciusToFahrenheit(measurement.getValue());
+				measurement.setValue(normalized);
+				normalizedTemperatureUS.addValue(normalized);
+			}
+			return value;
+		}
+	}
+
+	/**
+	 * Converts SI units to locale-dependent units, i.e. km/h to mph for the US. Adds a custom metric
+	 * to report wind speeds in the US.
+	 */
+	private static class ConvertToLocalWindSpeed extends
+			RichMapFunction<ExtendedMeasurement, ExtendedMeasurement> {
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public ExtendedMeasurement map(ExtendedMeasurement value) {
+			ExtendedMeasurement.Location location = value.getLocation();
+			if (GeoUtils2.isInUS(location.getLongitude(), location.getLatitude())) {
+				ExtendedMeasurement.MeasurementValue measurement = value.getMeasurement();
+				measurement.setValue(WeatherUtils.kphToMph(measurement.getValue()));
+			}
+			return value;
+		}
+	}
+}

--- a/troubleshooting/object-reuse/src/main/resources/log4j.properties
+++ b/troubleshooting/object-reuse/src/main/resources/log4j.properties
@@ -1,0 +1,23 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+log4j.rootLogger=INFO, console
+
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{HH:mm:ss,SSS} %-5p %-60c %x - %m%n

--- a/troubleshooting/object-reuse/src/provided/java/com/ververica/flink/training/provided/ExtendedMeasurement.java
+++ b/troubleshooting/object-reuse/src/provided/java/com/ververica/flink/training/provided/ExtendedMeasurement.java
@@ -1,0 +1,215 @@
+package com.ververica.flink.training.provided;
+
+import com.ververica.flink.training.common.DoNotChangeThis;
+
+import java.util.Objects;
+
+@DoNotChangeThis
+@SuppressWarnings({"WeakerAccess", "unused", "RedundantSuppression"})
+public class ExtendedMeasurement {
+
+	private Sensor sensor;
+	private Location location;
+	private MeasurementValue measurement;
+
+	public ExtendedMeasurement() {
+	}
+
+	public ExtendedMeasurement(
+			Sensor sensor,
+			Location location,
+			MeasurementValue measurement) {
+		this.sensor = sensor;
+		this.location = location;
+		this.measurement = measurement;
+	}
+
+	public Sensor getSensor() {
+		return sensor;
+	}
+
+	public void setSensor(Sensor sensor) {
+		this.sensor = sensor;
+	}
+
+	public Location getLocation() {
+		return location;
+	}
+
+	public void setLocation(Location location) {
+		this.location = location;
+	}
+
+	public MeasurementValue getMeasurement() {
+		return measurement;
+	}
+
+	public void setMeasurement(MeasurementValue measurement) {
+		this.measurement = measurement;
+	}
+
+	public enum SensorType {
+		Temperature,
+		Wind
+	}
+
+	public static class Sensor {
+		private long sensorId;
+		private long vendorId;
+		private SensorType sensorType;
+
+		public Sensor() {
+		}
+
+		public Sensor(
+				long sensorId,
+				long vendorId,
+				SensorType sensorType) {
+			this.sensorId = sensorId;
+			this.vendorId = vendorId;
+			this.sensorType = sensorType;
+		}
+
+		public long getSensorId() {
+			return sensorId;
+		}
+
+		public void setSensorId(long sensorId) {
+			this.sensorId = sensorId;
+		}
+
+		public long getVendorId() {
+			return vendorId;
+		}
+
+		public void setVendorId(long vendorId) {
+			this.vendorId = vendorId;
+		}
+
+		public SensorType getSensorType() {
+			return sensorType;
+		}
+
+		public void setSensorType(SensorType sensorType) {
+			this.sensorType = sensorType;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			Sensor sensor = (Sensor) o;
+			return sensorId == sensor.sensorId &&
+					vendorId == sensor.vendorId &&
+					sensorType == sensor.sensorType;
+		}
+
+		@Override
+		public int hashCode() {
+			// NOTE: do not use the enum directly here. Why?
+			// -> try with Sensor as a key in a distributed setting and see for yourself!
+			return Objects.hash(sensorId, vendorId, sensorType.ordinal());
+		}
+	}
+
+	public static class Location {
+		private double longitude;
+		private double latitude;
+		private double height;
+
+		public Location() {
+		}
+
+		public Location(double longitude, double latitude, double height) {
+			this.longitude = longitude;
+			this.latitude = latitude;
+			this.height = height;
+		}
+
+		public double getLongitude() {
+			return longitude;
+		}
+
+		public void setLongitude(double longitude) {
+			this.longitude = longitude;
+		}
+
+		public double getLatitude() {
+			return latitude;
+		}
+
+		public void setLatitude(double latitude) {
+			this.latitude = latitude;
+		}
+
+		public double getHeight() {
+			return height;
+		}
+
+		public void setHeight(double height) {
+			this.height = height;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			Location location = (Location) o;
+			return Double.compare(location.longitude, longitude) == 0 &&
+					Double.compare(location.latitude, latitude) == 0 &&
+					Double.compare(location.height, height) == 0;
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(longitude, latitude, height);
+		}
+	}
+
+	public static class MeasurementValue {
+		private double value;
+		private float accuracy;
+		private long timestamp;
+
+		public MeasurementValue() {
+		}
+
+		public MeasurementValue(double value, float accuracy, long timestamp) {
+			this.value = value;
+			this.accuracy = accuracy;
+			this.timestamp = timestamp;
+		}
+
+		public double getValue() {
+			return value;
+		}
+
+		public void setValue(double value) {
+			this.value = value;
+		}
+
+		public float getAccuracy() {
+			return accuracy;
+		}
+
+		public void setAccuracy(float accuracy) {
+			this.accuracy = accuracy;
+		}
+
+		public long getTimestamp() {
+			return timestamp;
+		}
+
+		public void setTimestamp(long timestamp) {
+			this.timestamp = timestamp;
+		}
+	}
+}

--- a/troubleshooting/object-reuse/src/provided/java/com/ververica/flink/training/provided/GeoUtils2.java
+++ b/troubleshooting/object-reuse/src/provided/java/com/ververica/flink/training/provided/GeoUtils2.java
@@ -1,0 +1,81 @@
+package com.ververica.flink.training.provided;
+
+import java.util.SplittableRandom;
+
+/**
+ * GeoUtils provides utility methods to deal with locations for the data streaming exercises.
+ */
+public class GeoUtils2 {
+
+	// bounding box of the area of the USA
+	public static final double US_LON_EAST = -66.9326;
+	public static final double US_LON_WEST = -125.0011;
+	public static final double US_LAT_NORTH = 49.5904;
+	public static final double US_LAT_SOUTH =  24.9493;
+
+	/**
+	 * Checks if a location specified by longitude and latitude values is
+	 * within the geo boundaries of the USA.
+	 *
+	 * @param lon longitude of the location to check
+	 * @param lat latitude of the location to check
+	 *
+	 * @return true if the location is within US boundaries, otherwise false.
+	 */
+	public static boolean isInUS(double lon, double lat) {
+		return !(lon > US_LON_EAST || lon < US_LON_WEST) &&
+				!(lat > US_LAT_NORTH || lat < US_LAT_SOUTH);
+	}
+
+	/**
+	 * Get a random longitude that is within the US bounding box.
+	 */
+	public static double getRandomLongitudeUS(SplittableRandom rnd) {
+		return rnd.nextDouble() * (US_LON_EAST - US_LON_WEST) +
+				US_LON_WEST;
+	}
+
+	/**
+	 * Get a random latitude that is within the US bounding box.
+	 */
+	public static double getRandomLatitudeUS(SplittableRandom rnd) {
+		return rnd.nextDouble() * (US_LAT_NORTH - US_LAT_SOUTH) +
+				US_LAT_SOUTH;
+	}
+
+	// bounding box of the area of the USA
+	public static final double DE_LON_EAST = 15.0419319;
+	public static final double DE_LON_WEST = 5.8663153;
+	public static final double DE_LAT_NORTH = 55.099161;
+	public static final double DE_LAT_SOUTH =  47.2701114;
+
+	/**
+	 * Checks if a location specified by longitude and latitude values is
+	 * within the geo boundaries of Germany.
+	 *
+	 * @param lon longitude of the location to check
+	 * @param lat latitude of the location to check
+	 *
+	 * @return true if the location is within German boundaries, otherwise false.
+	 */
+	public static boolean isInDE(double lon, double lat) {
+		return !(lon > DE_LON_EAST || lon < DE_LON_WEST) &&
+				!(lat > DE_LAT_NORTH || lat < DE_LAT_SOUTH);
+	}
+
+	/**
+	 * Get a random longitude that is within the DE bounding box.
+	 */
+	public static double getRandomLongitudeDE(SplittableRandom rnd) {
+		return rnd.nextDouble() * (DE_LON_EAST - DE_LON_WEST) +
+				DE_LON_WEST;
+	}
+
+	/**
+	 * Get a random latitude that is within the DE bounding box.
+	 */
+	public static double getRandomLatitudeDE(SplittableRandom rnd) {
+		return rnd.nextDouble() * (DE_LAT_NORTH - DE_LAT_SOUTH) +
+				DE_LAT_SOUTH;
+	}
+}

--- a/troubleshooting/object-reuse/src/provided/java/com/ververica/flink/training/provided/MeanGauge.java
+++ b/troubleshooting/object-reuse/src/provided/java/com/ververica/flink/training/provided/MeanGauge.java
@@ -1,0 +1,116 @@
+package com.ververica.flink.training.provided;
+
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.View;
+
+import com.ververica.flink.training.common.DoNotChangeThis;
+import org.apache.commons.math3.stat.descriptive.moment.SecondMoment;
+
+/**
+ * Gauge view for determining the mean per time span. Also allows access to min and max metrics via
+ * the {@link MinGauge} and {@link MaxGauge} wrappers.
+ */
+@DoNotChangeThis
+public class MeanGauge implements Gauge<Double>, View {
+
+	private final SimpleStats stats = new SimpleStats();
+	private SimpleStats currentStats = new SimpleStats();
+
+	@Override
+	public void update() {
+		currentStats = stats.copy();
+		stats.clear();
+	}
+
+	/**
+	 * Adds the given value to the internal statistics.
+	 */
+	public void addValue(double d) {
+		stats.increment(d);
+	}
+
+	@Override
+	public Double getValue() {
+		return currentStats.getMean();
+	}
+
+	/**
+	 * Wraps around the {@link MeanGauge} view to get the <code>min</code> of all reported values.
+	 */
+	public static class MinGauge implements Gauge<Double> {
+		private final MeanGauge base;
+
+		/**
+		 * Creates a min-gauge wrapper around <code>base</code>.
+		 */
+		public MinGauge(MeanGauge base) {
+			this.base = base;
+		}
+
+		@Override
+		public Double getValue() {
+			return base.currentStats.getMin();
+		}
+	}
+
+	/**
+	 * Wraps around the {@link MeanGauge} view to get the <code>max</code> of all reported values.
+	 */
+	public static class MaxGauge implements Gauge<Double> {
+		private final MeanGauge base;
+
+		/**
+		 * Creates a max-gauge wrapper around <code>base</code>.
+		 */
+		public MaxGauge(MeanGauge base) {
+			this.base = base;
+		}
+
+		@Override
+		public Double getValue() {
+			return base.currentStats.getMax();
+		}
+	}
+
+	/**
+	 * Calculates min, max, mean (first moment), as well as the second moment.
+	 */
+	private static class SimpleStats extends SecondMoment {
+		private static final long serialVersionUID = 1L;
+
+		private double min = Double.NaN;
+		private double max = Double.NaN;
+
+		@Override
+		public void increment(double d) {
+			if (d < min || Double.isNaN(min)) {
+				min = d;
+			}
+			if (d > max || Double.isNaN(max)) {
+				max = d;
+			}
+			super.increment(d);
+		}
+
+		@Override
+		public SimpleStats copy() {
+			SimpleStats result = new SimpleStats();
+			SecondMoment.copy(this, result);
+			result.min = min;
+			result.max = max;
+			return result;
+		}
+
+		double getMin() {
+			return min;
+		}
+
+		double getMax() {
+			return max;
+		}
+
+		double getMean() {
+			return m1;
+		}
+	}
+}

--- a/troubleshooting/object-reuse/src/provided/java/com/ververica/flink/training/provided/ObjectReuseExtendedMeasurementSource.java
+++ b/troubleshooting/object-reuse/src/provided/java/com/ververica/flink/training/provided/ObjectReuseExtendedMeasurementSource.java
@@ -1,0 +1,216 @@
+package com.ververica.flink.training.provided;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
+
+import com.ververica.flink.training.common.DoNotChangeThis;
+
+import java.util.SplittableRandom;
+
+/**
+ * Artificial source for sensor measurements (temperature and wind speed) of a pre-defined set of
+ * sensors (per parallel instance) creating measurements for two locations (inside the bounding
+ * boxes of Germany (DE) and the USA (US)) in SI units (°C and km/h).
+ */
+@SuppressWarnings("WeakerAccess")
+@DoNotChangeThis
+public class ObjectReuseExtendedMeasurementSource extends
+		RichParallelSourceFunction<ExtendedMeasurement> {
+
+	private static final long serialVersionUID = 1L;
+
+	private static final int NUM_SENSORS = 10_000;
+
+	public static final int LOWER_TEMPERATURE_CELCIUS = -10;
+	public static final int UPPER_TEMPERATURE_CELCIUS = 35;
+	public static final int LOWER_WIND_SPEED_KMH = 0;
+	public static final int UPPER_WIND_SPEED_KMH = 335;
+
+	private volatile boolean running = true;
+
+	private transient ExtendedMeasurement.Sensor[] sensors;
+	private transient ExtendedMeasurement.Location[] locations;
+	private transient double[] lastValue;
+	private transient MeanGauge sourceTemperatureUS;
+
+	@Override
+	public void open(final Configuration parameters) {
+		initSensors();
+
+		sourceTemperatureUS = getRuntimeContext().getMetricGroup()
+				.gauge("sourceTemperatureUSmean", new MeanGauge());
+		getRuntimeContext().getMetricGroup().gauge(
+				"sourceTemperatureUSmin",
+				new MeanGauge.MinGauge(sourceTemperatureUS));
+		getRuntimeContext().getMetricGroup().gauge(
+				"sourceTemperatureUSmax",
+				new MeanGauge.MaxGauge(sourceTemperatureUS));
+	}
+
+	@Override
+	public void run(SourceContext<ExtendedMeasurement> ctx) {
+		final SplittableRandom rnd = new SplittableRandom();
+		final Object lock = ctx.getCheckpointLock();
+
+		while (running) {
+			ExtendedMeasurement event = randomEvent(rnd);
+
+			//noinspection SynchronizationOnLocalVariableOrMethodParameter
+			synchronized (lock) {
+				ctx.collect(event);
+			}
+		}
+	}
+
+	@Override
+	public void cancel() {
+		running = false;
+	}
+
+	/**
+	 * Creates sensor metadata that this source instance will work with.
+	 */
+	private void initSensors() {
+		final SplittableRandom rnd = new SplittableRandom();
+		final ExtendedMeasurement.SensorType[] sensorTypes = ExtendedMeasurement.SensorType.values();
+
+		final int start = getRuntimeContext().getIndexOfThisSubtask() * NUM_SENSORS;
+		this.sensors = new ExtendedMeasurement.Sensor[NUM_SENSORS];
+		this.lastValue = new double[NUM_SENSORS];
+		this.locations = new ExtendedMeasurement.Location[NUM_SENSORS];
+		for (int i = 0; i < NUM_SENSORS; ++i) {
+			long sensorId = start + i;
+			long vendorId = sensorId % 100;
+			final ExtendedMeasurement.SensorType sensorType =
+					sensorTypes[(i / 2) % sensorTypes.length];
+			sensors[i] = new ExtendedMeasurement.Sensor(sensorId, vendorId, sensorType);
+
+			lastValue[i] = randomInitialMeasurementValue(rnd, sensorType);
+
+			// assume that a sensor has a fixed position
+			locations[i] = randomInitialLocation(rnd, i);
+		}
+	}
+
+	/**
+	 * Creates a random measurement value that a sensor will start with.
+	 */
+	private double randomInitialMeasurementValue(
+			SplittableRandom rnd,
+			ExtendedMeasurement.SensorType sensorType) {
+		switch (sensorType) {
+			case Temperature:
+				// -10°C - 35°C
+				return rnd.nextInt(
+						(UPPER_TEMPERATURE_CELCIUS - LOWER_TEMPERATURE_CELCIUS) * 10) / 10.0 +
+						LOWER_TEMPERATURE_CELCIUS;
+			case Wind:
+				// 0km/h - 335km/h
+				return rnd.nextInt((UPPER_WIND_SPEED_KMH - LOWER_WIND_SPEED_KMH) * 10) / 10.0 +
+						LOWER_WIND_SPEED_KMH;
+			default:
+				throw new IllegalStateException("Unknown sensor type: " + sensorType);
+		}
+	}
+
+	/**
+	 * Creates a random location for a sensor, distinguishing two bounding boxes: US and DE.
+	 */
+	private static ExtendedMeasurement.Location randomInitialLocation(
+			SplittableRandom rnd, int i) {
+		final double longitude;
+		final double latitude;
+		// let's assume that no selected region wraps around LON -180/+180
+		if (i < NUM_SENSORS / 2) {
+			// in US
+			longitude = GeoUtils2.getRandomLongitudeUS(rnd);
+			latitude = GeoUtils2.getRandomLatitudeUS(rnd);
+		} else {
+			// in DE
+			longitude = GeoUtils2.getRandomLongitudeDE(rnd);
+			latitude = GeoUtils2.getRandomLatitudeDE(rnd);
+		}
+		double height = rnd.nextDouble() * 3000;
+		return new ExtendedMeasurement.Location(longitude, latitude, height);
+	}
+
+	/**
+	 * Creates a randomized sensor value during runtime of the source. Each new value differs
+	 * slightly from the previous value that this sensor had.
+	 */
+	private ExtendedMeasurement randomEvent(SplittableRandom rnd) {
+		int randomIdx = rnd.nextInt(sensors.length);
+		ExtendedMeasurement.Sensor sensor = sensors[randomIdx];
+		ExtendedMeasurement.Location location = locations[randomIdx];
+
+		long timestamp = System.currentTimeMillis();
+
+		final double value = randomChangeMeasurementValue(
+				rnd,
+				sensor.getSensorType(),
+				location,
+				lastValue[randomIdx]);
+
+		lastValue[randomIdx] = value;
+
+		final ExtendedMeasurement.MeasurementValue measurement =
+				new ExtendedMeasurement.MeasurementValue(
+						value,
+						(float) (rnd.nextInt(100) - 50) / 10.0f, // +- 5
+						timestamp);
+
+		return new ExtendedMeasurement(
+				new ExtendedMeasurement.Sensor(
+						sensor.getSensorId(), sensor.getVendorId(), sensor.getSensorType()),
+				new ExtendedMeasurement.Location(
+						location.getLongitude(), location.getLatitude(), location.getHeight()),
+				measurement);
+	}
+
+	/**
+	 * Generates a new sensor value that is +-3 of the old value and reports a custom metric for
+	 * sensor values in the US.
+	 */
+	private double randomChangeMeasurementValue(
+			SplittableRandom rnd,
+			ExtendedMeasurement.SensorType sensorType,
+			ExtendedMeasurement.Location location,
+			double lastValue) {
+		double change = rnd.nextDouble(6) - 3.0; // +- 3
+		final double value;
+		switch (sensorType) {
+			case Temperature:
+				value = newValueWithinBounds(
+						lastValue, change, LOWER_TEMPERATURE_CELCIUS, UPPER_TEMPERATURE_CELCIUS);
+				if (GeoUtils2.isInUS(location.getLongitude(), location.getLatitude())) {
+					sourceTemperatureUS.addValue(value);
+				}
+				break;
+			case Wind:
+				value = newValueWithinBounds(
+						lastValue, change, LOWER_WIND_SPEED_KMH, UPPER_WIND_SPEED_KMH);
+				break;
+			default:
+				throw new InternalError("Unknown sensor type: " + sensorType);
+		}
+		return value;
+	}
+
+	/**
+	 * Returns either <code>lastValue + change</code> (if within the given bounds) or
+	 * <code>lastValue - change</code> (otherwise).
+	 */
+	private static double newValueWithinBounds(
+			double lastValue,
+			double change,
+			double lowerLimit,
+			double upperLimit) {
+		double value;
+		if (lastValue + change >= lowerLimit && lastValue + change <= upperLimit) {
+			value = lastValue + change;
+		} else {
+			value = lastValue - change;
+		}
+		return value;
+	}
+}

--- a/troubleshooting/object-reuse/src/provided/java/com/ververica/flink/training/provided/WeatherUtils.java
+++ b/troubleshooting/object-reuse/src/provided/java/com/ververica/flink/training/provided/WeatherUtils.java
@@ -1,0 +1,38 @@
+package com.ververica.flink.training.provided;
+
+import com.ververica.flink.training.common.DoNotChangeThis;
+
+/**
+ * Various tools to convert units used in weather sensors.
+ */
+@DoNotChangeThis
+public class WeatherUtils {
+
+	/**
+	 * Converts the given temperature from Fahrenheit to Celcius.
+	 */
+	public static double fahrenheitToCelcius(double temperatureInFahrenheit) {
+		return ((temperatureInFahrenheit - 32) * 5.0) / 9.0;
+	}
+
+	/**
+	 * Converts the given temperature from Celcius to Fahrenheit.
+	 */
+	public static double celciusToFahrenheit(double celcius) {
+		return (celcius * 9.0) / 5.0 + 32;
+	}
+
+	/**
+	 * Miles per hour -> kilometres per hour.
+	 */
+	public static double mphToKph(double mph) {
+		return mph * 1.60934;
+	}
+
+	/**
+	 * Kilometres per hour -> miles per hour.
+	 */
+	public static double kphToMph(double kph) {
+		return kph / 1.60934;
+	}
+}

--- a/troubleshooting/object-reuse/src/solution/java/com/ververica/flink/training/solutions/ObjectReuseJobSolution1.java
+++ b/troubleshooting/object-reuse/src/solution/java/com/ververica/flink/training/solutions/ObjectReuseJobSolution1.java
@@ -1,0 +1,333 @@
+package com.ververica.flink.training.solutions;
+
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.api.common.functions.RichFlatMapFunction;
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.datastream.DataStreamUtils;
+import org.apache.flink.streaming.api.datastream.KeyedStream;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.types.DoubleValue;
+import org.apache.flink.types.FloatValue;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.OutputTag;
+
+import com.ververica.flink.training.provided.ExtendedMeasurement;
+import com.ververica.flink.training.provided.GeoUtils2;
+import com.ververica.flink.training.provided.MeanGauge;
+import com.ververica.flink.training.provided.ObjectReuseExtendedMeasurementSource;
+import com.ververica.flink.training.provided.WeatherUtils;
+
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static com.ververica.flink.training.common.EnvironmentUtils.createConfiguredEnvironment;
+
+/**
+ * Object reuse solution fixing incorrect object reuse.
+ */
+public class ObjectReuseJobSolution1 {
+
+	/**
+	 * Creates and starts the object reuse job.
+	 *
+	 * @throws Exception if the application is misconfigured or fails during job submission
+	 */
+	public static void main(String[] args) throws Exception {
+		ParameterTool parameters = ParameterTool.fromArgs(args);
+
+		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
+
+		final boolean objectReuse = parameters.getBoolean("objectReuse", false);
+		if (objectReuse) {
+			env.getConfig().enableObjectReuse();
+		}
+
+		//Checkpointing Configuration
+		env.enableCheckpointing(5000);
+		env.getCheckpointConfig().setMinPauseBetweenCheckpoints(4000);
+
+		final OutputTag<ExtendedMeasurement> temperatureTag =
+				new OutputTag<ExtendedMeasurement>("temperature") {
+					private static final long serialVersionUID = -3127503822430851744L;
+				};
+		final OutputTag<ExtendedMeasurement> windTag =
+				new OutputTag<ExtendedMeasurement>("wind") {
+					private static final long serialVersionUID = 4249595595891069268L;
+				};
+
+		SingleOutputStreamOperator<ExtendedMeasurement> splitStream = env
+				.addSource(new ObjectReuseExtendedMeasurementSource())
+				.name("FakeMeasurementSource")
+				.uid("FakeMeasurementSource")
+				.keyBy(ExtendedMeasurement::getSensor)
+				.process(new SplitSensors(temperatureTag, windTag))
+				.name("SplitSensors")
+				.uid("SplitSensors");
+
+		// (1) stream with the temperature converted into local temperature units (°F in the US)
+		splitStream.getSideOutput(temperatureTag)
+				.map(new ConvertToLocalTemperature())
+				.name("ConvertToLocalTemperature")
+				.uid("ConvertToLocalTemperature")
+				.addSink(new DiscardingSink<>())
+				.name("LocalizedTemperatureSink")
+				.uid("LocalizedTemperatureSink")
+				.disableChaining();
+
+		// no need to do keyBy again; we did not change the key!
+		KeyedStream<ExtendedMeasurement, ExtendedMeasurement.Sensor> keyedTemperatureStream =
+				DataStreamUtils.reinterpretAsKeyedStream(
+						splitStream.getSideOutput(temperatureTag),
+						ExtendedMeasurement::getSensor);
+
+		// (2) stream with an (exponentially) moving average of the temperature (smoothens sensor
+		//     measurements, variant A); then converted into local temperature units (°F in the US)
+		keyedTemperatureStream
+				.flatMap(new MovingAverageSensors())
+				.name("MovingAverageTemperature")
+				.uid("MovingAverageTemperature")
+				.map(new ConvertToLocalTemperature())
+				.name("ConvertToLocalAverageTemperature")
+				.uid("ConvertToLocalAverageTemperature")
+				.addSink(new DiscardingSink<>())
+				.name("LocalizedAverageTemperatureSink")
+				.uid("LocalizedAverageTemperatureSink")
+				.disableChaining();
+
+		// (3) stream with an windowed-average of the temperature (to smoothens sensor
+		//     measurements, variant B); then converted into local temperature units (°F in the US)
+		keyedTemperatureStream
+				.timeWindow(Time.of(10, TimeUnit.SECONDS), Time.of(1, TimeUnit.SECONDS))
+				.aggregate(new WindowAverageSensor())
+				.name("WindowAverageTemperature")
+				.uid("WindowAverageTemperature")
+				.map(new ConvertToLocalTemperature())
+				.name("ConvertToLocalWindowedTemperature")
+				.uid("ConvertToLocalWindowedTemperature")
+				.addSink(new DiscardingSink<>())
+				.name("LocalizedWindowedTemperatureSink")
+				.uid("LocalizedWindowedTemperatureSink")
+				.disableChaining();
+
+		// (4) stream with the wind speed converted into local speed units (mph in the US)
+		splitStream.getSideOutput(windTag)
+				.map(new ConvertToLocalWindSpeed())
+				.name("NormalizeWindSpeed")
+				.uid("NormalizeWindSpeed")
+				.addSink(new DiscardingSink<>())
+				.name("WindSink")
+				.uid("WindSink")
+				.disableChaining();
+
+		env.execute(ObjectReuseJobSolution1.class.getSimpleName());
+	}
+
+	/**
+	 * Splits a stream into multiple side-outputs, one for each sensor.
+	 */
+	private static class SplitSensors extends
+			KeyedProcessFunction<ExtendedMeasurement.Sensor, ExtendedMeasurement, ExtendedMeasurement> {
+		private static final long serialVersionUID = 1L;
+
+		private final EnumMap<ExtendedMeasurement.SensorType, OutputTag<ExtendedMeasurement>>
+				outputTagBySensor =
+				new EnumMap<>(ExtendedMeasurement.SensorType.class);
+
+		SplitSensors(
+				OutputTag<ExtendedMeasurement> temperatureTag,
+				OutputTag<ExtendedMeasurement> windTag) {
+			outputTagBySensor.put(ExtendedMeasurement.SensorType.Temperature, temperatureTag);
+			outputTagBySensor.put(ExtendedMeasurement.SensorType.Wind, windTag);
+		}
+
+		@Override
+		public void processElement(
+				ExtendedMeasurement value,
+				Context ctx,
+				Collector<ExtendedMeasurement> out) {
+			ExtendedMeasurement.SensorType sensorType = value.getSensor().getSensorType();
+			OutputTag<ExtendedMeasurement> output = outputTagBySensor.get(sensorType);
+			ctx.output(output, value);
+		}
+	}
+
+	/**
+	 * Implements an exponentially moving average with a coefficient of <code>0.5</code>, i.e.
+	 * <ul>
+	 *     <li><code>avg[0] = value[0]</code> (not forwarded to the next stream)</li>
+	 *     <li><code>avg[i] = avg[i-1] * 0.5 + value[i] * 0.5</code> (for <code>i > 0</code>)</li>
+	 * </ul>
+	 *
+	 * <p>See <a href="https://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average">
+	 *     https://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average</a>
+	 */
+	private static class MovingAverageSensors extends
+			RichFlatMapFunction<ExtendedMeasurement, ExtendedMeasurement> {
+		private static final long serialVersionUID = 1L;
+
+		private final Map<ExtendedMeasurement.Sensor, Tuple2<FloatValue, DoubleValue>> lastAverage =
+				new HashMap<>();
+
+		@Override
+		public void flatMap(ExtendedMeasurement value, Collector<ExtendedMeasurement> out) {
+			ExtendedMeasurement.Sensor sensor = value.getSensor();
+			ExtendedMeasurement.MeasurementValue measurement = value.getMeasurement();
+
+			Tuple2<FloatValue, DoubleValue> last = lastAverage.get(sensor);
+			if (last != null) {
+				last.f0.setValue((last.f0.getValue() + measurement.getAccuracy()) / 2.0f);
+				last.f1.setValue((last.f1.getValue() + measurement.getValue()) / 2.0);
+
+				ExtendedMeasurement.MeasurementValue averageMeasurement =
+						new ExtendedMeasurement.MeasurementValue(
+								last.f1.getValue(), last.f0.getValue(), measurement.getTimestamp());
+				ExtendedMeasurement forward = new ExtendedMeasurement(
+						value.getSensor(), value.getLocation(), averageMeasurement);
+
+				// do not forward the first value (it only stands alone)
+				out.collect(forward);
+			} else {
+				lastAverage.put(
+						sensor,
+						Tuple2.of(
+								new FloatValue(measurement.getAccuracy()),
+								new DoubleValue(measurement.getValue())
+						));
+			}
+		}
+	}
+
+	@SuppressWarnings("WeakerAccess")
+	public static class WindowedAggregate {
+		public double sumValue = 0.0;
+		public double sumAccuracy = 0.0;
+		public long count = 0;
+		public ExtendedMeasurement lastValue = null;
+
+		/**
+		 * Constructor.
+		 */
+		public WindowedAggregate() {
+		}
+	}
+
+	/**
+	 * Aggregate function determining average sensor values and accuracies per sensor instance.
+	 */
+	private static class WindowAverageSensor implements
+			AggregateFunction<ExtendedMeasurement, WindowedAggregate, ExtendedMeasurement> {
+		@Override
+		public WindowedAggregate createAccumulator() {
+			return new WindowedAggregate();
+		}
+
+		@Override
+		public WindowedAggregate add(ExtendedMeasurement value, WindowedAggregate accumulator) {
+			accumulator.sumAccuracy += value.getMeasurement().getAccuracy();
+			accumulator.sumValue += value.getMeasurement().getValue();
+			accumulator.count++;
+			accumulator.lastValue = value;
+			return accumulator;
+		}
+
+		@Override
+		public ExtendedMeasurement getResult(WindowedAggregate accumulator) {
+			double avgValue = accumulator.sumValue / accumulator.count;
+			float avgAccuracy = (float) (accumulator.sumAccuracy / accumulator.count);
+			ExtendedMeasurement lastValue = accumulator.lastValue;
+			ExtendedMeasurement.MeasurementValue measurement =
+					new ExtendedMeasurement.MeasurementValue(
+							avgValue, avgAccuracy, lastValue.getMeasurement().getTimestamp());
+			return new ExtendedMeasurement(
+					lastValue.getSensor(), lastValue.getLocation(), measurement);
+		}
+
+		@Override
+		public WindowedAggregate merge(WindowedAggregate a, WindowedAggregate b) {
+			a.count += b.count;
+			a.sumValue += b.sumValue;
+			a.sumAccuracy += b.sumAccuracy;
+			if (b.lastValue.getMeasurement().getTimestamp() >
+					a.lastValue.getMeasurement().getTimestamp()) {
+				a.lastValue = b.lastValue;
+			}
+			return a;
+		}
+	}
+
+	/**
+	 * Converts SI units to locale-dependent units, i.e. °C to °F for the US. Adds a custom metric
+	 * to report temperatures in the US.
+	 */
+	private static class ConvertToLocalTemperature extends
+			RichMapFunction<ExtendedMeasurement, ExtendedMeasurement> {
+		private static final long serialVersionUID = 1L;
+
+		private transient MeanGauge normalizedTemperatureUS;
+
+		@Override
+		public void open(final Configuration parameters) {
+			normalizedTemperatureUS = getRuntimeContext().getMetricGroup()
+					.gauge("normalizedTemperatureUSmean", new MeanGauge());
+			getRuntimeContext().getMetricGroup().gauge(
+					"normalizedTemperatureUSmin", new MeanGauge.MinGauge(normalizedTemperatureUS));
+			getRuntimeContext().getMetricGroup().gauge(
+					"normalizedTemperatureUSmax", new MeanGauge.MaxGauge(normalizedTemperatureUS));
+		}
+
+		@Override
+		public ExtendedMeasurement map(ExtendedMeasurement value) {
+			ExtendedMeasurement.Location location = value.getLocation();
+			if (GeoUtils2.isInUS(location.getLongitude(), location.getLatitude())) {
+				ExtendedMeasurement.MeasurementValue measurement = value.getMeasurement();
+				double normalized = WeatherUtils.celciusToFahrenheit(measurement.getValue());
+
+				ExtendedMeasurement.MeasurementValue localizedMeasurement =
+						new ExtendedMeasurement.MeasurementValue(
+								normalized, measurement.getAccuracy(), measurement.getTimestamp());
+
+				normalizedTemperatureUS.addValue(normalized);
+				return new ExtendedMeasurement(
+						value.getSensor(), value.getLocation(), localizedMeasurement);
+			} else {
+				return value;
+			}
+		}
+	}
+
+	/**
+	 * Converts SI units to locale-dependent units, i.e. km/h to mph for the US. Adds a custom metric
+	 * to report wind speeds in the US.
+	 */
+	private static class ConvertToLocalWindSpeed extends
+			RichMapFunction<ExtendedMeasurement, ExtendedMeasurement> {
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public ExtendedMeasurement map(ExtendedMeasurement value) {
+			ExtendedMeasurement.Location location = value.getLocation();
+			if (GeoUtils2.isInUS(location.getLongitude(), location.getLatitude())) {
+				ExtendedMeasurement.MeasurementValue measurement = value.getMeasurement();
+				double normalized = WeatherUtils.kphToMph(measurement.getValue());
+
+				ExtendedMeasurement.MeasurementValue localizedMeasurement =
+						new ExtendedMeasurement.MeasurementValue(
+								normalized, measurement.getAccuracy(), measurement.getTimestamp());
+
+				return new ExtendedMeasurement(
+						value.getSensor(), value.getLocation(), localizedMeasurement);
+			} else {
+				return value;
+			}
+		}
+	}
+}

--- a/troubleshooting/object-reuse/src/solution/java/com/ververica/flink/training/solutions/ObjectReuseJobSolution1.java
+++ b/troubleshooting/object-reuse/src/solution/java/com/ververica/flink/training/solutions/ObjectReuseJobSolution1.java
@@ -12,6 +12,7 @@ import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.streaming.api.windowing.assigners.SlidingProcessingTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.types.DoubleValue;
 import org.apache.flink.types.FloatValue;
@@ -27,7 +28,6 @@ import com.ververica.flink.training.provided.WeatherUtils;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import static com.ververica.flink.training.common.EnvironmentUtils.createConfiguredEnvironment;
 
@@ -106,7 +106,7 @@ public class ObjectReuseJobSolution1 {
 		// (3) stream with an windowed-average of the temperature (to smoothens sensor
 		//     measurements, variant B); then converted into local temperature units (°F in the US)
 		keyedTemperatureStream
-				.timeWindow(Time.of(10, TimeUnit.SECONDS), Time.of(1, TimeUnit.SECONDS))
+				.window(SlidingProcessingTimeWindows.of(Time.seconds(10), Time.seconds(1)))
 				.aggregate(new WindowAverageSensor())
 				.name("WindowAverageTemperature")
 				.uid("WindowAverageTemperature")

--- a/troubleshooting/object-reuse/src/solution/java/com/ververica/flink/training/solutions/ObjectReuseJobSolution2.java
+++ b/troubleshooting/object-reuse/src/solution/java/com/ververica/flink/training/solutions/ObjectReuseJobSolution2.java
@@ -1,0 +1,335 @@
+package com.ververica.flink.training.solutions;
+
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.api.common.functions.RichFlatMapFunction;
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.datastream.DataStreamUtils;
+import org.apache.flink.streaming.api.datastream.KeyedStream;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.types.DoubleValue;
+import org.apache.flink.types.FloatValue;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.OutputTag;
+
+import com.ververica.flink.training.provided.GeoUtils2;
+import com.ververica.flink.training.provided.MeanGauge;
+import com.ververica.flink.training.provided.WeatherUtils;
+import com.ververica.flink.training.solutions.immutable.ExtendedMeasurement;
+import com.ververica.flink.training.solutions.immutable.Location;
+import com.ververica.flink.training.solutions.immutable.MeasurementValue;
+import com.ververica.flink.training.solutions.immutable.ObjectReuseExtendedMeasurementSource;
+import com.ververica.flink.training.solutions.immutable.Sensor;
+
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static com.ververica.flink.training.common.EnvironmentUtils.createConfiguredEnvironment;
+
+/**
+ * Object reuse solution that builds on top of {@link ObjectReuseJobSolution1} and uses immutable
+ * custom types for further performance improvements.
+ */
+public class ObjectReuseJobSolution2 {
+
+	/**
+	 * Creates and starts the object reuse job.
+	 *
+	 * @throws Exception if the application is misconfigured or fails during job submission
+	 */
+	public static void main(String[] args) throws Exception {
+		ParameterTool parameters = ParameterTool.fromArgs(args);
+
+		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
+
+		final boolean objectReuse = parameters.getBoolean("objectReuse", false);
+		if (objectReuse) {
+			env.getConfig().enableObjectReuse();
+		}
+
+		//Checkpointing Configuration
+		env.enableCheckpointing(5000);
+		env.getCheckpointConfig().setMinPauseBetweenCheckpoints(4000);
+
+		final OutputTag<ExtendedMeasurement> temperatureTag =
+				new OutputTag<ExtendedMeasurement>("temperature") {
+					private static final long serialVersionUID = -3127503822430851744L;
+				};
+		final OutputTag<ExtendedMeasurement> windTag =
+				new OutputTag<ExtendedMeasurement>("wind") {
+					private static final long serialVersionUID = 4249595595891069268L;
+				};
+
+		SingleOutputStreamOperator<ExtendedMeasurement> splitStream = env
+				.addSource(new ObjectReuseExtendedMeasurementSource())
+				.name("FakeMeasurementSource")
+				.uid("FakeMeasurementSource")
+				.keyBy(ExtendedMeasurement::getSensor)
+				.process(new SplitSensors(temperatureTag, windTag))
+				.name("SplitSensors")
+				.uid("SplitSensors");
+
+		// (1) stream with the temperature converted into local temperature units (°F in the US)
+		splitStream.getSideOutput(temperatureTag)
+				.map(new ConvertToLocalTemperature())
+				.name("ConvertToLocalTemperature")
+				.uid("ConvertToLocalTemperature")
+				.addSink(new DiscardingSink<>())
+				.name("LocalizedTemperatureSink")
+				.uid("LocalizedTemperatureSink")
+				.disableChaining();
+
+		// no need to do keyBy again; we did not change the key!
+		KeyedStream<ExtendedMeasurement, Sensor> keyedTemperatureStream =
+				DataStreamUtils.reinterpretAsKeyedStream(
+						splitStream.getSideOutput(temperatureTag),
+						ExtendedMeasurement::getSensor);
+
+		// (2) stream with an (exponentially) moving average of the temperature (smoothens sensor
+		//     measurements, variant A); then converted into local temperature units (°F in the US)
+		keyedTemperatureStream
+				.flatMap(new MovingAverageSensors())
+				.name("MovingAverageTemperature")
+				.uid("MovingAverageTemperature")
+				.map(new ConvertToLocalTemperature())
+				.name("ConvertToLocalAverageTemperature")
+				.uid("ConvertToLocalAverageTemperature")
+				.addSink(new DiscardingSink<>())
+				.name("LocalizedAverageTemperatureSink")
+				.uid("LocalizedAverageTemperatureSink")
+				.disableChaining();
+
+		// (3) stream with an windowed-average of the temperature (to smoothens sensor
+		//     measurements, variant B); then converted into local temperature units (°F in the US)
+		keyedTemperatureStream
+				.timeWindow(Time.of(10, TimeUnit.SECONDS), Time.of(1, TimeUnit.SECONDS))
+				.aggregate(new WindowAverageSensor())
+				.name("WindowAverageTemperature")
+				.uid("WindowAverageTemperature")
+				.map(new ConvertToLocalTemperature())
+				.name("ConvertToLocalWindowedTemperature")
+				.uid("ConvertToLocalWindowedTemperature")
+				.addSink(new DiscardingSink<>())
+				.name("LocalizedWindowedTemperatureSink")
+				.uid("LocalizedWindowedTemperatureSink")
+				.disableChaining();
+
+		// (4) stream with the wind speed converted into local speed units (mph in the US)
+		splitStream.getSideOutput(windTag)
+				.map(new ConvertToLocalWindSpeed())
+				.name("NormalizeWindSpeed")
+				.uid("NormalizeWindSpeed")
+				.addSink(new DiscardingSink<>())
+				.name("WindSink")
+				.uid("WindSink")
+				.disableChaining();
+
+		env.execute(ObjectReuseJobSolution2.class.getSimpleName());
+	}
+
+	/**
+	 * Splits a stream into multiple side-outputs, one for each sensor.
+	 */
+	private static class SplitSensors extends
+			KeyedProcessFunction<Sensor, ExtendedMeasurement, ExtendedMeasurement> {
+		private static final long serialVersionUID = 1L;
+
+		private final EnumMap<Sensor.SensorType, OutputTag<ExtendedMeasurement>> outputTagBySensor =
+				new EnumMap<>(Sensor.SensorType.class);
+
+		SplitSensors(
+				OutputTag<ExtendedMeasurement> temperatureTag,
+				OutputTag<ExtendedMeasurement> windTag) {
+			outputTagBySensor.put(Sensor.SensorType.Temperature, temperatureTag);
+			outputTagBySensor.put(Sensor.SensorType.Wind, windTag);
+		}
+
+		@Override
+		public void processElement(
+				ExtendedMeasurement value,
+				Context ctx,
+				Collector<ExtendedMeasurement> out) {
+			Sensor.SensorType sensorType = value.getSensor().getSensorType();
+			OutputTag<ExtendedMeasurement> output = outputTagBySensor.get(sensorType);
+			ctx.output(output, value);
+		}
+	}
+
+	/**
+	 * Implements an exponentially moving average with a coefficient of <code>0.5</code>, i.e.
+	 * <ul>
+	 *     <li><code>avg[0] = value[0]</code> (not forwarded to the next stream)</li>
+	 *     <li><code>avg[i] = avg[i-1] * 0.5 + value[i] * 0.5</code> (for <code>i > 0</code>)</li>
+	 * </ul>
+	 *
+	 * <p>See <a href="https://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average">
+	 *     https://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average</a>
+	 */
+	private static class MovingAverageSensors extends
+			RichFlatMapFunction<ExtendedMeasurement, ExtendedMeasurement> {
+		private static final long serialVersionUID = 1L;
+
+		private final Map<Sensor, Tuple2<FloatValue, DoubleValue>> lastAverage = new HashMap<>();
+
+		@Override
+		public void flatMap(ExtendedMeasurement value, Collector<ExtendedMeasurement> out) {
+			Sensor sensor = value.getSensor();
+			MeasurementValue measurement = value.getMeasurement();
+
+			Tuple2<FloatValue, DoubleValue> last = lastAverage.get(sensor);
+			if (last != null) {
+				last.f0.setValue((last.f0.getValue() + measurement.getAccuracy()) / 2.0f);
+				last.f1.setValue((last.f1.getValue() + measurement.getValue()) / 2.0);
+
+				MeasurementValue averageMeasurement =
+						new MeasurementValue(
+								last.f1.getValue(), last.f0.getValue(), measurement.getTimestamp());
+				ExtendedMeasurement forward = new ExtendedMeasurement(
+						value.getSensor(), value.getLocation(), averageMeasurement);
+
+				// do not forward the first value (it only stands alone)
+				out.collect(forward);
+			} else {
+				lastAverage.put(
+						sensor,
+						Tuple2.of(
+								new FloatValue(measurement.getAccuracy()),
+								new DoubleValue(measurement.getValue())
+						));
+			}
+		}
+	}
+
+	@SuppressWarnings("WeakerAccess")
+	public static class WindowedAggregate {
+		public double sumValue = 0.0;
+		public double sumAccuracy = 0.0;
+		public long count = 0;
+		public ExtendedMeasurement lastValue = null;
+
+		/**
+		 * Constructor.
+		 */
+		public WindowedAggregate() {
+		}
+	}
+
+	/**
+	 * Aggregate function determining average sensor values and accuracies per sensor instance.
+	 */
+	private static class WindowAverageSensor implements
+			AggregateFunction<ExtendedMeasurement, WindowedAggregate, ExtendedMeasurement> {
+		@Override
+		public WindowedAggregate createAccumulator() {
+			return new WindowedAggregate();
+		}
+
+		@Override
+		public WindowedAggregate add(ExtendedMeasurement value, WindowedAggregate accumulator) {
+			accumulator.sumAccuracy += value.getMeasurement().getAccuracy();
+			accumulator.sumValue += value.getMeasurement().getValue();
+			accumulator.count++;
+			accumulator.lastValue = value;
+			return accumulator;
+		}
+
+		@Override
+		public ExtendedMeasurement getResult(WindowedAggregate accumulator) {
+			double avgValue = accumulator.sumValue / accumulator.count;
+			float avgAccuracy = (float) (accumulator.sumAccuracy / accumulator.count);
+			ExtendedMeasurement lastValue = accumulator.lastValue;
+			MeasurementValue measurement =
+					new MeasurementValue(
+							avgValue, avgAccuracy, lastValue.getMeasurement().getTimestamp());
+			return new ExtendedMeasurement(
+					lastValue.getSensor(), lastValue.getLocation(), measurement);
+		}
+
+		@Override
+		public WindowedAggregate merge(WindowedAggregate a, WindowedAggregate b) {
+			a.count += b.count;
+			a.sumValue += b.sumValue;
+			a.sumAccuracy += b.sumAccuracy;
+			if (b.lastValue.getMeasurement().getTimestamp() >
+					a.lastValue.getMeasurement().getTimestamp()) {
+				a.lastValue = b.lastValue;
+			}
+			return a;
+		}
+	}
+
+	/**
+	 * Converts SI units to locale-dependent units, i.e. °C to °F for the US. Adds a custom metric
+	 * to report temperatures in the US.
+	 */
+	private static class ConvertToLocalTemperature extends
+			RichMapFunction<ExtendedMeasurement, ExtendedMeasurement> {
+		private static final long serialVersionUID = 1L;
+
+		private transient MeanGauge normalizedTemperatureUS;
+
+		@Override
+		public void open(final Configuration parameters) {
+			normalizedTemperatureUS = getRuntimeContext().getMetricGroup()
+					.gauge("normalizedTemperatureUSmean", new MeanGauge());
+			getRuntimeContext().getMetricGroup().gauge(
+					"normalizedTemperatureUSmin", new MeanGauge.MinGauge(normalizedTemperatureUS));
+			getRuntimeContext().getMetricGroup().gauge(
+					"normalizedTemperatureUSmax", new MeanGauge.MaxGauge(normalizedTemperatureUS));
+		}
+
+		@Override
+		public ExtendedMeasurement map(ExtendedMeasurement value) {
+			Location location = value.getLocation();
+			if (GeoUtils2.isInUS(location.getLongitude(), location.getLatitude())) {
+				MeasurementValue measurement = value.getMeasurement();
+				double normalized = WeatherUtils.celciusToFahrenheit(measurement.getValue());
+
+				MeasurementValue localizedMeasurement =
+						new MeasurementValue(
+								normalized, measurement.getAccuracy(), measurement.getTimestamp());
+
+				normalizedTemperatureUS.addValue(normalized);
+				return new ExtendedMeasurement(
+						value.getSensor(), value.getLocation(), localizedMeasurement);
+			} else {
+				return value;
+			}
+		}
+	}
+
+	/**
+	 * Converts SI units to locale-dependent units, i.e. km/h to mph for the US. Adds a custom metric
+	 * to report wind speeds in the US.
+	 */
+	private static class ConvertToLocalWindSpeed extends
+			RichMapFunction<ExtendedMeasurement, ExtendedMeasurement> {
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public ExtendedMeasurement map(ExtendedMeasurement value) {
+			Location location = value.getLocation();
+			if (GeoUtils2.isInUS(location.getLongitude(), location.getLatitude())) {
+				MeasurementValue measurement = value.getMeasurement();
+				double normalized = WeatherUtils.kphToMph(measurement.getValue());
+
+				MeasurementValue localizedMeasurement =
+						new MeasurementValue(
+								normalized, measurement.getAccuracy(), measurement.getTimestamp());
+
+				return new ExtendedMeasurement(
+						value.getSensor(), value.getLocation(), localizedMeasurement);
+			} else {
+				return value;
+			}
+		}
+	}
+}

--- a/troubleshooting/object-reuse/src/solution/java/com/ververica/flink/training/solutions/ObjectReuseJobSolution2.java
+++ b/troubleshooting/object-reuse/src/solution/java/com/ververica/flink/training/solutions/ObjectReuseJobSolution2.java
@@ -12,6 +12,7 @@ import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.streaming.api.windowing.assigners.SlidingProcessingTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.types.DoubleValue;
 import org.apache.flink.types.FloatValue;
@@ -30,7 +31,6 @@ import com.ververica.flink.training.solutions.immutable.Sensor;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import static com.ververica.flink.training.common.EnvironmentUtils.createConfiguredEnvironment;
 
@@ -110,7 +110,7 @@ public class ObjectReuseJobSolution2 {
 		// (3) stream with an windowed-average of the temperature (to smoothens sensor
 		//     measurements, variant B); then converted into local temperature units (°F in the US)
 		keyedTemperatureStream
-				.timeWindow(Time.of(10, TimeUnit.SECONDS), Time.of(1, TimeUnit.SECONDS))
+				.window(SlidingProcessingTimeWindows.of(Time.seconds(10), Time.seconds(1)))
 				.aggregate(new WindowAverageSensor())
 				.name("WindowAverageTemperature")
 				.uid("WindowAverageTemperature")

--- a/troubleshooting/object-reuse/src/solution/java/com/ververica/flink/training/solutions/immutable/ExtendedMeasurement.java
+++ b/troubleshooting/object-reuse/src/solution/java/com/ververica/flink/training/solutions/immutable/ExtendedMeasurement.java
@@ -1,0 +1,53 @@
+package com.ververica.flink.training.solutions.immutable;
+
+import org.apache.flink.api.common.typeinfo.TypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInfoFactory;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+
+/**
+ * Immutable variant of {@link com.ververica.flink.training.provided.ExtendedMeasurement}.
+ */
+@TypeInfo(ExtendedMeasurement.ExtendedMeasurementTypeInfoFactory.class)
+public class ExtendedMeasurement {
+
+	private final Sensor sensor;
+	private final Location location;
+	private final MeasurementValue measurement;
+
+	/**
+	 * Constructor.
+	 */
+	public ExtendedMeasurement(
+			Sensor sensor,
+			Location location,
+			MeasurementValue measurement) {
+		this.sensor = sensor;
+		this.location = location;
+		this.measurement = measurement;
+	}
+
+	public Sensor getSensor() {
+		return sensor;
+	}
+
+	public Location getLocation() {
+		return location;
+	}
+
+	public MeasurementValue getMeasurement() {
+		return measurement;
+	}
+
+	public static class ExtendedMeasurementTypeInfoFactory extends
+			TypeInfoFactory<ExtendedMeasurement> {
+		@Override
+		public TypeInformation<ExtendedMeasurement> createTypeInfo(
+				Type t,
+				Map<String, TypeInformation<?>> genericParameters) {
+			return ExtendedMeasurementTypeInfo.INSTANCE;
+		}
+	}
+}

--- a/troubleshooting/object-reuse/src/solution/java/com/ververica/flink/training/solutions/immutable/ExtendedMeasurementSerializer.java
+++ b/troubleshooting/object-reuse/src/solution/java/com/ververica/flink/training/solutions/immutable/ExtendedMeasurementSerializer.java
@@ -1,0 +1,94 @@
+package com.ververica.flink.training.solutions.immutable;
+
+import org.apache.flink.api.common.typeutils.SimpleTypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.base.TypeSerializerSingleton;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+
+import java.io.IOException;
+
+public class ExtendedMeasurementSerializer extends TypeSerializerSingleton<ExtendedMeasurement> {
+
+	private ExtendedMeasurementSerializer() {
+	}
+
+	static final ExtendedMeasurementSerializer INSTANCE = new ExtendedMeasurementSerializer();
+
+	@Override
+	public boolean isImmutableType() {
+		return true;
+	}
+
+	@Override
+	public ExtendedMeasurement createInstance() {
+		return null;
+	}
+
+	@Override
+	public ExtendedMeasurement copy(ExtendedMeasurement from) {
+		return new ExtendedMeasurement(
+				SensorSerializer.INSTANCE.copy(from.getSensor()),
+				LocationSerializer.INSTANCE.copy(from.getLocation()),
+				MeasurementValueSerializer.INSTANCE.copy(from.getMeasurement()));
+	}
+
+	@Override
+	public ExtendedMeasurement copy(ExtendedMeasurement from, ExtendedMeasurement reuse) {
+		return copy(from);
+	}
+
+	@Override
+	public int getLength() {
+		return SensorSerializer.INSTANCE.getLength() +
+				LocationSerializer.INSTANCE.getLength() +
+				MeasurementValueSerializer.INSTANCE.getLength();
+	}
+
+	@Override
+	public void serialize(ExtendedMeasurement record, DataOutputView target) throws IOException {
+		SensorSerializer.INSTANCE.serialize(record.getSensor(), target);
+		LocationSerializer.INSTANCE.serialize(record.getLocation(), target);
+		MeasurementValueSerializer.INSTANCE.serialize(record.getMeasurement(), target);
+	}
+
+	@Override
+	public ExtendedMeasurement deserialize(DataInputView source) throws IOException {
+		Sensor sensor = SensorSerializer.INSTANCE.deserialize(source);
+		Location location = LocationSerializer.INSTANCE.deserialize(source);
+		MeasurementValue measurement = MeasurementValueSerializer.INSTANCE.deserialize(source);
+		return new ExtendedMeasurement(sensor, location, measurement);
+	}
+
+	@Override
+	public ExtendedMeasurement deserialize(ExtendedMeasurement reuse, DataInputView source)
+			throws IOException {
+		return deserialize(source);
+	}
+
+	@Override
+	public void copy(DataInputView source, DataOutputView target) throws IOException {
+		SensorSerializer.INSTANCE.copy(source, target);
+		LocationSerializer.INSTANCE.copy(source, target);
+		MeasurementValueSerializer.INSTANCE.copy(source, target);
+	}
+
+	// -----------------------------------------------------------------------------------
+
+	@Override
+	public TypeSerializerSnapshot<ExtendedMeasurement> snapshotConfiguration() {
+		return new ExtendedMeasurementSerializerSnapshot();
+	}
+
+	@SuppressWarnings("WeakerAccess")
+	public static final class ExtendedMeasurementSerializerSnapshot extends
+			SimpleTypeSerializerSnapshot<ExtendedMeasurement> {
+
+        /**
+         * Returns a snapshot pointing to the singleton serializer instance.
+         */
+		public ExtendedMeasurementSerializerSnapshot() {
+			super(() -> INSTANCE);
+		}
+	}
+}

--- a/troubleshooting/object-reuse/src/solution/java/com/ververica/flink/training/solutions/immutable/ExtendedMeasurementTypeInfo.java
+++ b/troubleshooting/object-reuse/src/solution/java/com/ververica/flink/training/solutions/immutable/ExtendedMeasurementTypeInfo.java
@@ -1,0 +1,73 @@
+package com.ververica.flink.training.solutions.immutable;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+
+class ExtendedMeasurementTypeInfo extends TypeInformation<ExtendedMeasurement> {
+
+	private ExtendedMeasurementTypeInfo() {
+	}
+
+	static final ExtendedMeasurementTypeInfo INSTANCE = new ExtendedMeasurementTypeInfo();
+
+	@Override
+	public boolean isBasicType() {
+		return false;
+	}
+
+	@Override
+	public boolean isTupleType() {
+		return false;
+	}
+
+	@Override
+	public int getArity() {
+		return 3;
+	}
+
+	@Override
+	public int getTotalFields() {
+		return SensorTypeInfo.INSTANCE.getArity() +
+				LocationTypeInfo.INSTANCE.getArity() +
+				MeasurementValueTypeInfo.INSTANCE.getArity();
+	}
+
+	@Override
+	public Class<ExtendedMeasurement> getTypeClass() {
+		return ExtendedMeasurement.class;
+	}
+
+	@Override
+	public boolean isKeyType() {
+		return SensorTypeInfo.INSTANCE.isKeyType() &&
+				LocationTypeInfo.INSTANCE.isKeyType() &&
+				MeasurementValueTypeInfo.INSTANCE.isKeyType();
+	}
+
+	@Override
+	public TypeSerializer<ExtendedMeasurement> createSerializer(ExecutionConfig config) {
+		return ExtendedMeasurementSerializer.INSTANCE;
+	}
+
+	@Override
+	public String toString() {
+		return getClass().getSimpleName();
+	}
+
+	@SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
+	@Override
+	public boolean equals(Object obj) {
+		return this.canEqual(obj);
+	}
+
+	@Override
+	public int hashCode() {
+		return ExtendedMeasurement.class.hashCode();
+	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof ExtendedMeasurementTypeInfo;
+	}
+}

--- a/troubleshooting/object-reuse/src/solution/java/com/ververica/flink/training/solutions/immutable/Location.java
+++ b/troubleshooting/object-reuse/src/solution/java/com/ververica/flink/training/solutions/immutable/Location.java
@@ -1,0 +1,69 @@
+package com.ververica.flink.training.solutions.immutable;
+
+import org.apache.flink.api.common.typeinfo.TypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInfoFactory;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Immutable variant of {@link com.ververica.flink.training.provided.ExtendedMeasurement.Location}.
+ */
+@SuppressWarnings("WeakerAccess")
+@TypeInfo(Location.LocationTypeInfoFactory.class)
+public class Location {
+	private final double longitude;
+	private final double latitude;
+	private final double height;
+
+    /**
+     * Constructor.
+     */
+	public Location(double longitude, double latitude, double height) {
+		this.longitude = longitude;
+		this.latitude = latitude;
+		this.height = height;
+	}
+
+	public double getLongitude() {
+		return longitude;
+	}
+
+	public double getLatitude() {
+		return latitude;
+	}
+
+	public double getHeight() {
+		return height;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		Location location = (Location) o;
+		return Double.compare(location.longitude, longitude) == 0 &&
+				Double.compare(location.latitude, latitude) == 0 &&
+				Double.compare(location.height, height) == 0;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(longitude, latitude, height);
+	}
+
+	public static class LocationTypeInfoFactory extends TypeInfoFactory<Location> {
+		@Override
+		public TypeInformation<Location> createTypeInfo(
+				Type t,
+				Map<String, TypeInformation<?>> genericParameters) {
+			return LocationTypeInfo.INSTANCE;
+		}
+	}
+}

--- a/troubleshooting/object-reuse/src/solution/java/com/ververica/flink/training/solutions/immutable/LocationSerializer.java
+++ b/troubleshooting/object-reuse/src/solution/java/com/ververica/flink/training/solutions/immutable/LocationSerializer.java
@@ -1,0 +1,88 @@
+package com.ververica.flink.training.solutions.immutable;
+
+import org.apache.flink.api.common.typeutils.SimpleTypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.base.TypeSerializerSingleton;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+
+import java.io.IOException;
+
+public class LocationSerializer extends TypeSerializerSingleton<Location> {
+
+	private LocationSerializer() {
+	}
+
+	static final LocationSerializer INSTANCE = new LocationSerializer();
+
+	@Override
+	public boolean isImmutableType() {
+		return true;
+	}
+
+	@Override
+	public Location createInstance() {
+		return null;
+	}
+
+	@Override
+	public Location copy(Location from) {
+		return new Location(from.getLongitude(), from.getLatitude(), from.getHeight());
+	}
+
+	@Override
+	public Location copy(Location from, Location reuse) {
+		return copy(from);
+	}
+
+	@Override
+	public int getLength() {
+		return Double.BYTES + Double.BYTES + Double.BYTES;
+	}
+
+	@Override
+	public void serialize(Location record, DataOutputView target) throws IOException {
+		target.writeDouble(record.getLongitude());
+		target.writeDouble(record.getLatitude());
+		target.writeDouble(record.getHeight());
+	}
+
+	@Override
+	public Location deserialize(DataInputView source) throws IOException {
+		double longitude = source.readDouble();
+		double latitude = source.readDouble();
+		double height = source.readDouble();
+		return new Location(longitude, latitude, height);
+	}
+
+	@Override
+	public Location deserialize(Location reuse, DataInputView source) throws IOException {
+		return deserialize(source);
+	}
+
+	@Override
+	public void copy(DataInputView source, DataOutputView target) throws IOException {
+		target.writeDouble(source.readDouble());
+		target.writeDouble(source.readDouble());
+		target.writeDouble(source.readDouble());
+	}
+
+	// -----------------------------------------------------------------------------------
+
+	@Override
+	public TypeSerializerSnapshot<Location> snapshotConfiguration() {
+		return new LocationSerializerSnapshot();
+	}
+
+	@SuppressWarnings("WeakerAccess")
+	public static final class LocationSerializerSnapshot extends
+			SimpleTypeSerializerSnapshot<Location> {
+
+		/**
+		 * Returns a snapshot pointing to the singleton serializer instance.
+		 */
+		public LocationSerializerSnapshot() {
+			super(() -> INSTANCE);
+		}
+	}
+}

--- a/troubleshooting/object-reuse/src/solution/java/com/ververica/flink/training/solutions/immutable/LocationTypeInfo.java
+++ b/troubleshooting/object-reuse/src/solution/java/com/ververica/flink/training/solutions/immutable/LocationTypeInfo.java
@@ -1,0 +1,69 @@
+package com.ververica.flink.training.solutions.immutable;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+
+class LocationTypeInfo extends TypeInformation<Location> {
+
+	private LocationTypeInfo() {
+	}
+
+	static final LocationTypeInfo INSTANCE = new LocationTypeInfo();
+
+	@Override
+	public boolean isBasicType() {
+		return false;
+	}
+
+	@Override
+	public boolean isTupleType() {
+		return false;
+	}
+
+	@Override
+	public int getArity() {
+		return 3;
+	}
+
+	@Override
+	public int getTotalFields() {
+		return 3;
+	}
+
+	@Override
+	public Class<Location> getTypeClass() {
+		return Location.class;
+	}
+
+	@Override
+	public boolean isKeyType() {
+		return true;
+	}
+
+	@Override
+	public TypeSerializer<Location> createSerializer(ExecutionConfig config) {
+		return LocationSerializer.INSTANCE;
+	}
+
+	@Override
+	public String toString() {
+		return getClass().getSimpleName();
+	}
+
+	@SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
+	@Override
+	public boolean equals(Object obj) {
+		return this.canEqual(obj);
+	}
+
+	@Override
+	public int hashCode() {
+		return Location.class.hashCode();
+	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof LocationTypeInfo;
+	}
+}

--- a/troubleshooting/object-reuse/src/solution/java/com/ververica/flink/training/solutions/immutable/MeasurementValue.java
+++ b/troubleshooting/object-reuse/src/solution/java/com/ververica/flink/training/solutions/immutable/MeasurementValue.java
@@ -1,0 +1,48 @@
+package com.ververica.flink.training.solutions.immutable;
+
+import org.apache.flink.api.common.typeinfo.TypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInfoFactory;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+
+/**
+ * Immutable variant of {@link com.ververica.flink.training.provided.ExtendedMeasurement.MeasurementValue}.
+ */
+@TypeInfo(MeasurementValue.MeasurementValueTypeInfoFactory.class)
+public class MeasurementValue {
+	private final double value;
+	private final float accuracy;
+	private final long timestamp;
+
+	/**
+	 * Constructor.
+	 */
+	public MeasurementValue(double value, float accuracy, long timestamp) {
+		this.value = value;
+		this.accuracy = accuracy;
+		this.timestamp = timestamp;
+	}
+
+	public double getValue() {
+		return value;
+	}
+
+	public float getAccuracy() {
+		return accuracy;
+	}
+
+	public long getTimestamp() {
+		return timestamp;
+	}
+
+	public static class MeasurementValueTypeInfoFactory extends TypeInfoFactory<MeasurementValue> {
+		@Override
+		public TypeInformation<MeasurementValue> createTypeInfo(
+				Type t,
+				Map<String, TypeInformation<?>> genericParameters) {
+			return MeasurementValueTypeInfo.INSTANCE;
+		}
+	}
+}

--- a/troubleshooting/object-reuse/src/solution/java/com/ververica/flink/training/solutions/immutable/MeasurementValueSerializer.java
+++ b/troubleshooting/object-reuse/src/solution/java/com/ververica/flink/training/solutions/immutable/MeasurementValueSerializer.java
@@ -1,0 +1,89 @@
+package com.ververica.flink.training.solutions.immutable;
+
+import org.apache.flink.api.common.typeutils.SimpleTypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.base.TypeSerializerSingleton;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+
+import java.io.IOException;
+
+public class MeasurementValueSerializer extends TypeSerializerSingleton<MeasurementValue> {
+
+	private MeasurementValueSerializer() {
+	}
+
+	static final MeasurementValueSerializer INSTANCE = new MeasurementValueSerializer();
+
+	@Override
+	public boolean isImmutableType() {
+		return true;
+	}
+
+	@Override
+	public MeasurementValue createInstance() {
+		return null;
+	}
+
+	@Override
+	public MeasurementValue copy(MeasurementValue from) {
+		return new MeasurementValue(from.getValue(), from.getAccuracy(), from.getTimestamp());
+	}
+
+	@Override
+	public MeasurementValue copy(MeasurementValue from, MeasurementValue reuse) {
+		return copy(from);
+	}
+
+	@Override
+	public int getLength() {
+		return Double.BYTES + Float.BYTES + Long.BYTES;
+	}
+
+	@Override
+	public void serialize(MeasurementValue record, DataOutputView target) throws IOException {
+		target.writeDouble(record.getValue());
+		target.writeFloat(record.getAccuracy());
+		target.writeLong(record.getTimestamp());
+	}
+
+	@Override
+	public MeasurementValue deserialize(DataInputView source) throws IOException {
+		double value = source.readDouble();
+		float accuracy = source.readFloat();
+		long timestamp = source.readLong();
+		return new MeasurementValue(value, accuracy, timestamp);
+	}
+
+	@Override
+	public MeasurementValue deserialize(MeasurementValue reuse, DataInputView source)
+			throws IOException {
+		return deserialize(source);
+	}
+
+	@Override
+	public void copy(DataInputView source, DataOutputView target) throws IOException {
+		target.writeDouble(source.readDouble());
+		target.writeFloat(source.readFloat());
+		target.writeLong(source.readLong());
+	}
+
+	// -----------------------------------------------------------------------------------
+
+	@Override
+	public TypeSerializerSnapshot<MeasurementValue> snapshotConfiguration() {
+		return new MeasurementValueSerializerSnapshot();
+	}
+
+	@SuppressWarnings("WeakerAccess")
+	public static final class MeasurementValueSerializerSnapshot extends
+			SimpleTypeSerializerSnapshot<MeasurementValue> {
+
+		/**
+		 * Returns a snapshot pointing to the singleton serializer instance.
+		 */
+		public MeasurementValueSerializerSnapshot() {
+			super(() -> INSTANCE);
+		}
+	}
+}

--- a/troubleshooting/object-reuse/src/solution/java/com/ververica/flink/training/solutions/immutable/MeasurementValueTypeInfo.java
+++ b/troubleshooting/object-reuse/src/solution/java/com/ververica/flink/training/solutions/immutable/MeasurementValueTypeInfo.java
@@ -1,0 +1,69 @@
+package com.ververica.flink.training.solutions.immutable;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+
+class MeasurementValueTypeInfo extends TypeInformation<MeasurementValue> {
+
+	private MeasurementValueTypeInfo() {
+	}
+
+	static final MeasurementValueTypeInfo INSTANCE = new MeasurementValueTypeInfo();
+
+	@Override
+	public boolean isBasicType() {
+		return false;
+	}
+
+	@Override
+	public boolean isTupleType() {
+		return false;
+	}
+
+	@Override
+	public int getArity() {
+		return 3;
+	}
+
+	@Override
+	public int getTotalFields() {
+		return 3;
+	}
+
+	@Override
+	public Class<MeasurementValue> getTypeClass() {
+		return MeasurementValue.class;
+	}
+
+	@Override
+	public boolean isKeyType() {
+		return true;
+	}
+
+	@Override
+	public TypeSerializer<MeasurementValue> createSerializer(ExecutionConfig config) {
+		return MeasurementValueSerializer.INSTANCE;
+	}
+
+	@Override
+	public String toString() {
+		return getClass().getSimpleName();
+	}
+
+	@SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
+	@Override
+	public boolean equals(Object obj) {
+		return this.canEqual(obj);
+	}
+
+	@Override
+	public int hashCode() {
+		return MeasurementValue.class.hashCode();
+	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof MeasurementValueTypeInfo;
+	}
+}

--- a/troubleshooting/object-reuse/src/solution/java/com/ververica/flink/training/solutions/immutable/ObjectReuseExtendedMeasurementSource.java
+++ b/troubleshooting/object-reuse/src/solution/java/com/ververica/flink/training/solutions/immutable/ObjectReuseExtendedMeasurementSource.java
@@ -1,0 +1,214 @@
+package com.ververica.flink.training.solutions.immutable;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
+
+import com.ververica.flink.training.provided.GeoUtils2;
+import com.ververica.flink.training.provided.MeanGauge;
+
+import java.util.SplittableRandom;
+
+/**
+ * Artificial source for sensor measurements (temperature and wind speed) of a pre-defined set of
+ * sensors (per parallel instance) creating measurements for two locations (inside the bounding
+ * boxes of Germany (DE) and the USA (US)) in SI units (°C and km/h).
+ */
+@SuppressWarnings("WeakerAccess")
+public class ObjectReuseExtendedMeasurementSource extends
+		RichParallelSourceFunction<ExtendedMeasurement> {
+
+	private static final long serialVersionUID = 1L;
+
+	private static final int NUM_SENSORS = 10_000;
+
+	public static final int LOWER_TEMPERATURE_CELCIUS = -10;
+	public static final int UPPER_TEMPERATURE_CELCIUS = 35;
+	public static final int LOWER_WIND_SPEED_KMH = 0;
+	public static final int UPPER_WIND_SPEED_KMH = 335;
+
+	private volatile boolean running = true;
+
+	private transient Sensor[] sensors;
+	private transient Location[] locations;
+	private transient double[] lastValue;
+	private transient MeanGauge sourceTemperatureUS;
+
+	@Override
+	public void open(final Configuration parameters) {
+		initSensors();
+
+		sourceTemperatureUS = getRuntimeContext().getMetricGroup()
+				.gauge("sourceTemperatureUSmean", new MeanGauge());
+		getRuntimeContext().getMetricGroup().gauge(
+				"sourceTemperatureUSmin", new MeanGauge.MinGauge(sourceTemperatureUS));
+		getRuntimeContext().getMetricGroup().gauge(
+				"sourceTemperatureUSmax", new MeanGauge.MaxGauge(sourceTemperatureUS));
+	}
+
+	@Override
+	public void run(SourceContext<ExtendedMeasurement> ctx) {
+		final SplittableRandom rnd = new SplittableRandom();
+		final Object lock = ctx.getCheckpointLock();
+
+		while (running) {
+			ExtendedMeasurement event = randomEvent(rnd);
+
+			//noinspection SynchronizationOnLocalVariableOrMethodParameter
+			synchronized (lock) {
+				ctx.collect(event);
+			}
+		}
+	}
+
+	@Override
+	public void cancel() {
+		running = false;
+	}
+
+	/**
+	 * Creates sensor metadata that this source instance will work with.
+	 */
+	private void initSensors() {
+		final SplittableRandom rnd = new SplittableRandom();
+		final Sensor.SensorType[] sensorTypes =
+				Sensor.SensorType.values();
+
+		final int start = getRuntimeContext().getIndexOfThisSubtask() * NUM_SENSORS;
+		this.sensors = new Sensor[NUM_SENSORS];
+		this.lastValue = new double[NUM_SENSORS];
+		this.locations = new Location[NUM_SENSORS];
+		for (int i = 0; i < NUM_SENSORS; ++i) {
+			long sensorId = start + i;
+			long vendorId = sensorId % 100;
+			final Sensor.SensorType sensorType =
+					sensorTypes[(i / 2) % sensorTypes.length];
+			sensors[i] = new Sensor(sensorId, vendorId, sensorType);
+
+			lastValue[i] = randomInitialMeasurementValue(rnd, sensorType);
+
+			// assume that a sensor has a fixed position
+			locations[i] = randomInitialLocation(rnd, i);
+		}
+	}
+
+	/**
+	 * Creates a random measurement value that a sensor will start with.
+	 */
+	private double randomInitialMeasurementValue(
+			SplittableRandom rnd,
+			Sensor.SensorType sensorType) {
+		switch (sensorType) {
+			case Temperature:
+				// -10°C - 35°C
+				return rnd.nextInt(
+						(UPPER_TEMPERATURE_CELCIUS - LOWER_TEMPERATURE_CELCIUS) * 10) / 10.0 +
+						LOWER_TEMPERATURE_CELCIUS;
+			case Wind:
+				// 0km/h - 335km/h
+				return rnd.nextInt((UPPER_WIND_SPEED_KMH - LOWER_WIND_SPEED_KMH) * 10) / 10.0 +
+						LOWER_WIND_SPEED_KMH;
+			default:
+				throw new IllegalStateException("Unknown sensor type: " + sensorType);
+		}
+	}
+
+	/**
+	 * Creates a random location for a sensor, distinguishing two bounding boxes: US and DE.
+	 */
+	private static Location randomInitialLocation(SplittableRandom rnd, int i) {
+		final double longitude;
+		final double latitude;
+		// let's assume that no selected region wraps around LON -180/+180
+		if (i < NUM_SENSORS / 2) {
+			// in US
+			longitude = GeoUtils2.getRandomLongitudeUS(rnd);
+			latitude = GeoUtils2.getRandomLatitudeUS(rnd);
+		} else {
+			// in DE
+			longitude = GeoUtils2.getRandomLongitudeDE(rnd);
+			latitude = GeoUtils2.getRandomLatitudeDE(rnd);
+		}
+		double height = rnd.nextDouble() * 3000;
+		return new Location(longitude, latitude, height);
+	}
+
+	/**
+	 * Creates a randomized sensor value during runtime of the source. Each new value differs
+	 * slightly from the previous value that this sensor had.
+	 */
+	private ExtendedMeasurement randomEvent(SplittableRandom rnd) {
+		int randomIdx = rnd.nextInt(sensors.length);
+		Sensor sensor = sensors[randomIdx];
+		Location location = locations[randomIdx];
+
+		long timestamp = System.currentTimeMillis();
+
+		final double value = randomChangeMeasurementValue(
+				rnd,
+				sensor.getSensorType(),
+				location,
+				lastValue[randomIdx]);
+
+		lastValue[randomIdx] = value;
+
+		final MeasurementValue measurement =
+				new MeasurementValue(
+						value,
+						(float) (rnd.nextInt(100) - 50) / 10.0f, // +- 5
+						timestamp);
+
+		return new ExtendedMeasurement(
+				new Sensor(
+						sensor.getSensorId(), sensor.getVendorId(), sensor.getSensorType()),
+				new Location(
+						location.getLongitude(), location.getLatitude(), location.getHeight()),
+				measurement);
+	}
+
+	/**
+	 * Generates a new sensor value that is +-3 of the old value and reports a custom metric for
+	 * sensor values in the US.
+	 */
+	private double randomChangeMeasurementValue(
+			SplittableRandom rnd,
+			Sensor.SensorType sensorType,
+			Location location,
+			double lastValue) {
+		double change = rnd.nextDouble(6) - 3.0; // +- 3
+		final double value;
+		switch (sensorType) {
+			case Temperature:
+				value = newValueWithinBounds(
+						lastValue, change, LOWER_TEMPERATURE_CELCIUS, UPPER_TEMPERATURE_CELCIUS);
+				if (GeoUtils2.isInUS(location.getLongitude(), location.getLatitude())) {
+					sourceTemperatureUS.addValue(value);
+				}
+				break;
+			case Wind:
+				value = newValueWithinBounds(
+						lastValue, change, LOWER_WIND_SPEED_KMH, UPPER_WIND_SPEED_KMH);
+				break;
+			default:
+				throw new InternalError("Unknown sensor type: " + sensorType);
+		}
+		return value;
+	}
+
+	/**
+	 * Returns either <code>lastValue + change</code> (if within the given bounds) or
+	 * <code>lastValue - change</code> (otherwise).
+	 */
+	private static double newValueWithinBounds(
+			double lastValue,
+			double change,
+			double lowerLimit,
+			double upperLimit) {
+		double value;
+		if (lastValue + change >= lowerLimit && lastValue + change <= upperLimit) {
+			value = lastValue + change;
+		} else {
+			value = lastValue - change;
+		}
+		return value;
+	}
+}

--- a/troubleshooting/object-reuse/src/solution/java/com/ververica/flink/training/solutions/immutable/Sensor.java
+++ b/troubleshooting/object-reuse/src/solution/java/com/ververica/flink/training/solutions/immutable/Sensor.java
@@ -1,0 +1,79 @@
+package com.ververica.flink.training.solutions.immutable;
+
+import org.apache.flink.api.common.typeinfo.TypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInfoFactory;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Immutable variant of {@link com.ververica.flink.training.provided.ExtendedMeasurement.Sensor}.
+ */
+@SuppressWarnings("WeakerAccess")
+@TypeInfo(Sensor.SensorTypeInfoFactory.class)
+public class Sensor {
+	public enum SensorType {
+		Temperature,
+		Wind
+	}
+
+	private final long sensorId;
+	private final long vendorId;
+	private final SensorType sensorType;
+
+    /**
+     * Constructor.
+     */
+	public Sensor(
+			long sensorId,
+			long vendorId,
+			SensorType sensorType) {
+		this.sensorId = sensorId;
+		this.vendorId = vendorId;
+		this.sensorType = sensorType;
+	}
+
+	public long getSensorId() {
+		return sensorId;
+	}
+
+	public long getVendorId() {
+		return vendorId;
+	}
+
+	public SensorType getSensorType() {
+		return sensorType;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		Sensor sensor = (Sensor) o;
+		return sensorId == sensor.sensorId &&
+				vendorId == sensor.vendorId &&
+				sensorType == sensor.sensorType;
+	}
+
+	@Override
+	public int hashCode() {
+		// NOTE: do not use the enum directly here. Why?
+		// -> try with Sensor as a key in a distributed setting and see for yourself!
+		return Objects.hash(sensorId, vendorId, sensorType.ordinal());
+	}
+
+	public static class SensorTypeInfoFactory extends TypeInfoFactory<Sensor> {
+		@Override
+		public TypeInformation<Sensor> createTypeInfo(
+				Type t,
+				Map<String, TypeInformation<?>> genericParameters) {
+			return SensorTypeInfo.INSTANCE;
+		}
+	}
+}

--- a/troubleshooting/object-reuse/src/solution/java/com/ververica/flink/training/solutions/immutable/SensorSerializer.java
+++ b/troubleshooting/object-reuse/src/solution/java/com/ververica/flink/training/solutions/immutable/SensorSerializer.java
@@ -1,0 +1,90 @@
+package com.ververica.flink.training.solutions.immutable;
+
+import org.apache.flink.api.common.typeutils.SimpleTypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.base.TypeSerializerSingleton;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+
+import java.io.IOException;
+
+public class SensorSerializer extends TypeSerializerSingleton<Sensor> {
+	private static final Sensor.SensorType[] SENSOR_TYPES =
+			Sensor.SensorType.values();
+
+	private SensorSerializer() {
+	}
+
+	static final SensorSerializer INSTANCE = new SensorSerializer();
+
+	@Override
+	public boolean isImmutableType() {
+		return true;
+	}
+
+	@Override
+	public Sensor createInstance() {
+		return null;
+	}
+
+	@Override
+	public Sensor copy(Sensor from) {
+		return new Sensor(from.getSensorId(), from.getVendorId(), from.getSensorType());
+	}
+
+	@Override
+	public Sensor copy(Sensor from, Sensor reuse) {
+		return copy(from);
+	}
+
+	@Override
+	public int getLength() {
+		return Long.BYTES + Long.BYTES + Integer.BYTES;
+	}
+
+	@Override
+	public void serialize(Sensor record, DataOutputView target) throws IOException {
+		target.writeLong(record.getSensorId());
+		target.writeLong(record.getVendorId());
+		target.writeInt(record.getSensorType().ordinal());
+	}
+
+	@Override
+	public Sensor deserialize(DataInputView source) throws IOException {
+		long sensorId = source.readLong();
+		long vendorId = source.readLong();
+		Sensor.SensorType sensorType = SENSOR_TYPES[source.readInt()];
+		return new Sensor(sensorId, vendorId, sensorType);
+	}
+
+	@Override
+	public Sensor deserialize(Sensor reuse, DataInputView source) throws IOException {
+		return deserialize(source);
+	}
+
+	@Override
+	public void copy(DataInputView source, DataOutputView target) throws IOException {
+		target.writeLong(source.readLong());
+		target.writeLong(source.readLong());
+		target.writeInt(source.readInt());
+	}
+
+	// -----------------------------------------------------------------------------------
+
+	@Override
+	public TypeSerializerSnapshot<Sensor> snapshotConfiguration() {
+		return new SensorSerializerSnapshot();
+	}
+
+	@SuppressWarnings("WeakerAccess")
+	public static final class SensorSerializerSnapshot extends
+			SimpleTypeSerializerSnapshot<Sensor> {
+
+		/**
+		 * Returns a snapshot pointing to the singleton serializer instance.
+		 */
+		public SensorSerializerSnapshot() {
+			super(() -> INSTANCE);
+		}
+	}
+}

--- a/troubleshooting/object-reuse/src/solution/java/com/ververica/flink/training/solutions/immutable/SensorTypeInfo.java
+++ b/troubleshooting/object-reuse/src/solution/java/com/ververica/flink/training/solutions/immutable/SensorTypeInfo.java
@@ -1,0 +1,69 @@
+package com.ververica.flink.training.solutions.immutable;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+
+class SensorTypeInfo extends TypeInformation<Sensor> {
+
+	private SensorTypeInfo() {
+	}
+
+	static final SensorTypeInfo INSTANCE = new SensorTypeInfo();
+
+	@Override
+	public boolean isBasicType() {
+		return false;
+	}
+
+	@Override
+	public boolean isTupleType() {
+		return false;
+	}
+
+	@Override
+	public int getArity() {
+		return 3;
+	}
+
+	@Override
+	public int getTotalFields() {
+		return 3;
+	}
+
+	@Override
+	public Class<Sensor> getTypeClass() {
+		return Sensor.class;
+	}
+
+	@Override
+	public boolean isKeyType() {
+		return true;
+	}
+
+	@Override
+	public TypeSerializer<Sensor> createSerializer(ExecutionConfig config) {
+		return SensorSerializer.INSTANCE;
+	}
+
+	@Override
+	public String toString() {
+		return getClass().getSimpleName();
+	}
+
+	@SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
+	@Override
+	public boolean equals(Object obj) {
+		return this.canEqual(obj);
+	}
+
+	@Override
+	public int hashCode() {
+		return Sensor.class.hashCode();
+	}
+
+	@Override
+	public boolean canEqual(Object obj) {
+		return obj instanceof SensorTypeInfo;
+	}
+}

--- a/troubleshooting/state-migration/README.md
+++ b/troubleshooting/state-migration/README.md
@@ -1,0 +1,7 @@
+# Lab: Advanced Tuning & Troubleshooting: State Migration
+
+...
+
+-----
+
+[**Back to Tuning & Troubleshooting Labs Overview**](../README.md)

--- a/troubleshooting/state-migration/build.gradle
+++ b/troubleshooting/state-migration/build.gradle
@@ -1,0 +1,3 @@
+subprojects {
+    group = 'com.ververica.flink.training.troubleshooting.state-migration'
+}

--- a/troubleshooting/state-migration/common/build.gradle
+++ b/troubleshooting/state-migration/common/build.gradle
@@ -1,0 +1,10 @@
+plugins {
+    id 'java-library'
+}
+
+dependencies {
+    api project(":troubleshooting:common")
+
+    api "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
+    api "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
+}

--- a/troubleshooting/state-migration/common/src/main/java/com/ververica/flink/training/exercises/MeasurementAggregationReport.java
+++ b/troubleshooting/state-migration/common/src/main/java/com/ververica/flink/training/exercises/MeasurementAggregationReport.java
@@ -1,0 +1,56 @@
+package com.ververica.flink.training.exercises;
+
+/**
+ * Type for reporting aggregate results.
+ */
+public class MeasurementAggregationReport {
+	private int sensorId;
+	private long count;
+	private double average;
+	private long latestUpdate;
+
+	public MeasurementAggregationReport() {
+	}
+
+	public int getSensorId() {
+		return sensorId;
+	}
+
+	public void setSensorId(int sensorId) {
+		this.sensorId = sensorId;
+	}
+
+	public long getCount() {
+		return count;
+	}
+
+	public void setCount(long count) {
+		this.count = count;
+	}
+
+	public double getAverage() {
+		return average;
+	}
+
+	public void setAverage(double average) {
+		this.average = average;
+	}
+
+	public long getLatestUpdate() {
+		return latestUpdate;
+	}
+
+	public void setLatestUpdate(long latestUpdate) {
+		this.latestUpdate = latestUpdate;
+	}
+
+	@Override
+	public String toString() {
+		return "MeasurementAggregationReport{" +
+				"sensorId=" + sensorId +
+				", count=" + count +
+				", average=" + average +
+				", latestUpdate=" + latestUpdate +
+				'}';
+	}
+}

--- a/troubleshooting/state-migration/common/src/main/java/com/ververica/flink/training/exercises/MeasurementDeserializer.java
+++ b/troubleshooting/state-migration/common/src/main/java/com/ververica/flink/training/exercises/MeasurementDeserializer.java
@@ -1,0 +1,44 @@
+package com.ververica.flink.training.exercises;
+
+import org.apache.flink.api.common.functions.RichFlatMapFunction;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.Collector;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ververica.flink.training.common.DoNotChangeThis;
+import com.ververica.flink.training.common.FakeKafkaRecord;
+import com.ververica.flink.training.common.Measurement;
+
+import java.io.IOException;
+
+/**
+ * Deserializes {@link FakeKafkaRecord} into {@link Measurement} objects, ignoring deserialization
+ * failures.
+ */
+@DoNotChangeThis
+public class MeasurementDeserializer extends RichFlatMapFunction<FakeKafkaRecord, Measurement> {
+
+	private static final long serialVersionUID = -5805258552949837150L;
+
+	private transient ObjectMapper mapper;
+
+	@Override
+	public void open(final Configuration parameters) throws Exception {
+		super.open(parameters);
+		mapper = new ObjectMapper();
+		mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+	}
+
+	private Measurement deserialize(final byte[] bytes) throws IOException {
+		return mapper.readValue(bytes, Measurement.class);
+	}
+
+	@Override
+	public void flatMap(final FakeKafkaRecord kafkaRecord, final Collector<Measurement> out) {
+		try {
+			out.collect(deserialize(kafkaRecord.getValue()));
+		} catch (IOException ignored) {
+		}
+	}
+}

--- a/troubleshooting/state-migration/common/src/main/java/com/ververica/flink/training/exercises/SensorAggregationProcessingBase.java
+++ b/troubleshooting/state-migration/common/src/main/java/com/ververica/flink/training/exercises/SensorAggregationProcessingBase.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.flink.training.exercises;
+
+import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
+
+import com.ververica.flink.training.common.Measurement;
+
+public abstract class SensorAggregationProcessingBase extends
+		KeyedProcessFunction<Integer, Measurement, MeasurementAggregationReport> {
+	private static final long serialVersionUID = 5841581588188443035L;
+
+	/**
+	 * Gets the name of the state serializer that is being used.
+	 */
+	public abstract String getStateSerializerName();
+}

--- a/troubleshooting/state-migration/common/src/main/java/com/ververica/flink/training/exercises/StateMigrationJobBase.java
+++ b/troubleshooting/state-migration/common/src/main/java/com/ververica/flink/training/exercises/StateMigrationJobBase.java
@@ -1,0 +1,94 @@
+package com.ververica.flink.training.exercises;
+
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.util.OutputTag;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ververica.flink.training.common.DoNotChangeThis;
+import com.ververica.flink.training.common.EnvironmentUtils;
+import com.ververica.flink.training.common.FakeKafkaRecord;
+import com.ververica.flink.training.common.Measurement;
+import com.ververica.flink.training.common.SourceUtils;
+
+import java.time.Duration;
+
+@DoNotChangeThis
+public class StateMigrationJobBase {
+	public static final OutputTag<Measurement> LATE_DATA_TAG =
+			new OutputTag<Measurement>("late-data") {
+				private static final long serialVersionUID = 33513631677208956L;
+			};
+
+	protected static void createAndExecuteJob(
+			String[] args,
+			SensorAggregationProcessingBase keyedProcessFunction)
+			throws Exception {
+		ParameterTool parameters = ParameterTool.fromArgs(args);
+
+		StreamExecutionEnvironment env = EnvironmentUtils.createConfiguredEnvironment(parameters);
+
+		//Time Characteristics
+		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+
+		//Checkpointing Configuration
+		env.enableCheckpointing(5000);
+		env.getCheckpointConfig().setMinPauseBetweenCheckpoints(4000);
+
+		DataStream<Measurement> sourceStream = env
+				.addSource(SourceUtils.createFailureFreeFakeKafkaSource()).name("FakeKafkaSource")
+				.assignTimestampsAndWatermarks(
+						WatermarkStrategy.<FakeKafkaRecord>forBoundedOutOfOrderness(
+								Duration.ofMillis(250))
+								.withTimestampAssigner(
+										(element, timestamp) -> element.getTimestamp())
+				)
+				.map(new MeasurementDeserializer())
+				.name("Deserialization");
+
+		SingleOutputStreamOperator<MeasurementAggregationReport> aggregatedPerSensor = sourceStream
+				.keyBy(Measurement::getSensorId)
+				.process(keyedProcessFunction)
+				.name("AggregatePerSensor (" + keyedProcessFunction.getStateSerializerName() + ")")
+				.uid("AggregatePerSensor");
+
+		aggregatedPerSensor.addSink(new DiscardingSink<>()).name("NormalOutput")
+				.disableChaining();
+		aggregatedPerSensor.getSideOutput(LATE_DATA_TAG).addSink(new DiscardingSink<>())
+				.name("LateDataSink").disableChaining();
+
+		env.execute();
+	}
+
+	/**
+	 * Deserializes the JSON Kafka message.
+	 */
+	public static class MeasurementDeserializer extends
+			RichMapFunction<FakeKafkaRecord, Measurement> {
+		private static final long serialVersionUID = 1L;
+
+		private transient ObjectMapper mapper;
+
+		@Override
+		public void open(final Configuration parameters) throws Exception {
+			super.open(parameters);
+			mapper = new ObjectMapper();
+			mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+		}
+
+		@Override
+		public Measurement map(FakeKafkaRecord kafkaRecord) throws Exception {
+			return mapper.readValue(kafkaRecord.getValue(), Measurement.class);
+		}
+
+	}
+
+}

--- a/troubleshooting/state-migration/common/src/main/java/com/ververica/flink/training/exercises/StateMigrationJobBase.java
+++ b/troubleshooting/state-migration/common/src/main/java/com/ververica/flink/training/exercises/StateMigrationJobBase.java
@@ -4,7 +4,6 @@ import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -35,9 +34,6 @@ public class StateMigrationJobBase {
 		ParameterTool parameters = ParameterTool.fromArgs(args);
 
 		StreamExecutionEnvironment env = EnvironmentUtils.createConfiguredEnvironment(parameters);
-
-		//Time Characteristics
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 
 		//Checkpointing Configuration
 		env.enableCheckpointing(5000);

--- a/troubleshooting/state-migration/common/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatisticsSerializerBase.java
+++ b/troubleshooting/state-migration/common/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatisticsSerializerBase.java
@@ -1,0 +1,66 @@
+package com.ververica.flink.training.exercises.custom;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+
+import com.ververica.flink.training.common.DoNotChangeThis;
+
+import java.io.IOException;
+
+/**
+ * Custom serializer base class providing some default implementations for convenience.
+ */
+@DoNotChangeThis
+public abstract class AggregatedSensorStatisticsSerializerBase<T> extends
+		TypeSerializer<T> {
+	private static final long serialVersionUID = -6967834481356870922L;
+
+	@Override
+	public boolean isImmutableType() {
+		return false;
+	}
+
+	@Override
+	public T deserialize(
+			T reuse, DataInputView source) throws IOException {
+		return deserialize(source);
+	}
+
+	@Override
+	public T copy(T from, T reuse) {
+		return copy(from);
+	}
+
+	@Override
+	public void copy(DataInputView source, DataOutputView target) throws IOException {
+		serialize(deserialize(source), target);
+	}
+
+	@Override
+	public int getLength() {
+		return -1;
+	}
+
+	@Override
+	public TypeSerializer<T> duplicate() {
+		return this;
+	}
+
+	@Override
+	public int hashCode() {
+		return this.getClass().hashCode();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj instanceof AggregatedSensorStatisticsSerializerBase) {
+			AggregatedSensorStatisticsSerializerBase<?> other =
+					(AggregatedSensorStatisticsSerializerBase<?>) obj;
+
+			return other.getClass().equals(getClass());
+		} else {
+			return false;
+		}
+	}
+}

--- a/troubleshooting/state-migration/exercise/build.gradle
+++ b/troubleshooting/state-migration/exercise/build.gradle
@@ -1,0 +1,25 @@
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.16.0"
+    }
+}
+apply plugin: "com.commercehub.gradle.plugin.avro"
+
+mainClassName = 'com.ververica.flink.training.exercises.TroubledStreamingJob'
+
+dependencies {
+    flinkShadowJar "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
+    flinkShadowJar "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
+
+    flinkShadowJar "org.apache.flink:flink-avro:${flinkVersion}"
+
+    implementation project(path: ':troubleshooting:state-migration:common')
+    // transitive dependencies for flinkShadowJar need to be defined above
+    // (the alternative of using configuration: 'shadow' does not work there because that adds a dependency on
+    // the jar file, not the sources)
+    flinkShadowJar project(path: ':troubleshooting:common', transitive: false)
+    flinkShadowJar project(path: ':troubleshooting:state-migration:common', transitive: false)
+}

--- a/troubleshooting/state-migration/exercise/src/main/avro/AggregatedSensorStatistics.avsc
+++ b/troubleshooting/state-migration/exercise/src/main/avro/AggregatedSensorStatistics.avsc
@@ -1,0 +1,20 @@
+{"namespace": "com.ververica.training.statemigration.avro",
+ "type": "record",
+ "name": "AggregatedSensorStatistics",
+ "fields": [
+     {
+     "name": "sensorId",
+     "type": "int"
+     },
+     {
+     "name": "count",
+     "type": "long",
+     "default": 0
+     },
+     {
+     "name": "lastUpdate",
+     "type": "long",
+     "default": 0
+     }
+ ]
+}

--- a/troubleshooting/state-migration/exercise/src/main/java/com/ververica/flink/training/exercises/avro/SensorAggregationProcessing.java
+++ b/troubleshooting/state-migration/exercise/src/main/java/com/ververica/flink/training/exercises/avro/SensorAggregationProcessing.java
@@ -1,0 +1,80 @@
+package com.ververica.flink.training.exercises.avro;
+
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.Collector;
+
+import com.ververica.flink.training.common.Measurement;
+import com.ververica.flink.training.exercises.MeasurementAggregationReport;
+import com.ververica.flink.training.exercises.SensorAggregationProcessingBase;
+import com.ververica.flink.training.exercises.StateMigrationJobBase;
+import com.ververica.training.statemigration.avro.AggregatedSensorStatistics;
+
+/**
+ * Process function to report aggregated sensor statistics using Avro-serialized state.
+ */
+public class SensorAggregationProcessing extends SensorAggregationProcessingBase {
+
+	private static final int REPORTING_INTERVAL = 60_000;
+
+	private static final long serialVersionUID = 4123696380484855346L;
+
+	private transient ValueState<AggregatedSensorStatistics> aggregationState;
+
+	@Override
+	public void processElement(
+			Measurement measurement,
+			Context ctx,
+			Collector<MeasurementAggregationReport> out) throws Exception {
+		if (ctx.timestamp() > ctx.timerService().currentWatermark()) {
+			AggregatedSensorStatistics currentStats = aggregationState.value();
+			if (currentStats == null) {
+				currentStats = AggregatedSensorStatistics.newBuilder()
+						.setSensorId(measurement.getSensorId())
+						.build();
+			}
+			currentStats.setCount(currentStats.getCount() + 1);
+
+			// emit once per minute
+			long reportingTime = (ctx.timestamp() / REPORTING_INTERVAL) * REPORTING_INTERVAL;
+			if (reportingTime > ctx.timerService().currentWatermark()) {
+				ctx.timerService().registerEventTimeTimer(reportingTime);
+			}
+
+			aggregationState.update(currentStats);
+		} else {
+			ctx.output(StateMigrationJobBase.LATE_DATA_TAG, measurement);
+		}
+	}
+
+	@Override
+	public void onTimer(
+			long timestamp,
+			OnTimerContext ctx,
+			Collector<MeasurementAggregationReport> out) throws Exception {
+		AggregatedSensorStatistics currentStats = aggregationState.value();
+		currentStats.setLastUpdate(ctx.timestamp());
+
+		MeasurementAggregationReport report = new MeasurementAggregationReport();
+		report.setSensorId(currentStats.getSensorId());
+		report.setCount(currentStats.getCount());
+		report.setLatestUpdate(currentStats.getLastUpdate());
+
+		out.collect(report);
+	}
+
+	@Override
+	public void open(Configuration parameters) throws Exception {
+		super.open(parameters);
+
+		final ValueStateDescriptor<AggregatedSensorStatistics> aggregationStateDesc =
+				new ValueStateDescriptor<>("aggregationStats", AggregatedSensorStatistics.class);
+		aggregationState = getRuntimeContext().getState(aggregationStateDesc);
+	}
+
+	@Override
+	public String getStateSerializerName() {
+		return "avro v1";
+	}
+}

--- a/troubleshooting/state-migration/exercise/src/main/java/com/ververica/flink/training/exercises/avro/StateMigrationJob.java
+++ b/troubleshooting/state-migration/exercise/src/main/java/com/ververica/flink/training/exercises/avro/StateMigrationJob.java
@@ -1,0 +1,20 @@
+package com.ververica.flink.training.exercises.avro;
+
+import com.ververica.flink.training.common.DoNotChangeThis;
+import com.ververica.flink.training.exercises.StateMigrationJobBase;
+
+/**
+ * State migration job for Avro state migration / schema evolution.
+ */
+@DoNotChangeThis
+public class StateMigrationJob extends StateMigrationJobBase {
+
+    /**
+     * Creates and starts the state migration streaming job.
+	 *
+	 * @throws Exception if the application is misconfigured or fails during job submission
+     */
+	public static void main(String[] args) throws Exception {
+		createAndExecuteJob(args, new SensorAggregationProcessing());
+	}
+}

--- a/troubleshooting/state-migration/exercise/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatistics.java
+++ b/troubleshooting/state-migration/exercise/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatistics.java
@@ -1,0 +1,38 @@
+package com.ververica.flink.training.exercises.custom;
+
+/**
+ * Sensor statistics state POJO.
+ */
+public class AggregatedSensorStatistics {
+	private int sensorId;
+	private long count;
+	private long lastUpdate;
+
+	public AggregatedSensorStatistics() {
+	}
+
+	public int getSensorId() {
+		return sensorId;
+	}
+
+	public void setSensorId(int sensorId) {
+		this.sensorId = sensorId;
+	}
+
+	public long getCount() {
+		return count;
+	}
+
+	public void setCount(long count) {
+		this.count = count;
+	}
+
+	public long getLastUpdate() {
+		return lastUpdate;
+	}
+
+	public void setLastUpdate(long lastUpdate) {
+		this.lastUpdate = lastUpdate;
+	}
+
+}

--- a/troubleshooting/state-migration/exercise/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatisticsSerializerSnapshotV1.java
+++ b/troubleshooting/state-migration/exercise/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatisticsSerializerSnapshotV1.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.flink.training.exercises.custom;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+
+/**
+ * Serializer configuration snapshot for POJO and format evolution.
+ */
+public final class AggregatedSensorStatisticsSerializerSnapshotV1 implements
+		TypeSerializerSnapshot<AggregatedSensorStatistics> {
+	@Override
+	public int getCurrentVersion() {
+		return 1;
+	}
+
+	@Override
+	public TypeSerializerSchemaCompatibility<AggregatedSensorStatistics> resolveSchemaCompatibility(
+			TypeSerializer<AggregatedSensorStatistics> newSerializer) {
+		if (newSerializer instanceof AggregatedSensorStatisticsSerializerV1) {
+			return TypeSerializerSchemaCompatibility.compatibleAsIs();
+		} else {
+			return TypeSerializerSchemaCompatibility.incompatible();
+		}
+	}
+
+	@Override
+	public TypeSerializer<AggregatedSensorStatistics> restoreSerializer() {
+		return new AggregatedSensorStatisticsSerializerV1();
+	}
+
+	@Override
+	public void writeSnapshot(DataOutputView out) {
+	}
+
+	@Override
+	public void readSnapshot(int readVersion, DataInputView in, ClassLoader userCodeClassLoader) {
+	}
+}

--- a/troubleshooting/state-migration/exercise/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatisticsSerializerV1.java
+++ b/troubleshooting/state-migration/exercise/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatisticsSerializerV1.java
@@ -1,0 +1,53 @@
+package com.ververica.flink.training.exercises.custom;
+
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+
+import java.io.IOException;
+
+public class AggregatedSensorStatisticsSerializerV1
+		extends AggregatedSensorStatisticsSerializerBase<AggregatedSensorStatistics> {
+
+	private static final long serialVersionUID = 7089080352317847665L;
+
+	@Override
+	public AggregatedSensorStatistics createInstance() {
+		return new AggregatedSensorStatistics();
+	}
+
+	@Override
+	public void serialize(AggregatedSensorStatistics record, DataOutputView target)
+			throws IOException {
+		target.writeInt(record.getSensorId());
+		target.writeLong(record.getCount());
+		target.writeLong(record.getLastUpdate());
+	}
+
+	@Override
+	public AggregatedSensorStatistics deserialize(DataInputView source) throws IOException {
+		int sensorId = source.readInt();
+		long count = source.readLong();
+		long lastUpdate = source.readLong();
+
+		AggregatedSensorStatistics result = new AggregatedSensorStatistics();
+		result.setSensorId(sensorId);
+		result.setCount(count);
+		result.setLastUpdate(lastUpdate);
+		return result;
+	}
+
+	@Override
+	public AggregatedSensorStatistics copy(AggregatedSensorStatistics from) {
+		AggregatedSensorStatistics result = new AggregatedSensorStatistics();
+		result.setSensorId(from.getSensorId());
+		result.setCount(from.getCount());
+		result.setLastUpdate(from.getLastUpdate());
+		return result;
+	}
+
+	@Override
+	public TypeSerializerSnapshot<AggregatedSensorStatistics> snapshotConfiguration() {
+		return new AggregatedSensorStatisticsSerializerSnapshotV1();
+	}
+}

--- a/troubleshooting/state-migration/exercise/src/main/java/com/ververica/flink/training/exercises/custom/SensorAggregationProcessing.java
+++ b/troubleshooting/state-migration/exercise/src/main/java/com/ververica/flink/training/exercises/custom/SensorAggregationProcessing.java
@@ -1,0 +1,79 @@
+package com.ververica.flink.training.exercises.custom;
+
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.Collector;
+
+import com.ververica.flink.training.common.Measurement;
+import com.ververica.flink.training.exercises.MeasurementAggregationReport;
+import com.ververica.flink.training.exercises.SensorAggregationProcessingBase;
+import com.ververica.flink.training.exercises.StateMigrationJobBase;
+
+/**
+ * Process function to report aggregated sensor statistics using a custom serializer for its state.
+ */
+public class SensorAggregationProcessing extends SensorAggregationProcessingBase {
+
+	private static final int REPORTING_INTERVAL = 60_000;
+
+	private static final long serialVersionUID = 4123696380484855346L;
+
+	private transient ValueState<AggregatedSensorStatistics> aggregationState;
+
+	@Override
+	public void processElement(
+			Measurement measurement,
+			Context ctx,
+			Collector<MeasurementAggregationReport> out) throws Exception {
+		if (ctx.timestamp() > ctx.timerService().currentWatermark()) {
+			AggregatedSensorStatistics currentStats = aggregationState.value();
+			if (currentStats == null) {
+				currentStats = new AggregatedSensorStatistics();
+				currentStats.setSensorId(measurement.getSensorId());
+			}
+			currentStats.setCount(currentStats.getCount() + 1);
+
+			// emit once per minute
+			long reportingTime = (ctx.timestamp() / REPORTING_INTERVAL) * REPORTING_INTERVAL;
+			if (reportingTime > ctx.timerService().currentWatermark()) {
+				ctx.timerService().registerEventTimeTimer(reportingTime);
+			}
+
+			aggregationState.update(currentStats);
+		} else {
+			ctx.output(StateMigrationJobBase.LATE_DATA_TAG, measurement);
+		}
+	}
+
+	@Override
+	public void onTimer(
+			long timestamp,
+			OnTimerContext ctx,
+			Collector<MeasurementAggregationReport> out) throws Exception {
+		AggregatedSensorStatistics currentStats = aggregationState.value();
+		currentStats.setLastUpdate(ctx.timestamp());
+
+		MeasurementAggregationReport report = new MeasurementAggregationReport();
+		report.setSensorId(currentStats.getSensorId());
+		report.setCount(currentStats.getCount());
+		report.setLatestUpdate(currentStats.getLastUpdate());
+
+		out.collect(report);
+	}
+
+	@Override
+	public void open(Configuration parameters) throws Exception {
+		super.open(parameters);
+
+		final ValueStateDescriptor<AggregatedSensorStatistics> aggregationStateDesc =
+				new ValueStateDescriptor<>("aggregationStats",
+						new AggregatedSensorStatisticsSerializerV1());
+		aggregationState = getRuntimeContext().getState(aggregationStateDesc);
+	}
+
+	@Override
+	public String getStateSerializerName() {
+		return "custom v1";
+	}
+}

--- a/troubleshooting/state-migration/exercise/src/main/java/com/ververica/flink/training/exercises/custom/StateMigrationJob.java
+++ b/troubleshooting/state-migration/exercise/src/main/java/com/ververica/flink/training/exercises/custom/StateMigrationJob.java
@@ -1,0 +1,20 @@
+package com.ververica.flink.training.exercises.custom;
+
+import com.ververica.flink.training.common.DoNotChangeThis;
+import com.ververica.flink.training.exercises.StateMigrationJobBase;
+
+/**
+ * State migration job for custom serializer state migration / schema evolution.
+ */
+@DoNotChangeThis
+public class StateMigrationJob extends StateMigrationJobBase {
+
+	/**
+	 * Creates and starts the state migration streaming job.
+	 *
+	 * @throws Exception if the application is misconfigured or fails during job submission
+	 */
+	public static void main(String[] args) throws Exception {
+		createAndExecuteJob(args, new SensorAggregationProcessing());
+	}
+}

--- a/troubleshooting/state-migration/exercise/src/main/resources/log4j.properties
+++ b/troubleshooting/state-migration/exercise/src/main/resources/log4j.properties
@@ -1,0 +1,23 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+log4j.rootLogger=INFO, console
+
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{HH:mm:ss,SSS} %-5p %-60c %x - %m%n

--- a/troubleshooting/state-migration/solution-custom-to-avro/build.gradle
+++ b/troubleshooting/state-migration/solution-custom-to-avro/build.gradle
@@ -1,0 +1,25 @@
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.16.0"
+    }
+}
+apply plugin: "com.commercehub.gradle.plugin.avro"
+
+mainClassName = 'com.ververica.flink.training.exercises.TroubledStreamingJob'
+
+dependencies {
+    flinkShadowJar "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
+    flinkShadowJar "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
+
+    flinkShadowJar "org.apache.flink:flink-avro:${flinkVersion}"
+
+    implementation project(path: ':troubleshooting:common')
+    // transitive dependencies for flinkShadowJar need to be defined above
+    // (the alternative of using configuration: 'shadow' does not work there because that adds a dependency on
+    // the jar file, not the sources)
+    flinkShadowJar project(path: ':troubleshooting:common', transitive: false)
+    flinkShadowJar project(path: ':troubleshooting:state-migration:common', transitive: false)
+}

--- a/troubleshooting/state-migration/solution-custom-to-avro/src/main/avro/AggregatedSensorStatistics.avsc
+++ b/troubleshooting/state-migration/solution-custom-to-avro/src/main/avro/AggregatedSensorStatistics.avsc
@@ -1,0 +1,25 @@
+{"namespace": "com.ververica.training.statemigration.avro",
+ "type": "record",
+ "name": "AggregatedSensorStatistics",
+ "fields": [
+     {
+     "name": "sensorId",
+     "type": "int"
+     },
+     {
+     "name": "count",
+     "type": "long",
+     "default": 0
+     },
+     {
+     "name": "sum",
+     "type": "double",
+     "default": 0.0
+     },
+     {
+     "name": "lastUpdate",
+     "type": "long",
+     "default": 0
+     }
+ ]
+}

--- a/troubleshooting/state-migration/solution-custom-to-avro/src/main/java/com/ververica/flink/training/exercises/avro/SensorAggregationProcessing.java
+++ b/troubleshooting/state-migration/solution-custom-to-avro/src/main/java/com/ververica/flink/training/exercises/avro/SensorAggregationProcessing.java
@@ -1,0 +1,82 @@
+package com.ververica.flink.training.exercises.avro;
+
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.Collector;
+
+import com.ververica.flink.training.common.Measurement;
+import com.ververica.flink.training.exercises.MeasurementAggregationReport;
+import com.ververica.flink.training.exercises.SensorAggregationProcessingBase;
+import com.ververica.flink.training.exercises.StateMigrationJobBase;
+import com.ververica.training.statemigration.avro.AggregatedSensorStatistics;
+
+/**
+ * Process function to report aggregated sensor statistics using Avro-serialized state.
+ */
+public class SensorAggregationProcessing extends SensorAggregationProcessingBase {
+
+	private static final int REPORTING_INTERVAL = 60_000;
+
+	private static final long serialVersionUID = 4123696380484855346L;
+
+	private transient ValueState<AggregatedSensorStatistics> aggregationState;
+
+	@Override
+	public void processElement(
+			Measurement measurement,
+			Context ctx,
+			Collector<MeasurementAggregationReport> out) throws Exception {
+		if (ctx.timestamp() > ctx.timerService().currentWatermark()) {
+			AggregatedSensorStatistics currentStats = aggregationState.value();
+			if (currentStats == null) {
+				currentStats = AggregatedSensorStatistics.newBuilder()
+						.setSensorId(measurement.getSensorId())
+						.build();
+			}
+			currentStats.setCount(currentStats.getCount() + 1);
+			currentStats.setSum(currentStats.getSum() + measurement.getValue());
+
+			// emit once per minute
+			long reportingTime = (ctx.timestamp() / REPORTING_INTERVAL) * REPORTING_INTERVAL;
+			if (reportingTime > ctx.timerService().currentWatermark()) {
+				ctx.timerService().registerEventTimeTimer(reportingTime);
+			}
+
+			aggregationState.update(currentStats);
+		} else {
+			ctx.output(StateMigrationJobBase.LATE_DATA_TAG, measurement);
+		}
+	}
+
+	@Override
+	public void onTimer(
+			long timestamp,
+			OnTimerContext ctx,
+			Collector<MeasurementAggregationReport> out) throws Exception {
+		AggregatedSensorStatistics currentStats = aggregationState.value();
+		currentStats.setLastUpdate(ctx.timestamp());
+
+		MeasurementAggregationReport report = new MeasurementAggregationReport();
+		report.setSensorId(currentStats.getSensorId());
+		report.setCount(currentStats.getCount());
+		report.setAverage(currentStats.getSum() / (double) currentStats.getCount());
+		report.setLatestUpdate(currentStats.getLastUpdate());
+
+		out.collect(report);
+	}
+
+	@Override
+	public void open(Configuration parameters) throws Exception {
+		super.open(parameters);
+
+		final ValueStateDescriptor<AggregatedSensorStatistics> aggregationStateDesc =
+				new ValueStateDescriptor<>("aggregationStats", AggregatedSensorStatistics.class);
+		aggregationState = getRuntimeContext().getState(aggregationStateDesc);
+	}
+
+	@Override
+	public String getStateSerializerName() {
+		return "avro v2";
+	}
+}

--- a/troubleshooting/state-migration/solution-custom-to-avro/src/main/java/com/ververica/flink/training/exercises/avro/StateMigrationJob.java
+++ b/troubleshooting/state-migration/solution-custom-to-avro/src/main/java/com/ververica/flink/training/exercises/avro/StateMigrationJob.java
@@ -1,0 +1,20 @@
+package com.ververica.flink.training.exercises.avro;
+
+import com.ververica.flink.training.common.DoNotChangeThis;
+import com.ververica.flink.training.exercises.StateMigrationJobBase;
+
+/**
+ * State migration job for Avro state migration / schema evolution.
+ */
+@DoNotChangeThis
+public class StateMigrationJob extends StateMigrationJobBase {
+
+    /**
+     * Creates and starts the state migration streaming job.
+	 *
+	 * @throws Exception if the application is misconfigured or fails during job submission
+     */
+	public static void main(String[] args) throws Exception {
+		createAndExecuteJob(args, new SensorAggregationProcessing());
+	}
+}

--- a/troubleshooting/state-migration/solution-custom-to-avro/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatistics.java
+++ b/troubleshooting/state-migration/solution-custom-to-avro/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatistics.java
@@ -1,0 +1,46 @@
+package com.ververica.flink.training.exercises.custom;
+
+/**
+ * Sensor statistics state POJO.
+ */
+public class AggregatedSensorStatistics {
+	private int sensorId;
+	private long count;
+	private double sum;
+	private long lastUpdate;
+
+	public AggregatedSensorStatistics() {
+	}
+
+	public int getSensorId() {
+		return sensorId;
+	}
+
+	public void setSensorId(int sensorId) {
+		this.sensorId = sensorId;
+	}
+
+	public long getCount() {
+		return count;
+	}
+
+	public void setCount(long count) {
+		this.count = count;
+	}
+
+	public long getLastUpdate() {
+		return lastUpdate;
+	}
+
+	public void setLastUpdate(long lastUpdate) {
+		this.lastUpdate = lastUpdate;
+	}
+
+	public double getSum() {
+		return sum;
+	}
+
+	public void setSum(double sum) {
+		this.sum = sum;
+	}
+}

--- a/troubleshooting/state-migration/solution-custom-to-avro/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatisticsSerializerSnapshotV1.java
+++ b/troubleshooting/state-migration/solution-custom-to-avro/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatisticsSerializerSnapshotV1.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.flink.training.exercises.custom;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+
+/**
+ * Serializer configuration snapshot for POJO and format evolution.
+ */
+public final class AggregatedSensorStatisticsSerializerSnapshotV1 implements
+		TypeSerializerSnapshot<AggregatedSensorStatistics> {
+	@Override
+	public int getCurrentVersion() {
+		return 1;
+	}
+
+	@Override
+	public TypeSerializerSchemaCompatibility<AggregatedSensorStatistics> resolveSchemaCompatibility(
+			TypeSerializer<AggregatedSensorStatistics> newSerializer) {
+		if (newSerializer instanceof AggregatedSensorStatisticsSerializerV1) {
+			return TypeSerializerSchemaCompatibility.compatibleAsIs();
+		} else {
+			return TypeSerializerSchemaCompatibility.incompatible();
+		}
+	}
+
+	@Override
+	public TypeSerializer<AggregatedSensorStatistics> restoreSerializer() {
+		return new AggregatedSensorStatisticsSerializerV1();
+	}
+
+	@Override
+	public void writeSnapshot(DataOutputView out) {
+	}
+
+	@Override
+	public void readSnapshot(int readVersion, DataInputView in, ClassLoader userCodeClassLoader) {
+	}
+}

--- a/troubleshooting/state-migration/solution-custom-to-avro/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatisticsSerializerSnapshotV2.java
+++ b/troubleshooting/state-migration/solution-custom-to-avro/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatisticsSerializerSnapshotV2.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.flink.training.exercises.custom;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.formats.avro.typeutils.AvroSerializer;
+
+import com.ververica.training.statemigration.avro.AggregatedSensorStatistics;
+
+/**
+ * Serializer configuration snapshot for POJO and format evolution.
+ */
+public final class AggregatedSensorStatisticsSerializerSnapshotV2 implements
+		TypeSerializerSnapshot<AggregatedSensorStatistics> {
+	@Override
+	public int getCurrentVersion() {
+		return 1;
+	}
+
+	@Override
+	public TypeSerializerSchemaCompatibility<AggregatedSensorStatistics> resolveSchemaCompatibility(
+			TypeSerializer<AggregatedSensorStatistics> newSerializer) {
+		if (newSerializer instanceof AggregatedSensorStatisticsSerializerV2) {
+			return TypeSerializerSchemaCompatibility.compatibleAsIs();
+		} else if (newSerializer instanceof AvroSerializer) {
+			return TypeSerializerSchemaCompatibility.compatibleAfterMigration();
+		} else {
+			return TypeSerializerSchemaCompatibility.incompatible();
+		}
+	}
+
+	@Override
+	public TypeSerializer<AggregatedSensorStatistics> restoreSerializer() {
+		return new AggregatedSensorStatisticsSerializerV2();
+	}
+
+	@Override
+	public void writeSnapshot(DataOutputView out) {
+	}
+
+	@Override
+	public void readSnapshot(int readVersion, DataInputView in, ClassLoader userCodeClassLoader) {
+	}
+}

--- a/troubleshooting/state-migration/solution-custom-to-avro/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatisticsSerializerV1.java
+++ b/troubleshooting/state-migration/solution-custom-to-avro/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatisticsSerializerV1.java
@@ -1,0 +1,53 @@
+package com.ververica.flink.training.exercises.custom;
+
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+
+import java.io.IOException;
+
+public class AggregatedSensorStatisticsSerializerV1
+		extends AggregatedSensorStatisticsSerializerBase<AggregatedSensorStatistics> {
+
+	private static final long serialVersionUID = 7089080352317847665L;
+
+	@Override
+	public AggregatedSensorStatistics createInstance() {
+		return new AggregatedSensorStatistics();
+	}
+
+	@Override
+	public void serialize(AggregatedSensorStatistics record, DataOutputView target)
+			throws IOException {
+		target.writeInt(record.getSensorId());
+		target.writeLong(record.getCount());
+		target.writeLong(record.getLastUpdate());
+	}
+
+	@Override
+	public AggregatedSensorStatistics deserialize(DataInputView source) throws IOException {
+		int sensorId = source.readInt();
+		long count = source.readLong();
+		long lastUpdate = source.readLong();
+
+		AggregatedSensorStatistics result = new AggregatedSensorStatistics();
+		result.setSensorId(sensorId);
+		result.setCount(count);
+		result.setLastUpdate(lastUpdate);
+		return result;
+	}
+
+	@Override
+	public AggregatedSensorStatistics copy(AggregatedSensorStatistics from) {
+		AggregatedSensorStatistics result = new AggregatedSensorStatistics();
+		result.setSensorId(from.getSensorId());
+		result.setCount(from.getCount());
+		result.setLastUpdate(from.getLastUpdate());
+		return result;
+	}
+
+	@Override
+	public TypeSerializerSnapshot<AggregatedSensorStatistics> snapshotConfiguration() {
+		return new AggregatedSensorStatisticsSerializerSnapshotV1();
+	}
+}

--- a/troubleshooting/state-migration/solution-custom-to-avro/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatisticsSerializerV2.java
+++ b/troubleshooting/state-migration/solution-custom-to-avro/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatisticsSerializerV2.java
@@ -1,0 +1,59 @@
+package com.ververica.flink.training.exercises.custom;
+
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+
+import com.ververica.training.statemigration.avro.AggregatedSensorStatistics;
+
+import java.io.IOException;
+
+public class AggregatedSensorStatisticsSerializerV2
+		extends AggregatedSensorStatisticsSerializerBase<AggregatedSensorStatistics> {
+
+	private static final long serialVersionUID = -6778106052344549131L;
+
+	@Override
+	public AggregatedSensorStatistics createInstance() {
+		return new AggregatedSensorStatistics();
+	}
+
+	@Override
+	public void serialize(AggregatedSensorStatistics record, DataOutputView target)
+			throws IOException {
+		target.writeInt(record.getSensorId());
+		target.writeLong(record.getCount());
+		target.writeDouble(record.getSum());
+		target.writeLong(record.getLastUpdate());
+	}
+
+	@Override
+	public AggregatedSensorStatistics deserialize(DataInputView source) throws IOException {
+		int sensorId = source.readInt();
+		long count = source.readLong();
+		double sum = source.readDouble();
+		long lastUpdate = source.readLong();
+
+		AggregatedSensorStatistics result = new AggregatedSensorStatistics();
+		result.setSensorId(sensorId);
+		result.setCount(count);
+		result.setSum(sum);
+		result.setLastUpdate(lastUpdate);
+		return result;
+	}
+
+	@Override
+	public AggregatedSensorStatistics copy(AggregatedSensorStatistics from) {
+		AggregatedSensorStatistics result = new AggregatedSensorStatistics();
+		result.setSensorId(from.getSensorId());
+		result.setCount(from.getCount());
+		result.setSum(from.getSum());
+		result.setLastUpdate(from.getLastUpdate());
+		return result;
+	}
+
+	@Override
+	public TypeSerializerSnapshot<AggregatedSensorStatistics> snapshotConfiguration() {
+		return new AggregatedSensorStatisticsSerializerSnapshotV2();
+	}
+}

--- a/troubleshooting/state-migration/solution-custom-to-avro/src/main/java/com/ververica/flink/training/exercises/custom/SensorAggregationProcessing.java
+++ b/troubleshooting/state-migration/solution-custom-to-avro/src/main/java/com/ververica/flink/training/exercises/custom/SensorAggregationProcessing.java
@@ -1,0 +1,82 @@
+package com.ververica.flink.training.exercises.custom;
+
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.Collector;
+
+import com.ververica.flink.training.common.Measurement;
+import com.ververica.flink.training.exercises.MeasurementAggregationReport;
+import com.ververica.flink.training.exercises.SensorAggregationProcessingBase;
+import com.ververica.flink.training.exercises.StateMigrationJobBase;
+import com.ververica.training.statemigration.avro.AggregatedSensorStatistics;
+
+/**
+ * Process function to report aggregated sensor statistics using a custom serializer for its state.
+ */
+public class SensorAggregationProcessing extends SensorAggregationProcessingBase {
+
+	private static final int REPORTING_INTERVAL = 60_000;
+
+	private static final long serialVersionUID = 4123696380484855346L;
+
+	private transient ValueState<AggregatedSensorStatistics> aggregationState;
+
+	@Override
+	public void processElement(
+			Measurement measurement,
+			Context ctx,
+			Collector<MeasurementAggregationReport> out) throws Exception {
+		if (ctx.timestamp() > ctx.timerService().currentWatermark()) {
+			AggregatedSensorStatistics currentStats = aggregationState.value();
+			if (currentStats == null) {
+				currentStats = new AggregatedSensorStatistics();
+				currentStats.setSensorId(measurement.getSensorId());
+			}
+			currentStats.setCount(currentStats.getCount() + 1);
+			currentStats.setSum(currentStats.getSum() + measurement.getValue());
+
+			// emit once per minute
+			long reportingTime = (ctx.timestamp() / REPORTING_INTERVAL) * REPORTING_INTERVAL;
+			if (reportingTime > ctx.timerService().currentWatermark()) {
+				ctx.timerService().registerEventTimeTimer(reportingTime);
+			}
+
+			aggregationState.update(currentStats);
+		} else {
+			ctx.output(StateMigrationJobBase.LATE_DATA_TAG, measurement);
+		}
+	}
+
+	@Override
+	public void onTimer(
+			long timestamp,
+			OnTimerContext ctx,
+			Collector<MeasurementAggregationReport> out) throws Exception {
+		AggregatedSensorStatistics currentStats = aggregationState.value();
+		currentStats.setLastUpdate(ctx.timestamp());
+
+		MeasurementAggregationReport report = new MeasurementAggregationReport();
+		report.setSensorId(currentStats.getSensorId());
+		report.setCount(currentStats.getCount());
+		report.setAverage(currentStats.getSum() / (double) currentStats.getCount());
+		report.setLatestUpdate(currentStats.getLastUpdate());
+
+		out.collect(report);
+	}
+
+	@Override
+	public void open(Configuration parameters) throws Exception {
+		super.open(parameters);
+
+		final ValueStateDescriptor<AggregatedSensorStatistics> aggregationStateDesc =
+				new ValueStateDescriptor<>("aggregationStats",
+						AggregatedSensorStatistics.class);
+		aggregationState = getRuntimeContext().getState(aggregationStateDesc);
+	}
+
+	@Override
+	public String getStateSerializerName() {
+		return "avro";
+	}
+}

--- a/troubleshooting/state-migration/solution-custom-to-avro/src/main/java/com/ververica/flink/training/exercises/custom/StateMigrationJob.java
+++ b/troubleshooting/state-migration/solution-custom-to-avro/src/main/java/com/ververica/flink/training/exercises/custom/StateMigrationJob.java
@@ -1,0 +1,20 @@
+package com.ververica.flink.training.exercises.custom;
+
+import com.ververica.flink.training.common.DoNotChangeThis;
+import com.ververica.flink.training.exercises.StateMigrationJobBase;
+
+/**
+ * State migration job for custom serializer state migration / schema evolution.
+ */
+@DoNotChangeThis
+public class StateMigrationJob extends StateMigrationJobBase {
+
+	/**
+	 * Creates and starts the state migration streaming job.
+	 *
+	 * @throws Exception if the application is misconfigured or fails during job submission
+	 */
+	public static void main(String[] args) throws Exception {
+		createAndExecuteJob(args, new SensorAggregationProcessing());
+	}
+}

--- a/troubleshooting/state-migration/solution-custom-to-avro/src/main/resources/log4j.properties
+++ b/troubleshooting/state-migration/solution-custom-to-avro/src/main/resources/log4j.properties
@@ -1,0 +1,23 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+log4j.rootLogger=INFO, console
+
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{HH:mm:ss,SSS} %-5p %-60c %x - %m%n

--- a/troubleshooting/state-migration/solution/build.gradle
+++ b/troubleshooting/state-migration/solution/build.gradle
@@ -1,0 +1,25 @@
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.16.0"
+    }
+}
+apply plugin: "com.commercehub.gradle.plugin.avro"
+
+mainClassName = 'com.ververica.flink.training.exercises.TroubledStreamingJob'
+
+dependencies {
+    flinkShadowJar "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
+    flinkShadowJar "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
+
+    flinkShadowJar "org.apache.flink:flink-avro:${flinkVersion}"
+
+    implementation project(path: ':troubleshooting:state-migration:common')
+    // transitive dependencies for flinkShadowJar need to be defined above
+    // (the alternative of using configuration: 'shadow' does not work there because that adds a dependency on
+    // the jar file, not the sources)
+    flinkShadowJar project(path: ':troubleshooting:common', transitive: false)
+    flinkShadowJar project(path: ':troubleshooting:state-migration:common', transitive: false)
+}

--- a/troubleshooting/state-migration/solution/src/main/avro/AggregatedSensorStatistics.avsc
+++ b/troubleshooting/state-migration/solution/src/main/avro/AggregatedSensorStatistics.avsc
@@ -1,0 +1,25 @@
+{"namespace": "com.ververica.training.statemigration.avro",
+ "type": "record",
+ "name": "AggregatedSensorStatistics",
+ "fields": [
+     {
+     "name": "sensorId",
+     "type": "int"
+     },
+     {
+     "name": "count",
+     "type": "long",
+     "default": 0
+     },
+     {
+     "name": "sum",
+     "type": "double",
+     "default": 0.0
+     },
+     {
+     "name": "lastUpdate",
+     "type": "long",
+     "default": 0
+     }
+ ]
+}

--- a/troubleshooting/state-migration/solution/src/main/java/com/ververica/flink/training/exercises/avro/SensorAggregationProcessing.java
+++ b/troubleshooting/state-migration/solution/src/main/java/com/ververica/flink/training/exercises/avro/SensorAggregationProcessing.java
@@ -1,0 +1,82 @@
+package com.ververica.flink.training.exercises.avro;
+
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.Collector;
+
+import com.ververica.flink.training.common.Measurement;
+import com.ververica.flink.training.exercises.MeasurementAggregationReport;
+import com.ververica.flink.training.exercises.SensorAggregationProcessingBase;
+import com.ververica.flink.training.exercises.StateMigrationJobBase;
+import com.ververica.training.statemigration.avro.AggregatedSensorStatistics;
+
+/**
+ * Process function to report aggregated sensor statistics using Avro-serialized state.
+ */
+public class SensorAggregationProcessing extends SensorAggregationProcessingBase {
+
+	private static final int REPORTING_INTERVAL = 60_000;
+
+	private static final long serialVersionUID = 4123696380484855346L;
+
+	private transient ValueState<AggregatedSensorStatistics> aggregationState;
+
+	@Override
+	public void processElement(
+			Measurement measurement,
+			Context ctx,
+			Collector<MeasurementAggregationReport> out) throws Exception {
+		if (ctx.timestamp() > ctx.timerService().currentWatermark()) {
+			AggregatedSensorStatistics currentStats = aggregationState.value();
+			if (currentStats == null) {
+				currentStats = AggregatedSensorStatistics.newBuilder()
+						.setSensorId(measurement.getSensorId())
+						.build();
+			}
+			currentStats.setCount(currentStats.getCount() + 1);
+			currentStats.setSum(currentStats.getSum() + measurement.getValue());
+
+			// emit once per minute
+			long reportingTime = (ctx.timestamp() / REPORTING_INTERVAL) * REPORTING_INTERVAL;
+			if (reportingTime > ctx.timerService().currentWatermark()) {
+				ctx.timerService().registerEventTimeTimer(reportingTime);
+			}
+
+			aggregationState.update(currentStats);
+		} else {
+			ctx.output(StateMigrationJobBase.LATE_DATA_TAG, measurement);
+		}
+	}
+
+	@Override
+	public void onTimer(
+			long timestamp,
+			OnTimerContext ctx,
+			Collector<MeasurementAggregationReport> out) throws Exception {
+		AggregatedSensorStatistics currentStats = aggregationState.value();
+		currentStats.setLastUpdate(ctx.timestamp());
+
+		MeasurementAggregationReport report = new MeasurementAggregationReport();
+		report.setSensorId(currentStats.getSensorId());
+		report.setCount(currentStats.getCount());
+		report.setAverage(currentStats.getSum() / (double) currentStats.getCount());
+		report.setLatestUpdate(currentStats.getLastUpdate());
+
+		out.collect(report);
+	}
+
+	@Override
+	public void open(Configuration parameters) throws Exception {
+		super.open(parameters);
+
+		final ValueStateDescriptor<AggregatedSensorStatistics> aggregationStateDesc =
+				new ValueStateDescriptor<>("aggregationStats", AggregatedSensorStatistics.class);
+		aggregationState = getRuntimeContext().getState(aggregationStateDesc);
+	}
+
+	@Override
+	public String getStateSerializerName() {
+		return "avro v2";
+	}
+}

--- a/troubleshooting/state-migration/solution/src/main/java/com/ververica/flink/training/exercises/avro/StateMigrationJob.java
+++ b/troubleshooting/state-migration/solution/src/main/java/com/ververica/flink/training/exercises/avro/StateMigrationJob.java
@@ -1,0 +1,20 @@
+package com.ververica.flink.training.exercises.avro;
+
+import com.ververica.flink.training.common.DoNotChangeThis;
+import com.ververica.flink.training.exercises.StateMigrationJobBase;
+
+/**
+ * State migration job for Avro state migration / schema evolution.
+ */
+@DoNotChangeThis
+public class StateMigrationJob extends StateMigrationJobBase {
+
+    /**
+     * Creates and starts the state migration streaming job.
+	 *
+	 * @throws Exception if the application is misconfigured or fails during job submission
+     */
+	public static void main(String[] args) throws Exception {
+		createAndExecuteJob(args, new SensorAggregationProcessing());
+	}
+}

--- a/troubleshooting/state-migration/solution/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatistics.java
+++ b/troubleshooting/state-migration/solution/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatistics.java
@@ -1,0 +1,46 @@
+package com.ververica.flink.training.exercises.custom;
+
+/**
+ * Sensor statistics state POJO.
+ */
+public class AggregatedSensorStatistics {
+	private int sensorId;
+	private long count;
+	private double sum;
+	private long lastUpdate;
+
+	public AggregatedSensorStatistics() {
+	}
+
+	public int getSensorId() {
+		return sensorId;
+	}
+
+	public void setSensorId(int sensorId) {
+		this.sensorId = sensorId;
+	}
+
+	public long getCount() {
+		return count;
+	}
+
+	public void setCount(long count) {
+		this.count = count;
+	}
+
+	public long getLastUpdate() {
+		return lastUpdate;
+	}
+
+	public void setLastUpdate(long lastUpdate) {
+		this.lastUpdate = lastUpdate;
+	}
+
+	public double getSum() {
+		return sum;
+	}
+
+	public void setSum(double sum) {
+		this.sum = sum;
+	}
+}

--- a/troubleshooting/state-migration/solution/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatisticsSerializerSnapshotV1.java
+++ b/troubleshooting/state-migration/solution/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatisticsSerializerSnapshotV1.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.flink.training.exercises.custom;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+
+/**
+ * Serializer configuration snapshot for POJO and format evolution.
+ */
+public final class AggregatedSensorStatisticsSerializerSnapshotV1 implements
+		TypeSerializerSnapshot<AggregatedSensorStatistics> {
+	@Override
+	public int getCurrentVersion() {
+		return 1;
+	}
+
+	@Override
+	public TypeSerializerSchemaCompatibility<AggregatedSensorStatistics> resolveSchemaCompatibility(
+			TypeSerializer<AggregatedSensorStatistics> newSerializer) {
+		if (newSerializer instanceof AggregatedSensorStatisticsSerializerV1) {
+			return TypeSerializerSchemaCompatibility.compatibleAsIs();
+		} else if (newSerializer instanceof AggregatedSensorStatisticsSerializerV2) {
+			return TypeSerializerSchemaCompatibility.compatibleAfterMigration();
+		} else {
+			return TypeSerializerSchemaCompatibility.incompatible();
+		}
+	}
+
+	@Override
+	public TypeSerializer<AggregatedSensorStatistics> restoreSerializer() {
+		return new AggregatedSensorStatisticsSerializerV1();
+	}
+
+	@Override
+	public void writeSnapshot(DataOutputView out) {
+	}
+
+	@Override
+	public void readSnapshot(int readVersion, DataInputView in, ClassLoader userCodeClassLoader) {
+	}
+}

--- a/troubleshooting/state-migration/solution/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatisticsSerializerSnapshotV2.java
+++ b/troubleshooting/state-migration/solution/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatisticsSerializerSnapshotV2.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.flink.training.exercises.custom;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+
+/**
+ * Serializer configuration snapshot for POJO and format evolution.
+ */
+public final class AggregatedSensorStatisticsSerializerSnapshotV2 implements
+		TypeSerializerSnapshot<AggregatedSensorStatistics> {
+	@Override
+	public int getCurrentVersion() {
+		return 1;
+	}
+
+	@Override
+	public TypeSerializerSchemaCompatibility<AggregatedSensorStatistics> resolveSchemaCompatibility(
+			TypeSerializer<AggregatedSensorStatistics> newSerializer) {
+		if (newSerializer instanceof AggregatedSensorStatisticsSerializerV2) {
+			return TypeSerializerSchemaCompatibility.compatibleAsIs();
+		} else {
+			return TypeSerializerSchemaCompatibility.incompatible();
+		}
+	}
+
+	@Override
+	public TypeSerializer<AggregatedSensorStatistics> restoreSerializer() {
+		return new AggregatedSensorStatisticsSerializerV2();
+	}
+
+	@Override
+	public void writeSnapshot(DataOutputView out) {
+	}
+
+	@Override
+	public void readSnapshot(int readVersion, DataInputView in, ClassLoader userCodeClassLoader) {
+	}
+}

--- a/troubleshooting/state-migration/solution/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatisticsSerializerV1.java
+++ b/troubleshooting/state-migration/solution/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatisticsSerializerV1.java
@@ -1,0 +1,53 @@
+package com.ververica.flink.training.exercises.custom;
+
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+
+import java.io.IOException;
+
+public class AggregatedSensorStatisticsSerializerV1
+		extends AggregatedSensorStatisticsSerializerBase<AggregatedSensorStatistics> {
+
+	private static final long serialVersionUID = 7089080352317847665L;
+
+	@Override
+	public AggregatedSensorStatistics createInstance() {
+		return new AggregatedSensorStatistics();
+	}
+
+	@Override
+	public void serialize(AggregatedSensorStatistics record, DataOutputView target)
+			throws IOException {
+		target.writeInt(record.getSensorId());
+		target.writeLong(record.getCount());
+		target.writeLong(record.getLastUpdate());
+	}
+
+	@Override
+	public AggregatedSensorStatistics deserialize(DataInputView source) throws IOException {
+		int sensorId = source.readInt();
+		long count = source.readLong();
+		long lastUpdate = source.readLong();
+
+		AggregatedSensorStatistics result = new AggregatedSensorStatistics();
+		result.setSensorId(sensorId);
+		result.setCount(count);
+		result.setLastUpdate(lastUpdate);
+		return result;
+	}
+
+	@Override
+	public AggregatedSensorStatistics copy(AggregatedSensorStatistics from) {
+		AggregatedSensorStatistics result = new AggregatedSensorStatistics();
+		result.setSensorId(from.getSensorId());
+		result.setCount(from.getCount());
+		result.setLastUpdate(from.getLastUpdate());
+		return result;
+	}
+
+	@Override
+	public TypeSerializerSnapshot<AggregatedSensorStatistics> snapshotConfiguration() {
+		return new AggregatedSensorStatisticsSerializerSnapshotV1();
+	}
+}

--- a/troubleshooting/state-migration/solution/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatisticsSerializerV2.java
+++ b/troubleshooting/state-migration/solution/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatisticsSerializerV2.java
@@ -1,0 +1,57 @@
+package com.ververica.flink.training.exercises.custom;
+
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+
+import java.io.IOException;
+
+public class AggregatedSensorStatisticsSerializerV2
+		extends AggregatedSensorStatisticsSerializerBase<AggregatedSensorStatistics> {
+
+	private static final long serialVersionUID = -6778106052344549131L;
+
+	@Override
+	public AggregatedSensorStatistics createInstance() {
+		return new AggregatedSensorStatistics();
+	}
+
+	@Override
+	public void serialize(AggregatedSensorStatistics record, DataOutputView target)
+			throws IOException {
+		target.writeInt(record.getSensorId());
+		target.writeLong(record.getCount());
+		target.writeDouble(record.getSum());
+		target.writeLong(record.getLastUpdate());
+	}
+
+	@Override
+	public AggregatedSensorStatistics deserialize(DataInputView source) throws IOException {
+		int sensorId = source.readInt();
+		long count = source.readLong();
+		double sum = source.readDouble();
+		long lastUpdate = source.readLong();
+
+		AggregatedSensorStatistics result = new AggregatedSensorStatistics();
+		result.setSensorId(sensorId);
+		result.setCount(count);
+		result.setSum(sum);
+		result.setLastUpdate(lastUpdate);
+		return result;
+	}
+
+	@Override
+	public AggregatedSensorStatistics copy(AggregatedSensorStatistics from) {
+		AggregatedSensorStatistics result = new AggregatedSensorStatistics();
+		result.setSensorId(from.getSensorId());
+		result.setCount(from.getCount());
+		result.setSum(from.getSum());
+		result.setLastUpdate(from.getLastUpdate());
+		return result;
+	}
+
+	@Override
+	public TypeSerializerSnapshot<AggregatedSensorStatistics> snapshotConfiguration() {
+		return new AggregatedSensorStatisticsSerializerSnapshotV2();
+	}
+}

--- a/troubleshooting/state-migration/solution/src/main/java/com/ververica/flink/training/exercises/custom/SensorAggregationProcessing.java
+++ b/troubleshooting/state-migration/solution/src/main/java/com/ververica/flink/training/exercises/custom/SensorAggregationProcessing.java
@@ -1,0 +1,81 @@
+package com.ververica.flink.training.exercises.custom;
+
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.Collector;
+
+import com.ververica.flink.training.common.Measurement;
+import com.ververica.flink.training.exercises.MeasurementAggregationReport;
+import com.ververica.flink.training.exercises.SensorAggregationProcessingBase;
+import com.ververica.flink.training.exercises.StateMigrationJobBase;
+
+/**
+ * Process function to report aggregated sensor statistics using a custom serializer for its state.
+ */
+public class SensorAggregationProcessing extends SensorAggregationProcessingBase {
+
+	private static final int REPORTING_INTERVAL = 60_000;
+
+	private static final long serialVersionUID = 4123696380484855346L;
+
+	private transient ValueState<AggregatedSensorStatistics> aggregationState;
+
+	@Override
+	public void processElement(
+			Measurement measurement,
+			Context ctx,
+			Collector<MeasurementAggregationReport> out) throws Exception {
+		if (ctx.timestamp() > ctx.timerService().currentWatermark()) {
+			AggregatedSensorStatistics currentStats = aggregationState.value();
+			if (currentStats == null) {
+				currentStats = new AggregatedSensorStatistics();
+				currentStats.setSensorId(measurement.getSensorId());
+			}
+			currentStats.setCount(currentStats.getCount() + 1);
+			currentStats.setSum(currentStats.getSum() + measurement.getValue());
+
+			// emit once per minute
+			long reportingTime = (ctx.timestamp() / REPORTING_INTERVAL) * REPORTING_INTERVAL;
+			if (reportingTime > ctx.timerService().currentWatermark()) {
+				ctx.timerService().registerEventTimeTimer(reportingTime);
+			}
+
+			aggregationState.update(currentStats);
+		} else {
+			ctx.output(StateMigrationJobBase.LATE_DATA_TAG, measurement);
+		}
+	}
+
+	@Override
+	public void onTimer(
+			long timestamp,
+			OnTimerContext ctx,
+			Collector<MeasurementAggregationReport> out) throws Exception {
+		AggregatedSensorStatistics currentStats = aggregationState.value();
+		currentStats.setLastUpdate(ctx.timestamp());
+
+		MeasurementAggregationReport report = new MeasurementAggregationReport();
+		report.setSensorId(currentStats.getSensorId());
+		report.setCount(currentStats.getCount());
+		report.setAverage(currentStats.getSum() / (double) currentStats.getCount());
+		report.setLatestUpdate(currentStats.getLastUpdate());
+
+		out.collect(report);
+	}
+
+	@Override
+	public void open(Configuration parameters) throws Exception {
+		super.open(parameters);
+
+		final ValueStateDescriptor<AggregatedSensorStatistics> aggregationStateDesc =
+				new ValueStateDescriptor<>("aggregationStats",
+						new AggregatedSensorStatisticsSerializerV2());
+		aggregationState = getRuntimeContext().getState(aggregationStateDesc);
+	}
+
+	@Override
+	public String getStateSerializerName() {
+		return "custom v2";
+	}
+}

--- a/troubleshooting/state-migration/solution/src/main/java/com/ververica/flink/training/exercises/custom/StateMigrationJob.java
+++ b/troubleshooting/state-migration/solution/src/main/java/com/ververica/flink/training/exercises/custom/StateMigrationJob.java
@@ -1,0 +1,20 @@
+package com.ververica.flink.training.exercises.custom;
+
+import com.ververica.flink.training.common.DoNotChangeThis;
+import com.ververica.flink.training.exercises.StateMigrationJobBase;
+
+/**
+ * State migration job for custom serializer state migration / schema evolution.
+ */
+@DoNotChangeThis
+public class StateMigrationJob extends StateMigrationJobBase {
+
+	/**
+	 * Creates and starts the state migration streaming job.
+	 *
+	 * @throws Exception if the application is misconfigured or fails during job submission
+	 */
+	public static void main(String[] args) throws Exception {
+		createAndExecuteJob(args, new SensorAggregationProcessing());
+	}
+}

--- a/troubleshooting/state-migration/solution/src/main/resources/log4j.properties
+++ b/troubleshooting/state-migration/solution/src/main/resources/log4j.properties
@@ -1,0 +1,23 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+log4j.rootLogger=INFO, console
+
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{HH:mm:ss,SSS} %-5p %-60c %x - %m%n

--- a/troubleshooting/throughput/README.md
+++ b/troubleshooting/throughput/README.md
@@ -1,0 +1,18 @@
+# Lab: Advanced Tuning & Troubleshooting: Throughput
+
+## Exercise
+
+* Improve the throughput of [`ThroughputJob`](src/main/java/com/ververica/flink/training/exercises/ThroughputJob.java).
+  - Identify where backpressure originates.
+  - You can also use a (local) profiler of your choice for identifying further optimisation potential.
+    - Disable the local print sink for this (why?)
+
+## Stats from Throughput Task row in Grafana
+
+- [ThroughputJob](src/main/java/com/ververica/flink/training/exercises/ThroughputJob.java): ~160 K ops
+- [ThroughputJobSolution1](src/solution/java/com/ververica/flink/training/solutions/ThroughputJobSolution1.java): ~215 K ops
+- [ThroughputJobSolution2](src/solution/java/com/ververica/flink/training/solutions/ThroughputJobSolution2.java): ~930 K ops
+
+-----
+
+[**Back to Tuning & Troubleshooting Labs Overview**](../README.md)

--- a/troubleshooting/throughput/build.gradle
+++ b/troubleshooting/throughput/build.gradle
@@ -1,0 +1,19 @@
+mainClassName = 'com.ververica.flink.training.exercises.TroubledStreamingJob'
+
+dependencies {
+    flinkShadowJar "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
+    flinkShadowJar "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
+
+    implementation project(path: ':troubleshooting:common')
+    // transitive dependencies for flinkShadowJar need to be defined above
+    // (the alternative of using configuration: 'shadow' does not work there because that adds a dependency on
+    // the jar file, not the sources)
+    flinkShadowJar project(path: ':troubleshooting:common', transitive: false)
+}
+
+sourceSets {
+    main.java.srcDirs += 'src/provided/java'
+    tasks.withType(ScalaCompile) {
+        main.scala.srcDirs += 'src/provided/scala'
+    }
+}

--- a/troubleshooting/throughput/src/main/java/com/ververica/flink/training/exercises/ThroughputJob.java
+++ b/troubleshooting/throughput/src/main/java/com/ververica/flink/training/exercises/ThroughputJob.java
@@ -1,0 +1,256 @@
+package com.ververica.flink.training.exercises;
+
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.api.common.functions.RichFlatMapFunction;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
+import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
+import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
+import org.apache.flink.util.Collector;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ververica.flink.training.common.FakeKafkaRecord;
+import com.ververica.flink.training.common.SourceUtils;
+import com.ververica.flink.training.common.WindowedMeasurements;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import static com.ververica.flink.training.common.EnvironmentUtils.createConfiguredEnvironment;
+import static com.ververica.flink.training.common.EnvironmentUtils.isLocal;
+
+/**
+ * Streaming job that isn't performing as expected.
+ */
+public class ThroughputJob {
+
+    /**
+     * Creates and starts the troubled streaming job.
+	 *
+	 * @throws Exception if the application is misconfigured or fails during job submission
+     */
+	public static void main(String[] args) throws Exception {
+		ParameterTool parameters = ParameterTool.fromArgs(args);
+
+		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
+
+		//Time Characteristics
+		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		env.getConfig().setAutoWatermarkInterval(100);
+		env.setBufferTimeout(10);
+
+		//Checkpointing Configuration
+		env.enableCheckpointing(5000);
+		env.getCheckpointConfig().setMinPauseBetweenCheckpoints(4000);
+
+		DataStream<JsonNode> sourceStream = env
+				.addSource(SourceUtils.createFakeKafkaSource())
+				.name("FakeKafkaSource")
+				.uid("FakeKafkaSource")
+				.assignTimestampsAndWatermarks(
+						WatermarkStrategy
+								.<FakeKafkaRecord>forBoundedOutOfOrderness(Duration.ofMillis(250))
+								.withTimestampAssigner(
+										(element, timestamp) -> element.getTimestamp())
+								.withIdleness(Duration.ofSeconds(1)))
+				.name("Watermarks")
+				.uid("Watermarks")
+				.flatMap(new MeasurementDeserializer())
+				.name("Deserialization")
+				.uid("Deserialization");
+
+		DataStream<WindowedMeasurements> aggregatedPerLocation = sourceStream
+				.keyBy(jsonNode -> jsonNode.get("location").asText())
+				.timeWindow(Time.of(1, TimeUnit.SECONDS))
+				.aggregate(new MeasurementWindowAggregatingPerLocation(),
+						new MeasurementWindowProcessFunction())
+				.name("WindowedAggregationPerLocation")
+				.uid("WindowedAggregationPerLocation");
+
+		DataStream<WindowedMeasurementsForArea> aggregatedPerArea = aggregatedPerLocation
+				.keyBy(m -> WindowedMeasurementsForArea.getArea(m.getLocation()))
+				.timeWindow(Time.of(1, TimeUnit.SECONDS))
+				.aggregate(new MeasurementWindowAggregatingPerArea());
+
+		if (isLocal(parameters)) {
+			aggregatedPerLocation.addSink(new DiscardingSink<>())
+					.name("OutputPerLocation")
+					.uid("OutputPerLocation")
+					.disableChaining();
+			aggregatedPerArea.print()
+					.name("OutputPerArea")
+					.uid("OutputPerArea")
+					.disableChaining();
+		} else {
+			aggregatedPerLocation.addSink(new DiscardingSink<>())
+					.name("OutputPerLocation")
+					.uid("OutputPerLocation")
+					.disableChaining();
+			aggregatedPerArea.addSink(new DiscardingSink<>())
+					.name("OutputPerArea")
+					.uid("OutputPerArea")
+					.disableChaining();
+		}
+
+		env.execute(ThroughputJob.class.getSimpleName());
+	}
+
+	/**
+	 * Deserializes the JSON Kafka message.
+	 */
+	public static class MeasurementDeserializer extends
+			RichFlatMapFunction<FakeKafkaRecord, JsonNode> {
+		private static final long serialVersionUID = 1L;
+
+		private Counter numInvalidRecords;
+
+		@Override
+		public void open(final Configuration parameters) throws Exception {
+			super.open(parameters);
+			numInvalidRecords = getRuntimeContext().getMetricGroup().counter("numInvalidRecords");
+		}
+
+		@Override
+		public void flatMap(final FakeKafkaRecord kafkaRecord, final Collector<JsonNode> out) {
+			final JsonNode node;
+			try {
+				node = deserialize(kafkaRecord.getValue());
+			} catch (IOException e) {
+				numInvalidRecords.inc();
+				return;
+			}
+			out.collect(node);
+		}
+
+		private JsonNode deserialize(final byte[] bytes) throws IOException {
+			return ObjectMapperSingleton.getInstance().readValue(bytes, JsonNode.class);
+		}
+	}
+
+	public static class MeasurementWindowProcessFunction
+			extends
+			ProcessWindowFunction<WindowedMeasurements, WindowedMeasurements, String, TimeWindow> {
+		private static final long serialVersionUID = 1L;
+
+		private static final int EVENT_TIME_LAG_WINDOW_SIZE = 10_000;
+
+		private transient DescriptiveStatisticsHistogram eventTimeLag;
+
+		@Override
+		public void process(
+				final String location,
+				final Context context,
+				final Iterable<WindowedMeasurements> input,
+				final Collector<WindowedMeasurements> out) {
+
+			// Windows with pre-aggregation only forward the final aggregate to the WindowFunction
+			WindowedMeasurements aggregate = input.iterator().next();
+
+			final TimeWindow window = context.window();
+			aggregate.setWindow(window);
+			aggregate.setLocation(location);
+
+			eventTimeLag.update(System.currentTimeMillis() - window.getEnd());
+			out.collect(aggregate);
+		}
+
+		@Override
+		public void open(Configuration parameters) throws Exception {
+			super.open(parameters);
+
+			eventTimeLag = getRuntimeContext().getMetricGroup().histogram("eventTimeLag",
+					new DescriptiveStatisticsHistogram(EVENT_TIME_LAG_WINDOW_SIZE));
+		}
+	}
+
+	public static class MeasurementWindowAggregatingPerLocation
+			implements
+			AggregateFunction<JsonNode, WindowedMeasurements, WindowedMeasurements> {
+
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public WindowedMeasurements add(
+				final JsonNode record,
+				final WindowedMeasurements aggregate) {
+			double result = Double.parseDouble(record.get("value").asText());
+			aggregate.addMeasurement(result);
+			return aggregate;
+		}
+
+		@Override
+		public WindowedMeasurements createAccumulator() {
+			return new WindowedMeasurements();
+		}
+
+		@Override
+		public WindowedMeasurements getResult(final WindowedMeasurements windowedMeasurements) {
+			return windowedMeasurements;
+		}
+
+		@Override
+		public WindowedMeasurements merge(
+				final WindowedMeasurements agg1,
+				final WindowedMeasurements agg2) {
+			agg2.setEventsPerWindow(agg1.getEventsPerWindow() + agg2.getEventsPerWindow());
+			agg2.setSumPerWindow(agg1.getSumPerWindow() + agg2.getSumPerWindow());
+			return agg2;
+		}
+	}
+
+	public static class MeasurementWindowAggregatingPerArea
+			implements
+			AggregateFunction<WindowedMeasurements, WindowedMeasurementsForArea, WindowedMeasurementsForArea> {
+
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public WindowedMeasurementsForArea add(
+				final WindowedMeasurements value,
+				final WindowedMeasurementsForArea aggregate) {
+			aggregate.addMeasurement(value);
+			return aggregate;
+		}
+
+		@Override
+		public WindowedMeasurementsForArea getResult(WindowedMeasurementsForArea windowedMeasurements) {
+			String aLocation = windowedMeasurements.getLocations().get(0);
+			windowedMeasurements.setArea(WindowedMeasurementsForArea.getArea(aLocation));
+			return windowedMeasurements;
+		}
+
+		@Override
+		public WindowedMeasurementsForArea createAccumulator() {
+			return new WindowedMeasurementsForArea();
+		}
+
+		@Override
+		public WindowedMeasurementsForArea merge(
+				final WindowedMeasurementsForArea agg1,
+				final WindowedMeasurementsForArea agg2) {
+			agg2.setEventsPerWindow(agg1.getEventsPerWindow() + agg2.getEventsPerWindow());
+			agg2.setSumPerWindow(agg1.getSumPerWindow() + agg2.getSumPerWindow());
+			agg2.addAllLocations(agg1.getLocations());
+			return agg2;
+		}
+	}
+
+	private static class ObjectMapperSingleton {
+		static ObjectMapper getInstance() {
+			ObjectMapper objectMapper = new ObjectMapper();
+			objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+			return objectMapper;
+		}
+	}
+}

--- a/troubleshooting/throughput/src/main/java/com/ververica/flink/training/exercises/ThroughputJob.java
+++ b/troubleshooting/throughput/src/main/java/com/ververica/flink/training/exercises/ThroughputJob.java
@@ -7,11 +7,11 @@ import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
+import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 import org.apache.flink.util.Collector;
@@ -25,7 +25,6 @@ import com.ververica.flink.training.common.WindowedMeasurements;
 
 import java.io.IOException;
 import java.time.Duration;
-import java.util.concurrent.TimeUnit;
 
 import static com.ververica.flink.training.common.EnvironmentUtils.createConfiguredEnvironment;
 import static com.ververica.flink.training.common.EnvironmentUtils.isLocal;
@@ -45,8 +44,7 @@ public class ThroughputJob {
 
 		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
 
-		//Time Characteristics
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		//Timing Configuration
 		env.getConfig().setAutoWatermarkInterval(100);
 		env.setBufferTimeout(10);
 
@@ -72,7 +70,7 @@ public class ThroughputJob {
 
 		DataStream<WindowedMeasurements> aggregatedPerLocation = sourceStream
 				.keyBy(jsonNode -> jsonNode.get("location").asText())
-				.timeWindow(Time.of(1, TimeUnit.SECONDS))
+				.window(TumblingEventTimeWindows.of(Time.seconds(1)))
 				.aggregate(new MeasurementWindowAggregatingPerLocation(),
 						new MeasurementWindowProcessFunction())
 				.name("WindowedAggregationPerLocation")
@@ -80,7 +78,7 @@ public class ThroughputJob {
 
 		DataStream<WindowedMeasurementsForArea> aggregatedPerArea = aggregatedPerLocation
 				.keyBy(m -> WindowedMeasurementsForArea.getArea(m.getLocation()))
-				.timeWindow(Time.of(1, TimeUnit.SECONDS))
+				.window(TumblingEventTimeWindows.of(Time.seconds(1)))
 				.aggregate(new MeasurementWindowAggregatingPerArea());
 
 		if (isLocal(parameters)) {

--- a/troubleshooting/throughput/src/main/java/com/ververica/flink/training/exercises/WindowedMeasurementsForArea.java
+++ b/troubleshooting/throughput/src/main/java/com/ververica/flink/training/exercises/WindowedMeasurementsForArea.java
@@ -1,0 +1,137 @@
+package com.ververica.flink.training.exercises;
+
+import com.ververica.flink.training.common.WindowedMeasurements;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+
+@SuppressWarnings({"unused", "unchecked", "rawtypes"})
+public class WindowedMeasurementsForArea {
+
+	private long windowStart;
+	private long windowEnd;
+	private String area;
+	private final List locations = new ArrayList();
+	private long eventsPerWindow;
+	private double sumPerWindow;
+
+	public WindowedMeasurementsForArea() {
+	}
+
+	public WindowedMeasurementsForArea(
+			final long windowStart,
+			final long windowEnd,
+			final String area,
+			final String location,
+			final long eventsPerWindow,
+			final double sumPerWindow) {
+		this.windowStart = windowStart;
+		this.windowEnd = windowEnd;
+		this.area = area;
+		this.locations.add(location);
+		this.eventsPerWindow = eventsPerWindow;
+		this.sumPerWindow = sumPerWindow;
+	}
+
+	public long getWindowStart() {
+		return windowStart;
+	}
+
+	public void setWindowStart(final long windowStart) {
+		this.windowStart = windowStart;
+	}
+
+	public long getWindowEnd() {
+		return windowEnd;
+	}
+
+	public void setWindowEnd(final long windowEnd) {
+		this.windowEnd = windowEnd;
+	}
+
+	public String getArea() {
+		return area;
+	}
+
+	public void setArea(String area) {
+		this.area = area;
+	}
+
+	public List<String> getLocations() {
+		return locations;
+	}
+
+	public void addLocation(final String location) {
+		this.locations.add(location);
+	}
+
+	public void addAllLocations(final Collection<? extends String> locations) {
+		this.locations.addAll(locations);
+	}
+
+	public static String getArea(String location) {
+		if (location.length() > 0) {
+			return location.substring(0, 1);
+		} else {
+			return "";
+		}
+	}
+
+	public long getEventsPerWindow() {
+		return eventsPerWindow;
+	}
+
+	public void setEventsPerWindow(final long eventsPerWindow) {
+		this.eventsPerWindow = eventsPerWindow;
+	}
+
+	public double getSumPerWindow() {
+		return sumPerWindow;
+	}
+
+	public void setSumPerWindow(final double sumPerWindow) {
+		this.sumPerWindow = sumPerWindow;
+	}
+
+	public void addMeasurement(WindowedMeasurements measurements) {
+		sumPerWindow += measurements.getSumPerWindow();
+		eventsPerWindow += measurements.getEventsPerWindow();
+		locations.add(measurements.getLocation());
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		WindowedMeasurementsForArea that = (WindowedMeasurementsForArea) o;
+		return windowStart == that.windowStart &&
+				windowEnd == that.windowEnd &&
+				eventsPerWindow == that.eventsPerWindow &&
+				Double.compare(that.sumPerWindow, sumPerWindow) == 0 &&
+				Objects.equals(area, that.area) &&
+				locations.equals(that.locations);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(windowStart, windowEnd, area, locations, eventsPerWindow, sumPerWindow);
+	}
+
+	@Override
+	public String toString() {
+		return "WindowedMeasurementsForArea{" +
+				"windowStart=" + windowStart +
+				", windowEnd=" + windowEnd +
+				", area='" + area + '\'' +
+				", locations=" + locations +
+				", eventsPerWindow=" + eventsPerWindow +
+				", sumPerWindow=" + sumPerWindow +
+				'}';
+	}
+}

--- a/troubleshooting/throughput/src/main/resources/log4j.properties
+++ b/troubleshooting/throughput/src/main/resources/log4j.properties
@@ -1,0 +1,23 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+log4j.rootLogger=INFO, console
+
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{HH:mm:ss,SSS} %-5p %-60c %x - %m%n

--- a/troubleshooting/throughput/src/solution/java/com/ververica/flink/training/solutions/ThroughputJobSolution1.java
+++ b/troubleshooting/throughput/src/solution/java/com/ververica/flink/training/solutions/ThroughputJobSolution1.java
@@ -1,0 +1,257 @@
+package com.ververica.flink.training.solutions;
+
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.api.common.functions.RichFlatMapFunction;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
+import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
+import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
+import org.apache.flink.util.Collector;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ververica.flink.training.common.FakeKafkaRecord;
+import com.ververica.flink.training.common.SourceUtils;
+import com.ververica.flink.training.common.WindowedMeasurements;
+import com.ververica.flink.training.exercises.WindowedMeasurementsForArea;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import static com.ververica.flink.training.common.EnvironmentUtils.createConfiguredEnvironment;
+import static com.ververica.flink.training.common.EnvironmentUtils.isLocal;
+
+/**
+ * Streaming job evolved by optimising throughput initializing {@link ObjectMapper} only once.
+ */
+public class ThroughputJobSolution1 {
+
+    /**
+     * Creates and starts the troubled streaming job.
+	 *
+	 * @throws Exception if the application is misconfigured or fails during job submission
+     */
+	public static void main(String[] args) throws Exception {
+		ParameterTool parameters = ParameterTool.fromArgs(args);
+
+		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
+
+		//Time Characteristics
+		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		env.getConfig().setAutoWatermarkInterval(100);
+		env.setBufferTimeout(10);
+
+		//Checkpointing Configuration
+		env.enableCheckpointing(5000);
+		env.getCheckpointConfig().setMinPauseBetweenCheckpoints(4000);
+
+		DataStream<JsonNode> sourceStream = env
+				.addSource(SourceUtils.createFakeKafkaSource())
+				.name("FakeKafkaSource")
+				.uid("FakeKafkaSource")
+				.assignTimestampsAndWatermarks(
+						WatermarkStrategy
+								.<FakeKafkaRecord>forBoundedOutOfOrderness(Duration.ofMillis(250))
+								.withTimestampAssigner(
+										(element, timestamp) -> element.getTimestamp())
+								.withIdleness(Duration.ofSeconds(1)))
+				.name("Watermarks")
+				.uid("Watermarks")
+				.flatMap(new MeasurementDeserializer())
+				.name("Deserialization")
+				.uid("Deserialization");
+
+		DataStream<WindowedMeasurements> aggregatedPerLocation = sourceStream
+				.keyBy(jsonNode -> jsonNode.get("location").asText())
+				.timeWindow(Time.of(1, TimeUnit.SECONDS))
+				.aggregate(new MeasurementWindowAggregatingPerLocation(),
+						new MeasurementWindowProcessFunction())
+				.name("WindowedAggregationPerLocation")
+				.uid("WindowedAggregationPerLocation");
+
+		DataStream<WindowedMeasurementsForArea> aggregatedPerArea = aggregatedPerLocation
+				.keyBy(m -> WindowedMeasurementsForArea.getArea(m.getLocation()))
+				.timeWindow(Time.of(1, TimeUnit.SECONDS))
+				.aggregate(new MeasurementWindowAggregatingPerArea());
+
+		if (isLocal(parameters)) {
+			aggregatedPerLocation.addSink(new DiscardingSink<>())
+					.name("OutputPerLocation")
+					.uid("OutputPerLocation")
+					.disableChaining();
+			aggregatedPerArea.print()
+					.name("OutputPerArea")
+					.uid("OutputPerArea")
+					.disableChaining();
+		} else {
+			aggregatedPerLocation.addSink(new DiscardingSink<>())
+					.name("OutputPerLocation")
+					.uid("OutputPerLocation")
+					.disableChaining();
+			aggregatedPerArea.addSink(new DiscardingSink<>())
+					.name("OutputPerArea")
+					.uid("OutputPerArea")
+					.disableChaining();
+		}
+
+		env.execute(ThroughputJobSolution1.class.getSimpleName());
+	}
+
+	/**
+	 * Deserializes the JSON Kafka message.
+	 */
+	public static class MeasurementDeserializer extends
+			RichFlatMapFunction<FakeKafkaRecord, JsonNode> {
+		private static final long serialVersionUID = 2L;
+
+		private Counter numInvalidRecords;
+		private transient ObjectMapper instance;
+
+		@Override
+		public void open(final Configuration parameters) throws Exception {
+			super.open(parameters);
+			numInvalidRecords = getRuntimeContext().getMetricGroup().counter("numInvalidRecords");
+			instance = createObjectMapper();
+		}
+
+		@Override
+		public void flatMap(final FakeKafkaRecord kafkaRecord, final Collector<JsonNode> out) {
+			final JsonNode node;
+			try {
+				node = deserialize(kafkaRecord.getValue());
+			} catch (IOException e) {
+				numInvalidRecords.inc();
+				return;
+			}
+			out.collect(node);
+		}
+
+		private JsonNode deserialize(final byte[] bytes) throws IOException {
+			return instance.readValue(bytes, JsonNode.class);
+		}
+	}
+
+	public static class MeasurementWindowProcessFunction
+			extends
+			ProcessWindowFunction<WindowedMeasurements, WindowedMeasurements, String, TimeWindow> {
+		private static final long serialVersionUID = 1L;
+
+		private static final int EVENT_TIME_LAG_WINDOW_SIZE = 10_000;
+
+		private transient DescriptiveStatisticsHistogram eventTimeLag;
+
+		@Override
+		public void process(
+				final String location,
+				final Context context,
+				final Iterable<WindowedMeasurements> input,
+				final Collector<WindowedMeasurements> out) {
+
+			// Windows with pre-aggregation only forward the final aggregate to the WindowFunction
+			WindowedMeasurements aggregate = input.iterator().next();
+
+			final TimeWindow window = context.window();
+			aggregate.setWindow(window);
+			aggregate.setLocation(location);
+
+			eventTimeLag.update(System.currentTimeMillis() - window.getEnd());
+			out.collect(aggregate);
+		}
+
+		@Override
+		public void open(Configuration parameters) throws Exception {
+			super.open(parameters);
+
+			eventTimeLag = getRuntimeContext().getMetricGroup().histogram("eventTimeLag",
+					new DescriptiveStatisticsHistogram(EVENT_TIME_LAG_WINDOW_SIZE));
+		}
+	}
+
+	public static class MeasurementWindowAggregatingPerLocation
+			implements
+			AggregateFunction<JsonNode, WindowedMeasurements, WindowedMeasurements> {
+
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public WindowedMeasurements add(
+				final JsonNode record,
+				final WindowedMeasurements aggregate) {
+			double result = Double.parseDouble(record.get("value").asText());
+			aggregate.addMeasurement(result);
+			return aggregate;
+		}
+
+		@Override
+		public WindowedMeasurements createAccumulator() {
+			return new WindowedMeasurements();
+		}
+
+		@Override
+		public WindowedMeasurements getResult(final WindowedMeasurements windowedMeasurements) {
+			return windowedMeasurements;
+		}
+
+		@Override
+		public WindowedMeasurements merge(
+				final WindowedMeasurements agg1,
+				final WindowedMeasurements agg2) {
+			agg2.setEventsPerWindow(agg1.getEventsPerWindow() + agg2.getEventsPerWindow());
+			agg2.setSumPerWindow(agg1.getSumPerWindow() + agg2.getSumPerWindow());
+			return agg2;
+		}
+	}
+
+	public static class MeasurementWindowAggregatingPerArea
+			implements
+			AggregateFunction<WindowedMeasurements, WindowedMeasurementsForArea, WindowedMeasurementsForArea> {
+
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public WindowedMeasurementsForArea add(
+				final WindowedMeasurements value,
+				final WindowedMeasurementsForArea aggregate) {
+			aggregate.addMeasurement(value);
+			return aggregate;
+		}
+
+		@Override
+		public WindowedMeasurementsForArea getResult(WindowedMeasurementsForArea windowedMeasurements) {
+			String aLocation = windowedMeasurements.getLocations().get(0);
+			windowedMeasurements.setArea(WindowedMeasurementsForArea.getArea(aLocation));
+			return windowedMeasurements;
+		}
+
+		@Override
+		public WindowedMeasurementsForArea createAccumulator() {
+			return new WindowedMeasurementsForArea();
+		}
+
+		@Override
+		public WindowedMeasurementsForArea merge(
+				final WindowedMeasurementsForArea agg1,
+				final WindowedMeasurementsForArea agg2) {
+			agg2.setEventsPerWindow(agg1.getEventsPerWindow() + agg2.getEventsPerWindow());
+			agg2.setSumPerWindow(agg1.getSumPerWindow() + agg2.getSumPerWindow());
+			agg2.addAllLocations(agg1.getLocations());
+			return agg2;
+		}
+	}
+
+	private static ObjectMapper createObjectMapper() {
+		ObjectMapper objectMapper = new ObjectMapper();
+		objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+		return objectMapper;
+	}
+}

--- a/troubleshooting/throughput/src/solution/java/com/ververica/flink/training/solutions/ThroughputJobSolution1.java
+++ b/troubleshooting/throughput/src/solution/java/com/ververica/flink/training/solutions/ThroughputJobSolution1.java
@@ -7,11 +7,11 @@ import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
+import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 import org.apache.flink.util.Collector;
@@ -26,7 +26,6 @@ import com.ververica.flink.training.exercises.WindowedMeasurementsForArea;
 
 import java.io.IOException;
 import java.time.Duration;
-import java.util.concurrent.TimeUnit;
 
 import static com.ververica.flink.training.common.EnvironmentUtils.createConfiguredEnvironment;
 import static com.ververica.flink.training.common.EnvironmentUtils.isLocal;
@@ -46,8 +45,7 @@ public class ThroughputJobSolution1 {
 
 		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
 
-		//Time Characteristics
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		//Timing Configuration
 		env.getConfig().setAutoWatermarkInterval(100);
 		env.setBufferTimeout(10);
 
@@ -73,7 +71,7 @@ public class ThroughputJobSolution1 {
 
 		DataStream<WindowedMeasurements> aggregatedPerLocation = sourceStream
 				.keyBy(jsonNode -> jsonNode.get("location").asText())
-				.timeWindow(Time.of(1, TimeUnit.SECONDS))
+				.window(TumblingEventTimeWindows.of(Time.seconds(1)))
 				.aggregate(new MeasurementWindowAggregatingPerLocation(),
 						new MeasurementWindowProcessFunction())
 				.name("WindowedAggregationPerLocation")
@@ -81,7 +79,7 @@ public class ThroughputJobSolution1 {
 
 		DataStream<WindowedMeasurementsForArea> aggregatedPerArea = aggregatedPerLocation
 				.keyBy(m -> WindowedMeasurementsForArea.getArea(m.getLocation()))
-				.timeWindow(Time.of(1, TimeUnit.SECONDS))
+				.window(TumblingEventTimeWindows.of(Time.seconds(1)))
 				.aggregate(new MeasurementWindowAggregatingPerArea());
 
 		if (isLocal(parameters)) {

--- a/troubleshooting/throughput/src/solution/java/com/ververica/flink/training/solutions/ThroughputJobSolution2.java
+++ b/troubleshooting/throughput/src/solution/java/com/ververica/flink/training/solutions/ThroughputJobSolution2.java
@@ -1,0 +1,258 @@
+package com.ververica.flink.training.solutions;
+
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.api.common.functions.RichFlatMapFunction;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
+import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
+import org.apache.flink.streaming.api.windowing.time.Time;
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
+import org.apache.flink.util.Collector;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ververica.flink.training.common.FakeKafkaRecord;
+import com.ververica.flink.training.common.Measurement;
+import com.ververica.flink.training.common.SourceUtils;
+import com.ververica.flink.training.common.WindowedMeasurements;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import static com.ververica.flink.training.common.EnvironmentUtils.createConfiguredEnvironment;
+import static com.ververica.flink.training.common.EnvironmentUtils.isLocal;
+
+/**
+ * Streaming job evolved on top of {@link ThroughputJobSolution1} by optimising serialization.
+ */
+public class ThroughputJobSolution2 {
+
+    /**
+     * Creates and starts the troubled streaming job.
+	 *
+	 * @throws Exception if the application is misconfigured or fails during job submission
+     */
+	public static void main(String[] args) throws Exception {
+		ParameterTool parameters = ParameterTool.fromArgs(args);
+
+		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
+
+		//Time Characteristics
+		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		env.getConfig().setAutoWatermarkInterval(100);
+		env.setBufferTimeout(10);
+
+		//Checkpointing Configuration
+		env.enableCheckpointing(5000);
+		env.getCheckpointConfig().setMinPauseBetweenCheckpoints(4000);
+
+		env.getConfig().disableGenericTypes();
+
+		DataStream<Measurement> sourceStream = env
+				.addSource(SourceUtils.createFakeKafkaSource())
+				.name("FakeKafkaSource")
+				.uid("FakeKafkaSource")
+				.assignTimestampsAndWatermarks(
+						WatermarkStrategy
+								.<FakeKafkaRecord>forBoundedOutOfOrderness(Duration.ofMillis(250))
+								.withTimestampAssigner(
+										(element, timestamp) -> element.getTimestamp())
+								.withIdleness(Duration.ofSeconds(1)))
+				.name("Watermarks")
+				.uid("Watermarks")
+				.flatMap(new MeasurementDeserializer())
+				.name("Deserialization")
+				.uid("Deserialization");
+
+		DataStream<WindowedMeasurements> aggregatedPerLocation = sourceStream
+				.keyBy(Measurement::getLocation)
+				.timeWindow(Time.of(1, TimeUnit.SECONDS))
+				.aggregate(new MeasurementWindowAggregatingPerLocation(),
+						new MeasurementWindowProcessFunction())
+				.name("WindowedAggregationPerLocation")
+				.uid("WindowedAggregationPerLocation");
+
+		DataStream<WindowedMeasurementsForArea2> aggregatedPerArea = aggregatedPerLocation
+				.keyBy(m -> WindowedMeasurementsForArea2.getArea(m.getLocation()))
+				.timeWindow(Time.of(1, TimeUnit.SECONDS))
+				.aggregate(new MeasurementWindowAggregatingPerArea());
+
+		if (isLocal(parameters)) {
+			aggregatedPerLocation.addSink(new DiscardingSink<>())
+					.name("OutputPerLocation")
+					.uid("OutputPerLocation")
+					.disableChaining();
+			aggregatedPerArea.print()
+					.name("OutputPerArea")
+					.uid("OutputPerArea")
+					.disableChaining();
+		} else {
+			aggregatedPerLocation.addSink(new DiscardingSink<>())
+					.name("OutputPerLocation")
+					.uid("OutputPerLocation")
+					.disableChaining();
+			aggregatedPerArea.addSink(new DiscardingSink<>())
+					.name("OutputPerArea")
+					.uid("OutputPerArea")
+					.disableChaining();
+		}
+
+		env.execute(ThroughputJobSolution2.class.getSimpleName());
+	}
+
+	/**
+	 * Deserializes the JSON Kafka message.
+	 */
+	public static class MeasurementDeserializer extends
+			RichFlatMapFunction<FakeKafkaRecord, Measurement> {
+		private static final long serialVersionUID = 2L;
+
+		private Counter numInvalidRecords;
+		private transient ObjectMapper instance;
+
+		@Override
+		public void open(final Configuration parameters) throws Exception {
+			super.open(parameters);
+			numInvalidRecords = getRuntimeContext().getMetricGroup().counter("numInvalidRecords");
+			instance = createObjectMapper();
+		}
+
+		@Override
+		public void flatMap(final FakeKafkaRecord kafkaRecord, final Collector<Measurement> out) {
+			final Measurement node;
+			try {
+				node = deserialize(kafkaRecord.getValue());
+			} catch (IOException e) {
+				numInvalidRecords.inc();
+				return;
+			}
+			out.collect(node);
+		}
+
+		private Measurement deserialize(final byte[] bytes) throws IOException {
+			return instance.readValue(bytes, Measurement.class);
+		}
+	}
+
+	public static class MeasurementWindowProcessFunction
+			extends
+			ProcessWindowFunction<WindowedMeasurements, WindowedMeasurements, String, TimeWindow> {
+		private static final long serialVersionUID = 1L;
+
+		private static final int EVENT_TIME_LAG_WINDOW_SIZE = 10_000;
+
+		private transient DescriptiveStatisticsHistogram eventTimeLag;
+
+		@Override
+		public void process(
+				final String location,
+				final Context context,
+				final Iterable<WindowedMeasurements> input,
+				final Collector<WindowedMeasurements> out) {
+
+			// Windows with pre-aggregation only forward the final aggregate to the WindowFunction
+			WindowedMeasurements aggregate = input.iterator().next();
+
+			final TimeWindow window = context.window();
+			aggregate.setWindow(window);
+			aggregate.setLocation(location);
+
+			eventTimeLag.update(System.currentTimeMillis() - window.getEnd());
+			out.collect(aggregate);
+		}
+
+		@Override
+		public void open(Configuration parameters) throws Exception {
+			super.open(parameters);
+
+			eventTimeLag = getRuntimeContext().getMetricGroup().histogram("eventTimeLag",
+					new DescriptiveStatisticsHistogram(EVENT_TIME_LAG_WINDOW_SIZE));
+		}
+	}
+
+	public static class MeasurementWindowAggregatingPerLocation
+			implements
+			AggregateFunction<Measurement, WindowedMeasurements, WindowedMeasurements> {
+
+		private static final long serialVersionUID = 2L;
+
+		@Override
+		public WindowedMeasurements add(
+				final Measurement record,
+				final WindowedMeasurements aggregate) {
+			aggregate.addMeasurement(record);
+			return aggregate;
+		}
+
+		@Override
+		public WindowedMeasurements createAccumulator() {
+			return new WindowedMeasurements();
+		}
+
+		@Override
+		public WindowedMeasurements getResult(final WindowedMeasurements windowedMeasurements) {
+			return windowedMeasurements;
+		}
+
+		@Override
+		public WindowedMeasurements merge(
+				final WindowedMeasurements agg1,
+				final WindowedMeasurements agg2) {
+			agg2.setEventsPerWindow(agg1.getEventsPerWindow() + agg2.getEventsPerWindow());
+			agg2.setSumPerWindow(agg1.getSumPerWindow() + agg2.getSumPerWindow());
+			return agg2;
+		}
+	}
+
+	public static class MeasurementWindowAggregatingPerArea
+			implements
+			AggregateFunction<WindowedMeasurements, WindowedMeasurementsForArea2, WindowedMeasurementsForArea2> {
+
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public WindowedMeasurementsForArea2 add(
+				final WindowedMeasurements value,
+				final WindowedMeasurementsForArea2 aggregate) {
+			aggregate.addMeasurement(value);
+			return aggregate;
+		}
+
+		@Override
+		public WindowedMeasurementsForArea2 getResult(
+				WindowedMeasurementsForArea2 windowedMeasurements) {
+			String aLocation = windowedMeasurements.getLocations().get(0);
+			windowedMeasurements.setArea(WindowedMeasurementsForArea2.getArea(aLocation));
+			return windowedMeasurements;
+		}
+
+		@Override
+		public WindowedMeasurementsForArea2 createAccumulator() {
+			return new WindowedMeasurementsForArea2();
+		}
+
+		@Override
+		public WindowedMeasurementsForArea2 merge(
+				final WindowedMeasurementsForArea2 agg1,
+				final WindowedMeasurementsForArea2 agg2) {
+			agg2.setEventsPerWindow(agg1.getEventsPerWindow() + agg2.getEventsPerWindow());
+			agg2.setSumPerWindow(agg1.getSumPerWindow() + agg2.getSumPerWindow());
+			agg2.addAllLocations(agg1.getLocations());
+			return agg2;
+		}
+	}
+
+	private static ObjectMapper createObjectMapper() {
+		ObjectMapper objectMapper = new ObjectMapper();
+		objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+		return objectMapper;
+	}
+}

--- a/troubleshooting/throughput/src/solution/java/com/ververica/flink/training/solutions/WindowedMeasurementsForArea2.java
+++ b/troubleshooting/throughput/src/solution/java/com/ververica/flink/training/solutions/WindowedMeasurementsForArea2.java
@@ -1,0 +1,167 @@
+package com.ververica.flink.training.solutions;
+
+import org.apache.flink.api.common.typeinfo.TypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+
+import com.ververica.flink.training.common.WindowedMeasurements;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+@SuppressWarnings({"unused"})
+@TypeInfo(WindowedMeasurementsForArea2.TypeInfoFactory.class)
+public class WindowedMeasurementsForArea2 {
+
+	private long windowStart;
+	private long windowEnd;
+	private String area;
+	private final List<String> locations = new ArrayList<>();
+	private long eventsPerWindow;
+	private double sumPerWindow;
+
+	public WindowedMeasurementsForArea2() {
+	}
+
+	public WindowedMeasurementsForArea2(
+			final long windowStart,
+			final long windowEnd,
+			final String area,
+			final String location,
+			final long eventsPerWindow,
+			final double sumPerWindow) {
+		this.windowStart = windowStart;
+		this.windowEnd = windowEnd;
+		this.area = area;
+		this.locations.add(location);
+		this.eventsPerWindow = eventsPerWindow;
+		this.sumPerWindow = sumPerWindow;
+	}
+
+	public long getWindowStart() {
+		return windowStart;
+	}
+
+	public void setWindowStart(final long windowStart) {
+		this.windowStart = windowStart;
+	}
+
+	public long getWindowEnd() {
+		return windowEnd;
+	}
+
+	public void setWindowEnd(final long windowEnd) {
+		this.windowEnd = windowEnd;
+	}
+
+	public String getArea() {
+		return area;
+	}
+
+	public void setArea(String area) {
+		this.area = area;
+	}
+
+	public List<String> getLocations() {
+		return locations;
+	}
+
+	public void setLocations(List<String> locations) {
+		this.locations.clear();
+		this.locations.addAll(locations);
+	}
+
+	public void addLocation(final String location) {
+		this.locations.add(location);
+	}
+
+	public void addAllLocations(final Collection<? extends String> locations) {
+		this.locations.addAll(locations);
+	}
+
+	public static String getArea(String location) {
+		if (location.length() > 0) {
+			return location.substring(0, 1);
+		} else {
+			return "";
+		}
+	}
+
+	public long getEventsPerWindow() {
+		return eventsPerWindow;
+	}
+
+	public void setEventsPerWindow(final long eventsPerWindow) {
+		this.eventsPerWindow = eventsPerWindow;
+	}
+
+	public double getSumPerWindow() {
+		return sumPerWindow;
+	}
+
+	public void setSumPerWindow(final double sumPerWindow) {
+		this.sumPerWindow = sumPerWindow;
+	}
+
+	public void addMeasurement(WindowedMeasurements measurements) {
+		sumPerWindow += measurements.getSumPerWindow();
+		eventsPerWindow += measurements.getEventsPerWindow();
+		locations.add(measurements.getLocation());
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		WindowedMeasurementsForArea2 that = (WindowedMeasurementsForArea2) o;
+		return windowStart == that.windowStart &&
+				windowEnd == that.windowEnd &&
+				eventsPerWindow == that.eventsPerWindow &&
+				Double.compare(that.sumPerWindow, sumPerWindow) == 0 &&
+				Objects.equals(area, that.area) &&
+				locations.equals(that.locations);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(windowStart, windowEnd, area, locations, eventsPerWindow, sumPerWindow);
+	}
+
+	@Override
+	public String toString() {
+		return "WindowedMeasurementsForArea{" +
+				"windowStart=" + windowStart +
+				", windowEnd=" + windowEnd +
+				", area='" + area + '\'' +
+				", locations=" + locations +
+				", eventsPerWindow=" + eventsPerWindow +
+				", sumPerWindow=" + sumPerWindow +
+				'}';
+	}
+
+	public static class TypeInfoFactory extends org.apache.flink.api.common.typeinfo.TypeInfoFactory<WindowedMeasurementsForArea2> {
+		@Override
+		public TypeInformation<WindowedMeasurementsForArea2> createTypeInfo(
+				Type t,
+				Map<String, TypeInformation<?>> genericParameters) {
+			Map<String, TypeInformation<?>> fields = new HashMap<String, TypeInformation<?>>() {{
+				put("windowStart", Types.LONG);
+				put("windowEnd", Types.LONG);
+				put("area", Types.STRING);
+				put("locations", Types.LIST(Types.STRING));
+				put("eventsPerWindow", Types.LONG);
+				put("sumPerWindow", Types.DOUBLE);
+			}};
+			return Types.POJO(WindowedMeasurementsForArea2.class, fields);
+		}
+	}
+}


### PR DESCRIPTION
Similar to the update from apache/flink-training, but also fixed the deprecation for the MemoryStateBackend affecting the state processor API exercise/example.