### PR TITLE
[FLINK-23669] avoid using Scala >= 2.12.8 when setting up an IDE

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,9 @@ The project needs to be imported as a gradle project into your IDE.
 
 Then you should be able to open [`RideCleansingTest`](ride-cleansing/src/test/java/org/apache/flink/training/exercises/ridecleansing/RideCleansingTest.java) and run this test.
 
-> **:information_source: Note for Scala users:** You will need to use IntelliJ with the JetBrains Scala plugin, and you will need to add a Scala 2.12 SDK to the Global Libraries section of the Project Structure.
+> **:information_source: Note for Scala users:** You will need to use IntelliJ with the JetBrains Scala plugin, and you will need to add a Scala 2.12 SDK to the Global Libraries section of the Project Structure as well as to the module you are working on.
 > IntelliJ will ask you for the latter when you open a Scala file.
+> Please note that Scala 2.12.8 and above are not supported (see [Flink Scala Versions](https://ci.apache.org/projects/flink/flink-docs-stable/docs/dev/datastream/project-configuration/#scala-versions for details))!
 
 ## Use the taxi data streams
 


### PR DESCRIPTION
See https://ci.apache.org/projects/flink/flink-docs-stable/docs/dev/datastream/project-configuration/#scala-versions