### PR TITLE
[FLINK-23926] one timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,9 +153,7 @@ rideId         : Long      // a unique id for each ride
 taxiId         : Long      // a unique id for each taxi
 driverId       : Long      // a unique id for each driver
 isStart        : Boolean   // TRUE for ride start events, FALSE for ride end events
-startTime      : Instant   // the start time of a ride
-endTime        : Instant   // the end time of a ride,
-                           //   "1970-01-01 00:00:00" for start events
+eventTime      : Instant   // the timestamp for this event
 startLon       : Float     // the longitude of the ride start location
 startLat       : Float     // the latitude of the ride start location
 endLon         : Float     // the longitude of the ride end location
@@ -171,7 +169,7 @@ There is also a related data set containing fare data about those same rides, wi
 rideId         : Long      // a unique id for each ride
 taxiId         : Long      // a unique id for each taxi
 driverId       : Long      // a unique id for each driver
-startTime      : Instant   // the start time of a ride
+startTime      : Instant   // the start time for this ride
 paymentType    : String    // CASH or CARD
 tip            : Float     // tip for this ride
 tolls          : Float     // tolls for this ride

--- a/common/src/main/java/org/apache/flink/training/exercises/common/datatypes/TaxiFare.java
+++ b/common/src/main/java/org/apache/flink/training/exercises/common/datatypes/TaxiFare.java
@@ -130,13 +130,13 @@ public class TaxiFare implements Serializable {
     }
 
     /** Gets the fare's start time. */
-    public long getEventTime() {
+    public long getEventTimeMillis() {
         return startTime.toEpochMilli();
     }
 
     /** Creates a StreamRecord, using the fare and its timestamp. Used in tests. */
     @VisibleForTesting
     public StreamRecord<TaxiFare> asStreamRecord() {
-        return new StreamRecord<>(this, this.getEventTime());
+        return new StreamRecord<>(this, this.getEventTimeMillis());
     }
 }

--- a/common/src/main/java/org/apache/flink/training/exercises/common/datatypes/TaxiRide.java
+++ b/common/src/main/java/org/apache/flink/training/exercises/common/datatypes/TaxiRide.java
@@ -42,8 +42,7 @@ public class TaxiRide implements Comparable<TaxiRide>, Serializable {
 
     /** Creates a new TaxiRide with now as start and end time. */
     public TaxiRide() {
-        this.startTime = Instant.now();
-        this.endTime = Instant.now();
+        this.eventTime = Instant.now();
     }
 
     /** Invents a TaxiRide. */
@@ -52,8 +51,7 @@ public class TaxiRide implements Comparable<TaxiRide>, Serializable {
 
         this.rideId = rideId;
         this.isStart = isStart;
-        this.startTime = g.startTime();
-        this.endTime = isStart ? Instant.ofEpochMilli(0) : g.endTime();
+        this.eventTime = isStart ? g.startTime() : g.endTime();
         this.startLon = g.startLon();
         this.startLat = g.startLat();
         this.endLon = g.endLon();
@@ -67,8 +65,7 @@ public class TaxiRide implements Comparable<TaxiRide>, Serializable {
     public TaxiRide(
             long rideId,
             boolean isStart,
-            Instant startTime,
-            Instant endTime,
+            Instant eventTime,
             float startLon,
             float startLat,
             float endLon,
@@ -78,8 +75,7 @@ public class TaxiRide implements Comparable<TaxiRide>, Serializable {
             long driverId) {
         this.rideId = rideId;
         this.isStart = isStart;
-        this.startTime = startTime;
-        this.endTime = endTime;
+        this.eventTime = eventTime;
         this.startLon = startLon;
         this.startLat = startLat;
         this.endLon = endLon;
@@ -91,8 +87,7 @@ public class TaxiRide implements Comparable<TaxiRide>, Serializable {
 
     public long rideId;
     public boolean isStart;
-    public Instant startTime;
-    public Instant endTime;
+    public Instant eventTime;
     public float startLon;
     public float startLat;
     public float endLon;
@@ -108,9 +103,7 @@ public class TaxiRide implements Comparable<TaxiRide>, Serializable {
                 + ","
                 + (isStart ? "START" : "END")
                 + ","
-                + startTime.toString()
-                + ","
-                + endTime.toString()
+                + eventTime.toString()
                 + ","
                 + startLon
                 + ","
@@ -139,7 +132,7 @@ public class TaxiRide implements Comparable<TaxiRide>, Serializable {
         if (other == null) {
             return 1;
         }
-        int compareTimes = Long.compare(this.getEventTime(), other.getEventTime());
+        int compareTimes = this.eventTime.compareTo(other.eventTime);
         if (compareTimes == 0) {
             if (this.isStart == other.isStart) {
                 return 0;
@@ -173,8 +166,7 @@ public class TaxiRide implements Comparable<TaxiRide>, Serializable {
                 && passengerCnt == taxiRide.passengerCnt
                 && taxiId == taxiRide.taxiId
                 && driverId == taxiRide.driverId
-                && Objects.equals(startTime, taxiRide.startTime)
-                && Objects.equals(endTime, taxiRide.endTime);
+                && Objects.equals(eventTime, taxiRide.eventTime);
     }
 
     @Override
@@ -182,8 +174,7 @@ public class TaxiRide implements Comparable<TaxiRide>, Serializable {
         return Objects.hash(
                 rideId,
                 isStart,
-                startTime,
-                endTime,
+                eventTime,
                 startLon,
                 startLat,
                 endLon,
@@ -193,13 +184,9 @@ public class TaxiRide implements Comparable<TaxiRide>, Serializable {
                 driverId);
     }
 
-    /** Gets the ride's time stamp (start or end time depending on {@link #isStart}). */
-    public long getEventTime() {
-        if (isStart) {
-            return startTime.toEpochMilli();
-        } else {
-            return endTime.toEpochMilli();
-        }
+    /** Gets the ride's time stamp as a long in millis since the epoch. */
+    public long getEventTimeMillis() {
+        return eventTime.toEpochMilli();
     }
 
     /** Gets the distance from the ride location to the given one. */
@@ -216,12 +203,12 @@ public class TaxiRide implements Comparable<TaxiRide>, Serializable {
     /** Creates a StreamRecord, using the ride and its timestamp. Used in tests. */
     @VisibleForTesting
     public StreamRecord<TaxiRide> asStreamRecord() {
-        return new StreamRecord<>(this, this.getEventTime());
+        return new StreamRecord<>(this, this.getEventTimeMillis());
     }
 
     /** Creates a StreamRecord from this taxi ride, using its id and timestamp. Used in tests. */
     @VisibleForTesting
     public StreamRecord<Long> idAsStreamRecord() {
-        return new StreamRecord<>(this.rideId, this.getEventTime());
+        return new StreamRecord<>(this.rideId, this.getEventTimeMillis());
     }
 }

--- a/common/src/main/java/org/apache/flink/training/exercises/common/sources/TaxiRideGenerator.java
+++ b/common/src/main/java/org/apache/flink/training/exercises/common/sources/TaxiRideGenerator.java
@@ -69,9 +69,7 @@ public class TaxiRideGenerator implements SourceFunction<TaxiRide> {
 
             // then emit the new START events (out-of-order)
             java.util.Collections.shuffle(startEvents, new Random(id));
-            startEvents
-                    .iterator()
-                    .forEachRemaining(r -> ctx.collectWithTimestamp(r, r.getEventTimeMillis()));
+            startEvents.iterator().forEachRemaining(r -> ctx.collect(r));
 
             // prepare for the next batch
             id += BATCH_SIZE;

--- a/common/src/main/java/org/apache/flink/training/exercises/common/sources/TaxiRideGenerator.java
+++ b/common/src/main/java/org/apache/flink/training/exercises/common/sources/TaxiRideGenerator.java
@@ -52,7 +52,7 @@ public class TaxiRideGenerator implements SourceFunction<TaxiRide> {
                 TaxiRide ride = new TaxiRide(id + i, true);
                 startEvents.add(ride);
                 // the start times may be in order, but let's not assume that
-                maxStartTime = Math.max(maxStartTime, ride.startTime.toEpochMilli());
+                maxStartTime = Math.max(maxStartTime, ride.getEventTimeMillis());
             }
 
             // enqueue the corresponding END events
@@ -62,7 +62,7 @@ public class TaxiRideGenerator implements SourceFunction<TaxiRide> {
 
             // release the END events coming before the end of this new batch
             // (this allows a few END events to precede their matching START event)
-            while (endEventQ.peek().getEventTime() <= maxStartTime) {
+            while (endEventQ.peek().getEventTimeMillis() <= maxStartTime) {
                 TaxiRide ride = endEventQ.poll();
                 ctx.collect(ride);
             }
@@ -71,7 +71,7 @@ public class TaxiRideGenerator implements SourceFunction<TaxiRide> {
             java.util.Collections.shuffle(startEvents, new Random(id));
             startEvents
                     .iterator()
-                    .forEachRemaining(r -> ctx.collectWithTimestamp(r, r.getEventTime()));
+                    .forEachRemaining(r -> ctx.collectWithTimestamp(r, r.getEventTimeMillis()));
 
             // prepare for the next batch
             id += BATCH_SIZE;

--- a/common/src/main/java/org/apache/flink/training/exercises/common/utils/DataGenerator.java
+++ b/common/src/main/java/org/apache/flink/training/exercises/common/utils/DataGenerator.java
@@ -25,8 +25,8 @@ import java.util.Random;
  * Data generator for the fields in TaxiRide and TaxiFare objects.
  *
  * <p>Results are deterministically determined by the rideId. This guarantees (among other things)
- * that the startTime for a TaxiRide START event matches the startTime for the TaxiRide END and
- * TaxiFare events for that same rideId.
+ * that the eventTime for a TaxiRide START event matches the startTime for the TaxiFare event for
+ * that same rideId.
  */
 public class DataGenerator {
 

--- a/hourly-tips/src/solution/java/org/apache/flink/training/solutions/hourlytips/HourlyTipsSolution.java
+++ b/hourly-tips/src/solution/java/org/apache/flink/training/solutions/hourlytips/HourlyTipsSolution.java
@@ -83,7 +83,8 @@ public class HourlyTipsSolution {
                         .assignTimestampsAndWatermarks(
                                 // taxi fares are in order
                                 WatermarkStrategy.<TaxiFare>forMonotonousTimestamps()
-                                        .withTimestampAssigner((fare, t) -> fare.getEventTime()));
+                                        .withTimestampAssigner(
+                                                (fare, t) -> fare.getEventTimeMillis()));
 
         // compute tips per hour for each driver
         DataStream<Tuple3<Long, Long, Float>> hourlyTips =

--- a/hourly-tips/src/solution/scala/org/apache/flink/training/solutions/hourlytips/scala/HourlyTipsSolution.scala
+++ b/hourly-tips/src/solution/scala/org/apache/flink/training/solutions/hourlytips/scala/HourlyTipsSolution.scala
@@ -58,7 +58,7 @@ object HourlyTipsSolution {
         .forMonotonousTimestamps[TaxiFare]()
         .withTimestampAssigner(new SerializableTimestampAssigner[TaxiFare] {
           override def extractTimestamp(fare: TaxiFare, streamRecordTimestamp: Long): Long =
-            fare.getEventTime
+            fare.getEventTimeMillis
         })
 
       // setup the pipeline

--- a/long-ride-alerts/README.md
+++ b/long-ride-alerts/README.md
@@ -27,7 +27,10 @@ This should be done using the event time timestamps and watermarks that are prov
 The stream is out-of-order, and it is possible that the END event for a ride will be processed before
 its START event.
 
-A START or END event may be missing, but you may assume there are no duplicated events.
+An END event may be missing, but you may assume there are no duplicated events, and no missing START events.
+
+It is not enough to simply wait for the END event and calculate the duration, as we want to be alerted
+about the long ride as soon as possible.
 
 You should eventually clear any state you create.
 
@@ -69,8 +72,6 @@ The resulting stream should be printed to standard out.
 This exercise revolves around using a `KeyedProcessFunction` to manage some state and event time timers,
 and doing so in a way that works even when the END event for a given `rideId` arrives before the START.
 The challenge is figuring out what state and timers to use, and when to set and clear the state (and timers).
-It is not enough to simply wait for the END event and calculate the duration, as the END event
-may be missing.
 </details>
 
 ## Documentation

--- a/long-ride-alerts/src/main/java/org/apache/flink/training/exercises/longrides/LongRidesExercise.java
+++ b/long-ride-alerts/src/main/java/org/apache/flink/training/exercises/longrides/LongRidesExercise.java
@@ -71,7 +71,7 @@ public class LongRidesExercise {
         WatermarkStrategy<TaxiRide> watermarkStrategy =
                 WatermarkStrategy.<TaxiRide>forBoundedOutOfOrderness(Duration.ofSeconds(60))
                         .withTimestampAssigner(
-                                (ride, streamRecordTimestamp) -> ride.getEventTime());
+                                (ride, streamRecordTimestamp) -> ride.getEventTimeMillis());
 
         // create the pipeline
         rides.assignTimestampsAndWatermarks(watermarkStrategy)

--- a/long-ride-alerts/src/main/scala/org/apache/flink/training/exercises/longrides/scala/LongRidesExercise.scala
+++ b/long-ride-alerts/src/main/scala/org/apache/flink/training/exercises/longrides/scala/LongRidesExercise.scala
@@ -56,7 +56,7 @@ object LongRidesExercise {
         .forBoundedOutOfOrderness[TaxiRide](Duration.ofSeconds(60))
         .withTimestampAssigner(new SerializableTimestampAssigner[TaxiRide] {
           override def extractTimestamp(ride: TaxiRide, streamRecordTimestamp: Long): Long =
-            ride.getEventTime
+            ride.getEventTimeMillis
         })
 
       // create the pipeline

--- a/long-ride-alerts/src/test/java/org/apache/flink/training/exercises/longrides/LongRidesTestBase.java
+++ b/long-ride-alerts/src/test/java/org/apache/flink/training/exercises/longrides/LongRidesTestBase.java
@@ -12,21 +12,19 @@ public class LongRidesTestBase {
     public static final Instant THREE_HOURS_LATER = BEGINNING.plusSeconds(180 * 60);
 
     public static TaxiRide startRide(long rideId, Instant startTime) {
-        return testRide(rideId, true, startTime, Instant.EPOCH);
+        return testRide(rideId, true, startTime);
     }
 
     public static TaxiRide endRide(TaxiRide started, Instant endTime) {
-        return testRide(started.rideId, false, started.startTime, endTime);
+        return testRide(started.rideId, false, endTime);
     }
 
-    private static TaxiRide testRide(
-            long rideId, Boolean isStart, Instant startTime, Instant endTime) {
+    private static TaxiRide testRide(long rideId, Boolean isStart, Instant eventTime) {
 
         return new TaxiRide(
                 rideId,
                 isStart,
-                startTime,
-                endTime,
+                eventTime,
                 -73.9947F,
                 40.750626F,
                 -73.9947F,

--- a/ride-cleansing/src/test/java/org/apache/flink/training/exercises/ridecleansing/RideCleansingTestBase.java
+++ b/ride-cleansing/src/test/java/org/apache/flink/training/exercises/ridecleansing/RideCleansingTestBase.java
@@ -8,16 +8,6 @@ public class RideCleansingTestBase {
 
     public static TaxiRide testRide(float startLon, float startLat, float endLon, float endLat) {
         return new TaxiRide(
-                1L,
-                true,
-                Instant.EPOCH,
-                Instant.EPOCH,
-                startLon,
-                startLat,
-                endLon,
-                endLat,
-                (short) 1,
-                0,
-                0);
+                1L, true, Instant.EPOCH, startLon, startLat, endLon, endLat, (short) 1, 0, 0);
     }
 }

--- a/rides-and-fares/src/test/java/org/apache/flink/training/exercises/ridesandfares/RidesAndFaresTestBase.java
+++ b/rides-and-fares/src/test/java/org/apache/flink/training/exercises/ridesandfares/RidesAndFaresTestBase.java
@@ -8,8 +8,7 @@ import java.time.Instant;
 public class RidesAndFaresTestBase {
 
     public static TaxiRide testRide(long rideId) {
-        return new TaxiRide(
-                rideId, true, Instant.EPOCH, Instant.EPOCH, 0F, 0F, 0F, 0F, (short) 1, 0, rideId);
+        return new TaxiRide(rideId, true, Instant.EPOCH, 0F, 0F, 0F, 0F, (short) 1, 0, rideId);
     }
 
     public static TaxiFare testFare(long rideId) {

--- a/rides-and-fares/src/test/java/org/apache/flink/training/exercises/ridesandfares/RidesAndFaresUnitTest.java
+++ b/rides-and-fares/src/test/java/org/apache/flink/training/exercises/ridesandfares/RidesAndFaresUnitTest.java
@@ -53,7 +53,7 @@ public class RidesAndFaresUnitTest extends RidesAndFaresTestBase {
 
         // Verify the result
         StreamRecord<RideAndFare> expected =
-                new StreamRecord<>(new RideAndFare(ride1, fare1), ride1.getEventTime());
+                new StreamRecord<>(new RideAndFare(ride1, fare1), ride1.getEventTimeMillis());
         assertThat(harness.getOutput()).containsExactly(expected);
     }
 
@@ -70,7 +70,7 @@ public class RidesAndFaresUnitTest extends RidesAndFaresTestBase {
 
         // Verify the result
         StreamRecord<RideAndFare> expected =
-                new StreamRecord<>(new RideAndFare(ride1, fare1), ride1.getEventTime());
+                new StreamRecord<>(new RideAndFare(ride1, fare1), ride1.getEventTimeMillis());
         assertThat(harness.getOutput()).containsExactly(expected);
     }
 


### PR DESCRIPTION
This PR is layered on top of https://github.com/apache/flink-training/pull/31.

The objective is to replace the startTime and endTime fields with a single eventTime field. This is more natural, and will make it more straightforward to convert a `DataStream<TaxiRide>` into a table.

This does affect the long rides exercise. The biggest change is that it is no longer possible to determine if a ride has been too long in the case where the START event is missing.