### PR TITLE
[FLINK-27322][gradle] add missing license headers and spotless checks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,22 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
 # How to contribute to this project
 
 > **:heavy_exclamation_mark: Important:** This section contains tips for developers who are

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@
 
 plugins {
     id 'com.github.johnrengelman.shadow' version '7.0.0' apply false
-    id "com.diffplug.spotless" version "5.14.2" apply false
+    id "com.diffplug.spotless" version "6.4.2" apply false
 }
 
 description = "Flink Training Exercises"
@@ -159,7 +159,7 @@ subprojects {
                         ' * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n' +
                         ' * See the License for the specific language governing permissions and\n' +
                         ' * limitations under the License.\n' +
-                        ' */\n', 'package '
+                        ' */\n\n', 'package '
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -30,13 +30,56 @@ allprojects {
 
     spotless {
         format 'misc', {
-            // define the files to apply `misc` to
             target '*.gradle', '*.md', '.gitignore'
 
-            // define the steps to apply to those files
             trimTrailingWhitespace()
             indentWithSpaces(4)
             endWithNewline()
+        }
+
+        format 'markdown', {
+            target '*.md'
+
+            licenseHeader '<!--\n' +
+                    'Licensed to the Apache Software Foundation (ASF) under one\n' +
+                    'or more contributor license agreements.  See the NOTICE file\n' +
+                    'distributed with this work for additional information\n' +
+                    'regarding copyright ownership.  The ASF licenses this file\n' +
+                    'to you under the Apache License, Version 2.0 (the\n' +
+                    '"License"); you may not use this file except in compliance\n' +
+                    'with the License.  You may obtain a copy of the License at\n' +
+                    '\n' +
+                    '  http://www.apache.org/licenses/LICENSE-2.0\n' +
+                    '\n' +
+                    'Unless required by applicable law or agreed to in writing,\n' +
+                    'software distributed under the License is distributed on an\n' +
+                    '"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY\n' +
+                    'KIND, either express or implied.  See the License for the\n' +
+                    'specific language governing permissions and limitations\n' +
+                    'under the License.\n' +
+                    '-->\n\n', '# '
+
+        }
+
+        format 'gradle', {
+            target '*.gradle'
+
+            licenseHeader '/*\n' +
+                    ' * Licensed to the Apache Software Foundation (ASF) under one or more\n' +
+                    ' * contributor license agreements.  See the NOTICE file distributed with\n' +
+                    ' * this work for additional information regarding copyright ownership.\n' +
+                    ' * The ASF licenses this file to You under the Apache License, Version 2.0\n' +
+                    ' * (the "License"); you may not use this file except in compliance with\n' +
+                    ' * the License.  You may obtain a copy of the License at\n' +
+                    ' *\n' +
+                    ' *      http://www.apache.org/licenses/LICENSE-2.0\n' +
+                    ' *\n' +
+                    ' * Unless required by applicable law or agreed to in writing, software\n' +
+                    ' * distributed under the License is distributed on an "AS IS" BASIS,\n' +
+                    ' * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n' +
+                    ' * See the License for the specific language governing permissions and\n' +
+                    ' * limitations under the License.\n' +
+                    ' */\n\n', '(.*\\{)|(.* = .*)|(apply plugin:)'
         }
     }
 }
@@ -135,6 +178,24 @@ subprojects {
             removeUnusedImports()
 
             targetExclude("**/generated*/*.java")
+
+            licenseHeader '/*\n' +
+                    ' * Licensed to the Apache Software Foundation (ASF) under one\n' +
+                    ' * or more contributor license agreements.  See the NOTICE file\n' +
+                    ' * distributed with this work for additional information\n' +
+                    ' * regarding copyright ownership.  The ASF licenses this file\n' +
+                    ' * to you under the Apache License, Version 2.0 (the\n' +
+                    ' * "License"); you may not use this file except in compliance\n' +
+                    ' * with the License.  You may obtain a copy of the License at\n' +
+                    ' *\n' +
+                    ' *     http://www.apache.org/licenses/LICENSE-2.0\n' +
+                    ' *\n' +
+                    ' * Unless required by applicable law or agreed to in writing, software\n' +
+                    ' * distributed under the License is distributed on an "AS IS" BASIS,\n' +
+                    ' * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n' +
+                    ' * See the License for the specific language governing permissions and\n' +
+                    ' * limitations under the License.\n' +
+                    ' */\n\n'
         }
     }
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 plugins {
     id 'java-library'
 }

--- a/common/src/main/java/org/apache/flink/training/exercises/common/datatypes/RideAndFare.java
+++ b/common/src/main/java/org/apache/flink/training/exercises/common/datatypes/RideAndFare.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.training.exercises.common.datatypes;
 
 import java.io.Serializable;

--- a/common/src/test/java/org/apache/flink/training/exercises/testing/ComposedFilterFunction.java
+++ b/common/src/test/java/org/apache/flink/training/exercises/testing/ComposedFilterFunction.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.training.exercises.testing;
 
 import org.apache.flink.api.common.functions.FilterFunction;

--- a/common/src/test/java/org/apache/flink/training/exercises/testing/ComposedKeyedProcessFunction.java
+++ b/common/src/test/java/org/apache/flink/training/exercises/testing/ComposedKeyedProcessFunction.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.training.exercises.testing;
 
 import org.apache.flink.configuration.Configuration;

--- a/common/src/test/java/org/apache/flink/training/exercises/testing/ComposedPipeline.java
+++ b/common/src/test/java/org/apache/flink/training/exercises/testing/ComposedPipeline.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.training.exercises.testing;
 
 import org.apache.flink.api.common.JobExecutionResult;

--- a/common/src/test/java/org/apache/flink/training/exercises/testing/ComposedRichCoFlatMapFunction.java
+++ b/common/src/test/java/org/apache/flink/training/exercises/testing/ComposedRichCoFlatMapFunction.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.training.exercises.testing;
 
 import org.apache.flink.configuration.Configuration;

--- a/common/src/test/java/org/apache/flink/training/exercises/testing/ComposedTwoInputPipeline.java
+++ b/common/src/test/java/org/apache/flink/training/exercises/testing/ComposedTwoInputPipeline.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.training.exercises.testing;
 
 import org.apache.flink.api.common.JobExecutionResult;

--- a/common/src/test/java/org/apache/flink/training/exercises/testing/ExecutablePipeline.java
+++ b/common/src/test/java/org/apache/flink/training/exercises/testing/ExecutablePipeline.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.training.exercises.testing;
 
 import org.apache.flink.api.common.JobExecutionResult;

--- a/common/src/test/java/org/apache/flink/training/exercises/testing/ExecutableTwoInputPipeline.java
+++ b/common/src/test/java/org/apache/flink/training/exercises/testing/ExecutableTwoInputPipeline.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.training.exercises.testing;
 
 import org.apache.flink.api.common.JobExecutionResult;

--- a/common/src/test/java/org/apache/flink/training/exercises/testing/TestSink.java
+++ b/common/src/test/java/org/apache/flink/training/exercises/testing/TestSink.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.training.exercises.testing;
 
 import org.apache.flink.api.common.JobExecutionResult;

--- a/hourly-tips/build.gradle
+++ b/hourly-tips/build.gradle
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 ext.javaExerciseClassName = 'org.apache.flink.training.exercises.hourlytips.HourlyTipsExercise'
 ext.scalaExerciseClassName = 'org.apache.flink.training.exercises.hourlytips.scala.HourlyTipsExercise'
 ext.javaSolutionClassName = 'org.apache.flink.training.solutions.hourlytips.HourlyTipsSolution'

--- a/hourly-tips/src/main/scala/org/apache/flink/training/exercises/hourlytips/scala/HourlyTipsExercise.scala
+++ b/hourly-tips/src/main/scala/org/apache/flink/training/exercises/hourlytips/scala/HourlyTipsExercise.scala
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.flink.training.exercises.hourlytips.scala
 
 import org.apache.flink.api.common.JobExecutionResult

--- a/hourly-tips/src/solution/scala/org/apache/flink/training/solutions/hourlytips/scala/HourlyTipsSolution.scala
+++ b/hourly-tips/src/solution/scala/org/apache/flink/training/solutions/hourlytips/scala/HourlyTipsSolution.scala
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.flink.training.solutions.hourlytips.scala
 
 import org.apache.flink.api.common.JobExecutionResult

--- a/hourly-tips/src/test/scala/org/apache/flink/training/exercises/hourlytips/scala/HourlyTipsTest.scala
+++ b/hourly-tips/src/test/scala/org/apache/flink/training/exercises/hourlytips/scala/HourlyTipsTest.scala
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.flink.training.exercises.hourlytips.scala
 
 import java.util

--- a/long-ride-alerts/build.gradle
+++ b/long-ride-alerts/build.gradle
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 ext.javaExerciseClassName = 'org.apache.flink.training.exercises.longrides.LongRidesExercise'
 ext.scalaExerciseClassName = 'org.apache.flink.training.exercises.longrides.scala.LongRidesExercise'
 ext.javaSolutionClassName = 'org.apache.flink.training.solutions.longrides.LongRidesSolution'

--- a/long-ride-alerts/src/main/scala/org/apache/flink/training/exercises/longrides/scala/LongRidesExercise.scala
+++ b/long-ride-alerts/src/main/scala/org/apache/flink/training/exercises/longrides/scala/LongRidesExercise.scala
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.flink.training.exercises.longrides.scala
 
 import org.apache.flink.api.common.JobExecutionResult

--- a/long-ride-alerts/src/solution/scala/org/apache/flink/training/solutions/longrides/scala/LongRidesSolution.scala
+++ b/long-ride-alerts/src/solution/scala/org/apache/flink/training/solutions/longrides/scala/LongRidesSolution.scala
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.flink.training.solutions.longrides.scala
 
 import org.apache.flink.api.common.JobExecutionResult

--- a/long-ride-alerts/src/test/java/org/apache/flink/training/exercises/longrides/LongRidesTestBase.java
+++ b/long-ride-alerts/src/test/java/org/apache/flink/training/exercises/longrides/LongRidesTestBase.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.training.exercises.longrides;
 
 import org.apache.flink.training.exercises.common.datatypes.TaxiRide;

--- a/long-ride-alerts/src/test/java/org/apache/flink/training/exercises/longrides/LongRidesUnitTest.java
+++ b/long-ride-alerts/src/test/java/org/apache/flink/training/exercises/longrides/LongRidesUnitTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.training.exercises.longrides;
 
 import org.apache.flink.api.common.typeinfo.Types;

--- a/long-ride-alerts/src/test/scala/org/apache/flink/training/exercises/longrides/scala/LongRidesIntegrationTest.scala
+++ b/long-ride-alerts/src/test/scala/org/apache/flink/training/exercises/longrides/scala/LongRidesIntegrationTest.scala
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.flink.training.exercises.longrides.scala
 
 import org.apache.flink.api.common.JobExecutionResult

--- a/long-ride-alerts/src/test/scala/org/apache/flink/training/exercises/longrides/scala/LongRidesUnitTest.scala
+++ b/long-ride-alerts/src/test/scala/org/apache/flink/training/exercises/longrides/scala/LongRidesUnitTest.scala
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.flink.training.exercises.longrides.scala
 
 import org.apache.flink.training.exercises.common.datatypes.TaxiRide

--- a/ride-cleansing/build.gradle
+++ b/ride-cleansing/build.gradle
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 ext.javaExerciseClassName = 'org.apache.flink.training.exercises.ridecleansing.RideCleansingExercise'
 ext.scalaExerciseClassName = 'org.apache.flink.training.exercises.ridecleansing.scala.RideCleansingExercise'
 ext.javaSolutionClassName = 'org.apache.flink.training.solutions.ridecleansing.RideCleansingSolution'

--- a/ride-cleansing/src/main/scala/org/apache/flink/training/exercises/ridecleansing/scala/RideCleansingExercise.scala
+++ b/ride-cleansing/src/main/scala/org/apache/flink/training/exercises/ridecleansing/scala/RideCleansingExercise.scala
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.flink.training.exercises.ridecleansing.scala
 
 import org.apache.flink.api.common.JobExecutionResult

--- a/ride-cleansing/src/solution/scala/org/apache/flink/training/solutions/ridecleansing/scala/RideCleansingSolution.scala
+++ b/ride-cleansing/src/solution/scala/org/apache/flink/training/solutions/ridecleansing/scala/RideCleansingSolution.scala
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.flink.training.solutions.ridecleansing.scala
 
 import org.apache.flink.api.common.JobExecutionResult

--- a/ride-cleansing/src/test/java/org/apache/flink/training/exercises/ridecleansing/RideCleansingTestBase.java
+++ b/ride-cleansing/src/test/java/org/apache/flink/training/exercises/ridecleansing/RideCleansingTestBase.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.training.exercises.ridecleansing;
 
 import org.apache.flink.training.exercises.common.datatypes.TaxiRide;

--- a/ride-cleansing/src/test/java/org/apache/flink/training/exercises/ridecleansing/RideCleansingUnitTest.java
+++ b/ride-cleansing/src/test/java/org/apache/flink/training/exercises/ridecleansing/RideCleansingUnitTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.training.exercises.ridecleansing;
 
 import org.apache.flink.training.exercises.common.datatypes.TaxiRide;

--- a/ride-cleansing/src/test/scala/org/apache/flink/training/exercises/ridecleansing/scala/RideCleansingIntegrationTest.scala
+++ b/ride-cleansing/src/test/scala/org/apache/flink/training/exercises/ridecleansing/scala/RideCleansingIntegrationTest.scala
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.flink.training.exercises.ridecleansing.scala
 
 import org.apache.flink.streaming.api.functions.source.SourceFunction

--- a/ride-cleansing/src/test/scala/org/apache/flink/training/exercises/ridecleansing/scala/RideCleansingUnitTest.scala
+++ b/ride-cleansing/src/test/scala/org/apache/flink/training/exercises/ridecleansing/scala/RideCleansingUnitTest.scala
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.flink.training.exercises.ridecleansing.scala
 
 import org.apache.flink.training.exercises.common.datatypes.TaxiRide

--- a/rides-and-fares/build.gradle
+++ b/rides-and-fares/build.gradle
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 ext.javaExerciseClassName = 'org.apache.flink.training.exercises.ridesandfares.RidesAndFaresExercise'
 ext.scalaExerciseClassName = 'org.apache.flink.training.exercises.ridesandfares.scala.RidesAndFaresExercise'
 ext.javaSolutionClassName = 'org.apache.flink.training.solutions.ridesandfares.RidesAndFaresSolution'

--- a/rides-and-fares/src/main/scala/org/apache/flink/training/exercises/ridesandfares/scala/RidesAndFaresExercise.scala
+++ b/rides-and-fares/src/main/scala/org/apache/flink/training/exercises/ridesandfares/scala/RidesAndFaresExercise.scala
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.flink.training.exercises.ridesandfares.scala
 
 import org.apache.flink.api.common.JobExecutionResult

--- a/rides-and-fares/src/solution/scala/org/apache/flink/training/solutions/ridesandfares/scala/RidesAndFaresSolution.scala
+++ b/rides-and-fares/src/solution/scala/org/apache/flink/training/solutions/ridesandfares/scala/RidesAndFaresSolution.scala
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.flink.training.solutions.ridesandfares.scala
 
 import org.apache.flink.api.common.JobExecutionResult

--- a/rides-and-fares/src/test/java/org/apache/flink/training/exercises/ridesandfares/RidesAndFaresTestBase.java
+++ b/rides-and-fares/src/test/java/org/apache/flink/training/exercises/ridesandfares/RidesAndFaresTestBase.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.training.exercises.ridesandfares;
 
 import org.apache.flink.training.exercises.common.datatypes.TaxiFare;

--- a/rides-and-fares/src/test/java/org/apache/flink/training/exercises/ridesandfares/RidesAndFaresUnitTest.java
+++ b/rides-and-fares/src/test/java/org/apache/flink/training/exercises/ridesandfares/RidesAndFaresUnitTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.training.exercises.ridesandfares;
 
 import org.apache.flink.api.common.typeinfo.Types;

--- a/rides-and-fares/src/test/scala/org/apache/flink/training/exercises/ridesandfares/scala/RidesAndFaresIntegrationTest.scala
+++ b/rides-and-fares/src/test/scala/org/apache/flink/training/exercises/ridesandfares/scala/RidesAndFaresIntegrationTest.scala
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.flink.training.exercises.ridesandfares.scala
 
 import org.apache.flink.streaming.api.functions.source.SourceFunction

--- a/rides-and-fares/src/test/scala/org/apache/flink/training/exercises/ridesandfares/scala/RidesAndFaresUnitTest.scala
+++ b/rides-and-fares/src/test/scala/org/apache/flink/training/exercises/ridesandfares/scala/RidesAndFaresUnitTest.scala
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.flink.training.exercises.ridesandfares.scala
 
 import org.apache.flink.training.exercises.ridesandfares

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 plugins {
     id "com.gradle.enterprise" version "3.6.3"
 }


### PR DESCRIPTION
A couple of files were missing appropriate (Apache) license headers. This commit adds...
- the missing license headers
- spotless checks to ensure this doesn't happen again
