### PR TITLE
[FLINK-27353] Update to Flink 1.15

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ description = "Flink Training Exercises"
 
 allprojects {
     group = 'org.apache.flink'
-    version = '1.14-SNAPSHOT'
+    version = '1.15-SNAPSHOT'
 
     apply plugin: 'com.diffplug.spotless'
 
@@ -95,7 +95,7 @@ subprojects {
 
     ext {
         javaVersion = '1.8'
-        flinkVersion = '1.14.0'
+        flinkVersion = '1.15.0'
         scalaBinaryVersion = '2.12'
         log4jVersion = '2.12.1'
         junitVersion = '4.13'
@@ -126,13 +126,13 @@ subprojects {
         shadow "org.apache.logging.log4j:log4j-api:${log4jVersion}"
         shadow "org.apache.logging.log4j:log4j-core:${log4jVersion}"
 
-        shadow "org.apache.flink:flink-clients_${scalaBinaryVersion}:${flinkVersion}"
+        shadow "org.apache.flink:flink-clients:${flinkVersion}"
         shadow "org.apache.flink:flink-java:${flinkVersion}"
-        shadow "org.apache.flink:flink-streaming-java_${scalaBinaryVersion}:${flinkVersion}"
+        shadow "org.apache.flink:flink-streaming-java:${flinkVersion}"
         shadow "org.apache.flink:flink-streaming-scala_${scalaBinaryVersion}:${flinkVersion}"
 
         // allows using Flink's web UI when running in the IDE:
-        shadow "org.apache.flink:flink-runtime-web_${scalaBinaryVersion}:${flinkVersion}"
+        shadow "org.apache.flink:flink-runtime-web:${flinkVersion}"
 
         if (project != project(":common")) {
             implementation project(path: ':common')

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -28,9 +28,9 @@ java {
 // common set of dependencies
 dependencies {
     testApi "junit:junit:${junitVersion}"
-    testApi "org.apache.flink:flink-streaming-java_${scalaBinaryVersion}:${flinkVersion}:tests"
+    testApi "org.apache.flink:flink-streaming-java:${flinkVersion}:tests"
     testApi "org.apache.flink:flink-runtime:${flinkVersion}:tests"
     testApi "org.apache.flink:flink-test-utils-junit:${flinkVersion}"
-    testApi "org.apache.flink:flink-test-utils_${scalaBinaryVersion}:${flinkVersion}"
+    testApi "org.apache.flink:flink-test-utils:${flinkVersion}"
     testApi 'org.assertj:assertj-core:3.20.2'
 }


### PR DESCRIPTION
This PR will only go through CI once 1.15.0 is released. Until then, you can apply the following change to `build.gradle` to see it in action:
```
flinkVersion = '1.15-SNAPSHOT'
```