### PR TITLE
[FLINK-23335] add separate run tasks for Java/Scala exercises and solutions

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,24 @@ Each of these exercises includes an `...Exercise` class with most of the necessa
 
 > **:information_source: Note:** As long as your `...Exercise` class is throwing a `MissingSolutionException`, the provided JUnit test classes will ignore that failure and verify the correctness of the solution implementation instead.
 
-There are Java and Scala versions of all the exercise, test, and solution classes.
+There are Java and Scala versions of all the exercise, test, and solution classes, each of which can be run from IntelliJ as usual.
+
+#### Running Exercises, Tests, and Solutions on the Command Line
+
+You can execute exercises, solutions, and tests via `gradlew` from a CLI.
+
+- Tests can be executed as usual:
+
+    ```bash
+    ./gradlew test
+    ./gradlew :<subproject>:test
+    ```
+
+- For Java/Scala exercises and solutions, we provide special tasks that are listed via
+
+    ```bash
+    ./gradlew printRunTasks
+    ```
 
 -----
 

--- a/build.gradle
+++ b/build.gradle
@@ -94,6 +94,18 @@ subprojects {
         test.runtimeClasspath += configurations.shadow
     }
 
+    project.plugins.withId('application') {
+        ['javaExerciseClassName', 'scalaExerciseClassName',
+         'javaSolutionClassName', 'scalaSolutionClassName'].each { property ->
+            if (project.ext.has(property)) {
+                project.tasks.create(name: classNamePropertyToTaskName(property), type: JavaExec) {
+                    classpath = project.sourceSets.main.runtimeClasspath
+                    mainClass = project.ext.get(property)
+                    group = 'flink-training'
+                }
+            }
+        }
+    }
 
     jar {
         manifest {
@@ -118,4 +130,31 @@ subprojects {
     }
 
     assemble.dependsOn(shadowJar)
+}
+
+tasks.register('printRunTasks') {
+    println '------------------------------------------------------------'
+    println 'Flink Training Tasks runnable from root project \'' + project.name + '\''
+    println '------------------------------------------------------------'
+
+    subprojects.findAll { project ->
+        boolean first = true;
+        project.tasks.withType(JavaExec) { task ->
+            if (task.group == 'flink-training') {
+                if (first) {
+                    println ''
+                    println '> Subproject \'' + project.name + '\''
+                    first = false;
+                }
+                println './gradlew :' + project.name + ':' + task.name
+            }
+        }
+    }
+}
+
+static def classNamePropertyToTaskName(String property) {
+    return 'run' +
+            property.charAt(0).toString().toUpperCase() +
+            property.substring(1, property.lastIndexOf('ClassName'))
+
 }

--- a/hourly-tips/build.gradle
+++ b/hourly-tips/build.gradle
@@ -1,3 +1,8 @@
+ext.javaExerciseClassName = 'org.apache.flink.training.exercises.hourlytips.HourlyTipsExercise'
+ext.scalaExerciseClassName = 'org.apache.flink.training.exercises.hourlytips.scala.HourlyTipsExercise'
+ext.javaSolutionClassName = 'org.apache.flink.training.solutions.hourlytips.HourlyTipsSolution'
+ext.scalaSolutionClassName = 'org.apache.flink.training.solutions.hourlytips.scala.HourlyTipsSolution'
+
 apply plugin: 'application'
 
-mainClassName = 'org.apache.flink.training.exercises.hourlytips.HourlyTipsExercise'
+mainClassName = ext.javaExerciseClassName

--- a/long-ride-alerts/build.gradle
+++ b/long-ride-alerts/build.gradle
@@ -1,3 +1,8 @@
+ext.javaExerciseClassName = 'org.apache.flink.training.exercises.longrides.LongRidesExercise'
+ext.scalaExerciseClassName = 'org.apache.flink.training.exercises.longrides.scala.LongRidesExercise'
+ext.javaSolutionClassName = 'org.apache.flink.training.solutions.longrides.LongRidesSolution'
+ext.scalaSolutionClassName = 'org.apache.flink.training.solutions.longrides.scala.LongRidesSolution'
+
 apply plugin: 'application'
 
-mainClassName = 'org.apache.flink.training.exercises.longrides.LongRidesExercise'
+mainClassName = ext.javaExerciseClassName

--- a/ride-cleansing/build.gradle
+++ b/ride-cleansing/build.gradle
@@ -1,3 +1,8 @@
+ext.javaExerciseClassName = 'org.apache.flink.training.exercises.ridecleansing.RideCleansingExercise'
+ext.scalaExerciseClassName = 'org.apache.flink.training.exercises.ridecleansing.scala.RideCleansingExercise'
+ext.javaSolutionClassName = 'org.apache.flink.training.solutions.ridecleansing.RideCleansingSolution'
+ext.scalaSolutionClassName = 'org.apache.flink.training.solutions.ridecleansing.scala.RideCleansingSolution'
+
 apply plugin: 'application'
 
-mainClassName = 'org.apache.flink.training.exercises.ridecleansing.RideCleansingExercise'
+mainClassName = ext.javaExerciseClassName

--- a/rides-and-fares/build.gradle
+++ b/rides-and-fares/build.gradle
@@ -1,3 +1,8 @@
+ext.javaExerciseClassName = 'org.apache.flink.training.exercises.ridesandfares.RidesAndFaresExercise'
+ext.scalaExerciseClassName = 'org.apache.flink.training.exercises.ridesandfares.scala.RidesAndFaresExercise'
+ext.javaSolutionClassName = 'org.apache.flink.training.solutions.ridesandfares.RidesAndFaresSolution'
+ext.scalaSolutionClassName = 'org.apache.flink.training.solutions.ridesandfares.scala.RidesAndFaresSolution'
+
 apply plugin: 'application'
 
-mainClassName = 'org.apache.flink.training.exercises.ridesandfares.RidesAndFaresExercise'
+mainClassName = ext.javaExerciseClassName


### PR DESCRIPTION
This allows to quickly run the current state of the exercise or the solution implementation from the command line / IDE.