### PR TITLE
[hotfix] update flink version to 1.13.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ subprojects {
 
     ext {
         javaVersion = '1.8'
-        flinkVersion = '1.13.1'
+        flinkVersion = '1.13.2'
         scalaBinaryVersion = '2.12'
         log4jVersion = '2.12.1'
         junitVersion = '4.13'


### PR DESCRIPTION
FWIW, 1.13.2 has a bugfix for windowed top-n queries that I am particularly interested in.