### PR TITLE
[hotfix] trim whitespace before checking enable_scala

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ allprojects {
 
 subprojects {
     apply plugin: 'java'
-    if (project.properties['org.gradle.project.enable_scala'] == 'true') {
+    if (project.properties['org.gradle.project.enable_scala'].trim() == 'true') {
         apply plugin: 'scala'
     }
     apply plugin: 'com.github.johnrengelman.shadow'


### PR DESCRIPTION
Before this commit, if you accidentally added whitespace around `true` it would not have been recognised. This PR relaxes the property test so that a user doesn't run into this (hard to identify) problem.