### PR TITLE
4 lab exercises squashed

### DIFF
--- a/ride-cleansing/src/main/java/org/apache/flink/training/exercises/ridecleansing/RideCleansingExercise.java
+++ b/ride-cleansing/src/main/java/org/apache/flink/training/exercises/ridecleansing/RideCleansingExercise.java
@@ -26,7 +26,8 @@ import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.training.exercises.common.datatypes.TaxiRide;
 import org.apache.flink.training.exercises.common.sources.TaxiRideGenerator;
-import org.apache.flink.training.exercises.common.utils.MissingSolutionException;
+
+import static org.apache.flink.training.exercises.common.utils.GeoUtils.isInNYC;
 
 /**
  * The Ride Cleansing exercise from the Flink training.
@@ -70,7 +71,9 @@ public class RideCleansingExercise {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         // set up the pipeline
-        env.addSource(source).filter(new NYCFilter()).addSink(sink);
+        env.addSource(source)
+                .filter(new NYCFilter())
+                .addSink(sink);
 
         // run the pipeline and return the result
         return env.execute("Taxi Ride Cleansing");
@@ -79,8 +82,9 @@ public class RideCleansingExercise {
     /** Keep only those rides and both start and end in NYC. */
     public static class NYCFilter implements FilterFunction<TaxiRide> {
         @Override
-        public boolean filter(TaxiRide taxiRide) throws Exception {
-            throw new MissingSolutionException();
+        public boolean filter(TaxiRide taxiRide) {
+            return isInNYC(taxiRide.startLon, taxiRide.startLat) &&
+                    isInNYC(taxiRide.endLon, taxiRide.endLat);
         }
     }
 }


### PR DESCRIPTION
Please check my exercises solution found in the 4 files modified, each corresponding to the referred lab:

1.  **RideCleansingExercise** for [Lab: Filtering a Stream (Ride Cleansing)](https://github.com/apache/flink-training/tree/release-1.15/ride-cleansing#lab-filtering-a-stream-ride-cleansing)
2. **RidesAndFaresExercise** for [Lab: Stateful Enrichment (Rides and Fares)](https://github.com/apache/flink-training/tree/release-1.15/rides-and-fares#lab-stateful-enrichment-rides-and-fares)
3. **HourlyTipsExercise** for [Lab: Windowed Analytics (Hourly Tips)](https://github.com/apache/flink-training/tree/release-1.15/hourly-tips#lab-windowed-analytics-hourly-tips)
4. **LongRidesExercise** for [Lab: ProcessFunction and Timers (Long Ride Alerts)](https://github.com/apache/flink-training/tree/release-1.15/long-ride-alerts#lab-processfunction-and-timers-long-ride-alerts)