### PR TITLE
[FLINK-24022] Change how to enable Scala and use in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jdk:
   - openjdk11
 
 script:
-  - ./gradlew build --scan --stacktrace
+  - ./gradlew build --scan --stacktrace -Porg.gradle.project.enable_scala=true
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/README.md
+++ b/README.md
@@ -111,14 +111,14 @@ If you are in China, we recommend configuring the Maven repository to use a mirr
 
 The exercises in this project are also available in Scala but due to a couple
 of reported problems from non-Scala users, we decided to disable these by
-default. You can re-enable all Scala exercises and solutions by uncommenting
-this section in our [`build.gradle`](build.gradle) file:
+default. You can re-enable all Scala exercises and solutions adapting the
+[`gradle.properties`](gradle.properties) file like this:
 
-```groovy
-subprojects {
-    //...
-    apply plugin: 'scala' // optional; uncomment if needed
-}
+```properties
+#...
+
+# Scala exercises can be enabled by setting this to true
+org.gradle.project.enable_scala = true
 ```
 
 You can also selectively apply this plugin in a single subproject if desired.

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,9 @@ allprojects {
 
 subprojects {
     apply plugin: 'java'
-    // apply plugin: 'scala' // optional; uncomment if needed
+    if (project.properties['org.gradle.project.enable_scala'] == 'true') {
+        apply plugin: 'scala'
+    }
     apply plugin: 'com.github.johnrengelman.shadow'
     apply plugin: 'checkstyle'
     apply plugin: 'eclipse'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,5 @@
 org.gradle.caching = true
 org.gradle.parallel = true
+
+# Scala exercises can be enabled by setting this to true
+org.gradle.project.enable_scala = false


### PR DESCRIPTION
This allows CI to enable checks on the Scala exercises and solutions.

It contains the following changes:
- users can now enable the Scala code by changing the `gradle.properties` file and setting `org.gradle.project.enable_scala = true` (`org.gradle.project.enable_scala = false` remains the default)
- CI overrides this property to include Scala checks