### PR TITLE
[FLINK-24782] Upgrade training exercises to 1.14

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ description = "Flink Training Exercises"
 
 allprojects {
     group = 'org.apache.flink'
-    version = '1.13-SNAPSHOT'
+    version = '1.14-SNAPSHOT'
 
     apply plugin: 'com.diffplug.spotless'
 
@@ -52,7 +52,7 @@ subprojects {
 
     ext {
         javaVersion = '1.8'
-        flinkVersion = '1.13.2'
+        flinkVersion = '1.14.0'
         scalaBinaryVersion = '2.12'
         log4jVersion = '2.12.1'
         junitVersion = '4.13'

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -14,11 +14,11 @@ dependencies {
     // Compile-time dependencies that should NOT be part of the
     // shadow jar and are provided in the lib folder of Flink
     // --------------------------------------------------------------
-    shadow "org.apache.flink:flink-runtime_${scalaBinaryVersion}:${flinkVersion}"
+    shadow "org.apache.flink:flink-runtime:${flinkVersion}"
 
     testApi "junit:junit:${junitVersion}"
     testApi "org.apache.flink:flink-streaming-java_${scalaBinaryVersion}:${flinkVersion}:tests"
-    testApi "org.apache.flink:flink-runtime_${scalaBinaryVersion}:${flinkVersion}:tests"
+    testApi "org.apache.flink:flink-runtime:${flinkVersion}:tests"
     testApi "org.apache.flink:flink-test-utils-junit:${flinkVersion}"
     testApi "org.apache.flink:flink-test-utils_${scalaBinaryVersion}:${flinkVersion}"
     testApi 'org.assertj:assertj-core:3.20.2'


### PR DESCRIPTION
Upgrades Flink to 1.14. After merging, we will create a release-1.14 branch. 